### PR TITLE
new: Add a manifest file for tracking information.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,6 +1320,8 @@ dependencies = [
  "proto_go",
  "proto_node",
  "rustc-hash",
+ "serde",
+ "serde_json",
  "tokio",
  "toml",
 ]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -31,6 +31,8 @@ futures = "0.3.26"
 human-sort = "0.2.2"
 log = { workspace = true }
 rustc-hash = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 tokio = { workspace = true }
 toml = "0.7.0"
 

--- a/crates/cli/src/bin.rs
+++ b/crates/cli/src/bin.rs
@@ -2,6 +2,7 @@ mod app;
 mod commands;
 mod config;
 mod helpers;
+mod manifest;
 pub mod tools;
 
 use app::{App, Commands};

--- a/crates/cli/src/commands/global.rs
+++ b/crates/cli/src/commands/global.rs
@@ -1,8 +1,8 @@
-use crate::helpers::enable_logging;
-use crate::manifest::{Manifest, MANIFEST_NAME};
+use crate::helpers::{enable_logging, get_manifest_path};
+use crate::manifest::Manifest;
 use crate::tools::{create_tool, ToolType};
 use log::{info, trace};
-use proto_core::{color, get_tools_dir, ProtoError};
+use proto_core::{color, ProtoError};
 
 pub async fn global(tool_type: ToolType, version: String) -> Result<(), ProtoError> {
     enable_logging();
@@ -11,9 +11,7 @@ pub async fn global(tool_type: ToolType, version: String) -> Result<(), ProtoErr
 
     tool.resolve_version(&version).await?;
 
-    let manifest_path = get_tools_dir()?
-        .join(tool.get_bin_name())
-        .join(MANIFEST_NAME);
+    let manifest_path = get_manifest_path(&tool)?;
 
     let mut manifest = Manifest::load(&manifest_path)?;
     manifest.default_version = tool.get_resolved_version().to_owned();

--- a/crates/cli/src/commands/global.rs
+++ b/crates/cli/src/commands/global.rs
@@ -1,4 +1,4 @@
-use crate::helpers::{enable_logging, get_manifest_path};
+use crate::helpers::enable_logging;
 use crate::manifest::Manifest;
 use crate::tools::{create_tool, ToolType};
 use log::{info, trace};
@@ -11,16 +11,14 @@ pub async fn global(tool_type: ToolType, version: String) -> Result<(), ProtoErr
 
     tool.resolve_version(&version).await?;
 
-    let manifest_path = get_manifest_path(&tool)?;
-
-    let mut manifest = Manifest::load(&manifest_path)?;
+    let mut manifest = Manifest::load_for_tool(&tool)?;
     manifest.default_version = tool.get_resolved_version().to_owned();
-    manifest.save(&manifest_path)?;
+    manifest.save()?;
 
     trace!(
         target: "proto:global",
         "Wrote the global version to {}",
-        color::path(&manifest_path),
+        color::path(&manifest.path),
     );
 
     info!(

--- a/crates/cli/src/commands/global.rs
+++ b/crates/cli/src/commands/global.rs
@@ -12,7 +12,7 @@ pub async fn global(tool_type: ToolType, version: String) -> Result<(), ProtoErr
     tool.resolve_version(&version).await?;
 
     let mut manifest = Manifest::load_for_tool(&tool)?;
-    manifest.default_version = tool.get_resolved_version().to_owned();
+    manifest.default_version = Some(tool.get_resolved_version().to_owned());
     manifest.save()?;
 
     trace!(

--- a/crates/cli/src/commands/install.rs
+++ b/crates/cli/src/commands/install.rs
@@ -1,4 +1,5 @@
 use crate::helpers::enable_logging;
+use crate::manifest::Manifest;
 use crate::tools::{create_tool, ToolType};
 use log::info;
 use proto_core::{color, ProtoError};
@@ -16,22 +17,34 @@ pub async fn install(tool_type: ToolType, version: Option<String>) -> Result<(),
             tool.get_name(),
             color::path(tool.get_install_dir()?),
         );
-    } else {
-        info!(
-            target: "proto:install",
-            "Installing {} with version \"{}\"",
-            tool.get_name(),
-            version,
-        );
 
-        tool.setup(&version).await?;
-
-        info!(
-            target: "proto:install", "{} has been installed at {}!",
-            tool.get_name(),
-            color::path(tool.get_install_dir()?),
-        );
+        return Ok(());
     }
+
+    info!(
+        target: "proto:install",
+        "Installing {} with version \"{}\"",
+        tool.get_name(),
+        version,
+    );
+
+    tool.setup(&version).await?;
+
+    let version = tool.get_resolved_version();
+    let mut manifest = Manifest::load_for_tool(&tool)?;
+
+    if manifest.default_version.is_none() {
+        manifest.default_version = Some(version.to_owned());
+    }
+
+    manifest.installed_versions.insert(version.to_owned());
+    manifest.save()?;
+
+    info!(
+        target: "proto:install", "{} has been installed at {}!",
+        tool.get_name(),
+        color::path(tool.get_install_dir()?),
+    );
 
     Ok(())
 }

--- a/crates/cli/src/commands/install_all.rs
+++ b/crates/cli/src/commands/install_all.rs
@@ -10,7 +10,7 @@ pub async fn install_all() -> Result<(), ProtoError> {
 
     let current_dir = env::current_dir().expect("Invalid working directory!");
 
-    let Some(config) = Config::find_upwards(&current_dir)? else {
+    let Some(config) = Config::load_upwards(&current_dir)? else {
         return Err(ProtoError::MissingConfig(CONFIG_NAME.to_owned()));
     };
 

--- a/crates/cli/src/commands/list.rs
+++ b/crates/cli/src/commands/list.rs
@@ -1,33 +1,21 @@
 use crate::helpers::enable_logging;
+use crate::manifest::Manifest;
 use crate::tools::{create_tool, ToolType};
 use human_sort::compare;
 use log::{debug, info};
 use proto_core::{color, ProtoError};
-use std::fs;
 
 pub async fn list(tool_type: ToolType) -> Result<(), ProtoError> {
     enable_logging();
 
     let tool = create_tool(&tool_type)?;
-    let install_dir = tool.get_install_dir()?;
-    let tool_dir = install_dir.parent().unwrap(); // Without version/latest
+    let manifest = Manifest::load_for_tool(&tool)?;
 
-    debug!(target: "proto:list", "Finding versions in {}", color::path(tool_dir));
-
-    let handle_error = |e: std::io::Error| ProtoError::Fs(tool_dir.to_path_buf(), e.to_string());
-    let mut versions = vec![];
-
-    if tool_dir.exists() {
-        for entry in fs::read_dir(tool_dir).map_err(handle_error)? {
-            let entry = entry.map_err(handle_error)?;
-
-            if entry.file_type().map_err(handle_error)?.is_dir() {
-                versions.push(entry.file_name().to_string_lossy().to_string());
-            }
-        }
-    }
+    debug!(target: "proto:list", "Using versions from {}", color::path(&manifest.path));
 
     info!(target: "proto:list", "Locally installed versions:");
+
+    let mut versions = Vec::from_iter(manifest.installed_versions);
 
     if versions.is_empty() {
         eprintln!("No versions installed");

--- a/crates/cli/src/commands/local.rs
+++ b/crates/cli/src/commands/local.rs
@@ -19,7 +19,7 @@ pub async fn local(tool_type: ToolType, version: String) -> Result<(), ProtoErro
         .tools
         .insert(tool_type, tool.get_resolved_version().to_owned());
 
-    config.save(&local_path)?;
+    config.save_to(&local_path)?;
 
     trace!(
         target: "proto:local",

--- a/crates/cli/src/commands/local.rs
+++ b/crates/cli/src/commands/local.rs
@@ -19,7 +19,7 @@ pub async fn local(tool_type: ToolType, version: String) -> Result<(), ProtoErro
         .tools
         .insert(tool_type, tool.get_resolved_version().to_owned());
 
-    config.save_to(&local_path)?;
+    config.save()?;
 
     trace!(
         target: "proto:local",

--- a/crates/cli/src/commands/local.rs
+++ b/crates/cli/src/commands/local.rs
@@ -1,4 +1,4 @@
-use crate::config::{Config, CONFIG_NAME};
+use crate::config::Config;
 use crate::helpers::enable_logging;
 use crate::tools::{create_tool, ToolType};
 use log::{info, trace};
@@ -12,15 +12,8 @@ pub async fn local(tool_type: ToolType, version: String) -> Result<(), ProtoErro
 
     tool.resolve_version(&version).await?;
 
-    let local_path = env::current_dir()
-        .unwrap_or_else(|_| PathBuf::from("."))
-        .join(CONFIG_NAME);
-
-    let mut config = if local_path.exists() {
-        Config::load(&local_path)?
-    } else {
-        Config::default()
-    };
+    let local_path = env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let mut config = Config::load_from(&local_path)?;
 
     config
         .tools

--- a/crates/cli/src/commands/setup.rs
+++ b/crates/cli/src/commands/setup.rs
@@ -51,7 +51,9 @@ fn write_profile(shell: &Shell, profiles: &[PathBuf], contents: String) -> Resul
         color::path(last_profile),
     );
 
-    fs::create_dir_all(last_profile.parent().unwrap()).map_err(handle_error)?;
+    if let Some(parent) = last_profile.parent() {
+        fs::create_dir_all(parent).map_err(handle_error)?;
+    }
 
     let mut options = OpenOptions::new();
     options.read(true);

--- a/crates/cli/src/commands/uninstall.rs
+++ b/crates/cli/src/commands/uninstall.rs
@@ -1,4 +1,5 @@
 use crate::helpers::enable_logging;
+use crate::manifest::Manifest;
 use crate::tools::{create_tool, ToolType};
 use log::info;
 use proto_core::ProtoError;
@@ -8,30 +9,47 @@ pub async fn uninstall(tool_type: ToolType, version: String) -> Result<(), Proto
 
     let mut tool = create_tool(&tool_type)?;
 
-    if tool.is_setup(&version).await? {
-        info!(
-            target: "proto:uninstall",
-            "Uninstalling {} with version \"{}\"",
-            tool.get_name(),
-            version,
-        );
-
-        tool.teardown().await?;
-
-        info!(
-            target: "proto:uninstall",
-            "{} v{} has been uninstalled!",
-            tool.get_name(),
-            tool.get_resolved_version(),
-        );
-    } else {
+    if !tool.is_setup(&version).await? {
         info!(
             target: "proto:uninstall",
             "{} v{} does not exist!",
             tool.get_name(),
             tool.get_resolved_version(),
         );
+
+        return Ok(());
     }
+
+    info!(
+        target: "proto:uninstall",
+        "Uninstalling {} with version \"{}\"",
+        tool.get_name(),
+        version,
+    );
+
+    tool.teardown().await?;
+
+    let version = tool.get_resolved_version().to_owned();
+    let mut manifest = Manifest::load_for_tool(&tool)?;
+
+    manifest.installed_versions.remove(&version);
+
+    // Remove default version if nothing available
+    if manifest.installed_versions.is_empty() || manifest.default_version.as_ref() == Some(&version)
+    {
+        info!(target: "proto:uninstall", "Unpinning default global version");
+
+        manifest.default_version = None;
+    }
+
+    manifest.save()?;
+
+    info!(
+        target: "proto:uninstall",
+        "{} v{} has been uninstalled!",
+        tool.get_name(),
+        tool.get_resolved_version(),
+    );
 
     Ok(())
 }

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -73,7 +73,14 @@ impl Config {
         Ok(Config { tools })
     }
 
-    pub fn save(&self, path: &Path) -> Result<(), ProtoError> {
+    pub fn save_to<P: AsRef<Path>>(&self, dir: P) -> Result<(), ProtoError> {
+        self.save(dir.as_ref().join(CONFIG_NAME))?;
+
+        Ok(())
+    }
+
+    pub fn save<P: AsRef<Path>>(&self, path: P) -> Result<(), ProtoError> {
+        let path = path.as_ref();
         let mut map = Map::with_capacity(self.tools.len());
 
         for (tool, version) in &self.tools {

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -42,7 +42,10 @@ impl Config {
         let path = path.as_ref();
 
         if !path.exists() {
-            return Ok(Config::default());
+            return Ok(Config {
+                path: path.to_owned(),
+                ..Config::default()
+            });
         }
 
         let contents = fs::read_to_string(path)

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -2,7 +2,10 @@ use crate::tools::ToolType;
 use clap::ValueEnum;
 use proto_core::ProtoError;
 use rustc_hash::FxHashMap;
-use std::{fs, path::Path};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 use toml::{map::Map, Value};
 
 pub const CONFIG_NAME: &str = ".prototools";
@@ -10,10 +13,11 @@ pub const CONFIG_NAME: &str = ".prototools";
 #[derive(Debug, Default)]
 pub struct Config {
     pub tools: FxHashMap<ToolType, String>,
+    pub path: PathBuf,
 }
 
 impl Config {
-    pub fn find_upwards<P>(dir: P) -> Result<Option<Self>, ProtoError>
+    pub fn load_upwards<P>(dir: P) -> Result<Option<Self>, ProtoError>
     where
         P: AsRef<Path>,
     {
@@ -25,7 +29,7 @@ impl Config {
         }
 
         match dir.parent() {
-            Some(parent_dir) => Self::find_upwards(parent_dir),
+            Some(parent_dir) => Self::load_upwards(parent_dir),
             None => Ok(None),
         }
     }
@@ -70,17 +74,13 @@ impl Config {
             ));
         }
 
-        Ok(Config { tools })
+        Ok(Config {
+            tools,
+            path: path.to_owned(),
+        })
     }
 
-    pub fn save_to<P: AsRef<Path>>(&self, dir: P) -> Result<(), ProtoError> {
-        self.save(dir.as_ref().join(CONFIG_NAME))?;
-
-        Ok(())
-    }
-
-    pub fn save<P: AsRef<Path>>(&self, path: P) -> Result<(), ProtoError> {
-        let path = path.as_ref();
+    pub fn save(&self) -> Result<(), ProtoError> {
         let mut map = Map::with_capacity(self.tools.len());
 
         for (tool, version) in &self.tools {
@@ -91,9 +91,10 @@ impl Config {
         }
 
         let data = toml::to_string_pretty(&Value::Table(map))
-            .map_err(|e| ProtoError::Toml(path.to_path_buf(), e.to_string()))?;
+            .map_err(|e| ProtoError::Toml(self.path.to_path_buf(), e.to_string()))?;
 
-        fs::write(path, data).map_err(|e| ProtoError::Fs(path.to_path_buf(), e.to_string()))?;
+        fs::write(&self.path, data)
+            .map_err(|e| ProtoError::Fs(self.path.to_path_buf(), e.to_string()))?;
 
         Ok(())
     }

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -30,7 +30,17 @@ impl Config {
         }
     }
 
-    pub fn load(path: &Path) -> Result<Self, ProtoError> {
+    pub fn load_from<P: AsRef<Path>>(dir: P) -> Result<Self, ProtoError> {
+        Self::load(dir.as_ref().join(CONFIG_NAME))
+    }
+
+    pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, ProtoError> {
+        let path = path.as_ref();
+
+        if !path.exists() {
+            return Ok(Config::default());
+        }
+
         let contents = fs::read_to_string(path)
             .map_err(|e| ProtoError::Fs(path.to_path_buf(), e.to_string()))?;
 

--- a/crates/cli/src/helpers.rs
+++ b/crates/cli/src/helpers.rs
@@ -14,7 +14,7 @@ pub fn enable_logging() {
 
     if !ENABLED.load(Relaxed) {
         if let Ok(level) = env::var("PROTO_LOG") {
-            if !level.starts_with("proto=") {
+            if !level.starts_with("proto=") && level != "off" {
                 env::set_var("PROTO_LOG", format!("proto={level}"));
             }
         } else {

--- a/crates/cli/src/helpers.rs
+++ b/crates/cli/src/helpers.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::borrowed_box)]
 
-use crate::config::{Config, CONFIG_NAME};
+use crate::config::Config;
 use crate::tools::ToolType;
 use log::{debug, trace};
 use proto::Manifest;
@@ -84,18 +84,17 @@ pub async fn detect_version_from_environment(
                 "Checking proto configuration file"
             );
 
-            let config_file = dir.join(CONFIG_NAME);
-            let config = Config::load(&config_file)?;
+            let config = Config::load_from(&dir)?;
 
-            if let Some(config_version) = config.tools.get(tool_type) {
+            if let Some(local_version) = config.tools.get(tool_type) {
                 debug!(
                     target: "proto:detect",
                     "Detected version {} from configuration file {}",
-                    config_version,
-                    color::path(&config_file)
+                    local_version,
+                    color::path(&config.path)
                 );
 
-                version = Some(config_version.to_owned());
+                version = Some(local_version.to_owned());
                 break;
             }
 
@@ -129,15 +128,15 @@ pub async fn detect_version_from_environment(
 
         let manifest = Manifest::load_for_tool(&tool)?;
 
-        if !manifest.default_version.is_empty() {
+        if let Some(global_version) = manifest.default_version {
             debug!(
                 target: "proto:detect",
                 "Detected global version {} from {}",
-                &manifest.default_version,
+               global_version,
                 color::path(&manifest.path)
             );
 
-            version = Some(manifest.default_version);
+            version = Some(global_version);
         }
     }
 

--- a/crates/cli/src/helpers.rs
+++ b/crates/cli/src/helpers.rs
@@ -1,17 +1,13 @@
 #![allow(clippy::borrowed_box)]
 
 use crate::config::{Config, CONFIG_NAME};
-use crate::manifest::MANIFEST_NAME;
 use crate::tools::ToolType;
 use log::{debug, trace};
 use proto::Manifest;
-use proto_core::{color, get_tools_dir, ProtoError, Tool};
+use proto_core::{color, ProtoError, Tool};
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering::Relaxed;
-use std::{
-    env,
-    path::{Path, PathBuf},
-};
+use std::{env, path::Path};
 
 pub fn enable_logging() {
     static ENABLED: AtomicBool = AtomicBool::new(false);
@@ -31,12 +27,6 @@ pub fn enable_logging() {
 
         ENABLED.store(true, Relaxed);
     }
-}
-
-pub fn get_manifest_path(tool: &Box<dyn Tool<'_>>) -> Result<PathBuf, ProtoError> {
-    Ok(get_tools_dir()?
-        .join(tool.get_bin_name())
-        .join(MANIFEST_NAME))
 }
 
 pub async fn detect_version_from_environment(
@@ -137,15 +127,14 @@ pub async fn detect_version_from_environment(
             "Attempting to find global version"
         );
 
-        let manifest_file = get_manifest_path(tool)?;
-        let manifest = Manifest::load(&manifest_file)?;
+        let manifest = Manifest::load_for_tool(&tool)?;
 
         if !manifest.default_version.is_empty() {
             debug!(
                 target: "proto:detect",
                 "Detected global version {} from {}",
                 &manifest.default_version,
-                color::path(&manifest_file)
+                color::path(&manifest.path)
             );
 
             version = Some(manifest.default_version);

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,7 +1,9 @@
 pub mod config;
+pub mod manifest;
 pub mod tools;
 
 pub use config::*;
+pub use manifest::*;
 pub use proto_bun as bun;
 pub use proto_core::*;
 pub use proto_deno as deno;

--- a/crates/cli/src/manifest.rs
+++ b/crates/cli/src/manifest.rs
@@ -6,12 +6,14 @@ use std::{fs, path::Path};
 pub const MANIFEST_NAME: &str = "manifest.json";
 
 #[derive(Debug, Default, Deserialize, Serialize)]
+#[serde(default)]
 pub struct Manifest {
     pub default_version: String,
     pub installed_versions: FxHashSet<String>,
 }
 
 impl Manifest {
+    #[allow(dead_code)]
     pub fn load_from<P: AsRef<Path>>(dir: P) -> Result<Self, ProtoError> {
         Self::load(dir.as_ref().join(MANIFEST_NAME))
     }
@@ -32,6 +34,7 @@ impl Manifest {
         Ok(manifest)
     }
 
+    #[allow(dead_code)]
     pub fn save_to<P: AsRef<Path>>(&self, dir: P) -> Result<(), ProtoError> {
         self.save(dir.as_ref().join(MANIFEST_NAME))?;
 

--- a/crates/cli/src/manifest.rs
+++ b/crates/cli/src/manifest.rs
@@ -31,4 +31,24 @@ impl Manifest {
 
         Ok(manifest)
     }
+
+    pub fn save_to<P: AsRef<Path>>(&self, dir: P) -> Result<(), ProtoError> {
+        self.save(dir.as_ref().join(MANIFEST_NAME))?;
+
+        Ok(())
+    }
+
+    pub fn save<P: AsRef<Path>>(&self, path: P) -> Result<(), ProtoError> {
+        let path = path.as_ref();
+
+        let data = serde_json::to_string_pretty(self)
+            .map_err(|e| ProtoError::Json(path.to_path_buf(), e.to_string()))?;
+
+        let handle_error = |e: std::io::Error| ProtoError::Fs(path.to_path_buf(), e.to_string());
+
+        fs::create_dir_all(path.parent().unwrap()).map_err(handle_error)?;
+        fs::write(path, data).map_err(handle_error)?;
+
+        Ok(())
+    }
 }

--- a/crates/cli/src/manifest.rs
+++ b/crates/cli/src/manifest.rs
@@ -1,0 +1,34 @@
+use proto_core::ProtoError;
+use rustc_hash::FxHashSet;
+use serde::{Deserialize, Serialize};
+use std::{fs, path::Path};
+
+pub const MANIFEST_NAME: &str = "manifest.json";
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct Manifest {
+    pub default_version: String,
+    pub installed_versions: FxHashSet<String>,
+}
+
+impl Manifest {
+    pub fn load_from<P: AsRef<Path>>(dir: P) -> Result<Self, ProtoError> {
+        Self::load(dir.as_ref().join(MANIFEST_NAME))
+    }
+
+    pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, ProtoError> {
+        let path = path.as_ref();
+
+        if !path.exists() {
+            return Ok(Manifest::default());
+        }
+
+        let contents = fs::read_to_string(path)
+            .map_err(|e| ProtoError::Fs(path.to_path_buf(), e.to_string()))?;
+
+        let manifest: Manifest = serde_json::from_str(&contents)
+            .map_err(|e| ProtoError::Json(path.to_path_buf(), e.to_string()))?;
+
+        Ok(manifest)
+    }
+}

--- a/crates/cli/tests/global_test.rs
+++ b/crates/cli/tests/global_test.rs
@@ -3,15 +3,21 @@ mod utils;
 use utils::*;
 
 #[test]
-fn writes_global_version_file() {
+fn updates_manifest_file() {
     let temp = create_temp_dir();
-    let version_file = temp.join("tools/node/version");
+    let manifest_file = temp.join("tools/node/manifest.json");
 
-    assert!(!version_file.exists());
+    assert!(!manifest_file.exists());
 
     let mut cmd = create_proto_command(temp.path());
     cmd.arg("global").arg("node").arg("19.0.0").assert();
 
-    assert!(version_file.exists());
-    assert_eq!(std::fs::read_to_string(version_file).unwrap(), "19.0.0")
+    assert!(manifest_file.exists());
+    assert_eq!(
+        std::fs::read_to_string(manifest_file).unwrap(),
+        r#"{
+  "default_version": "19.0.0",
+  "installed_versions": []
+}"#
+    );
 }

--- a/crates/cli/tests/install_uninstall_test.rs
+++ b/crates/cli/tests/install_uninstall_test.rs
@@ -61,9 +61,7 @@ fn updates_the_manifest_when_installing() {
 
     // Install
     let mut cmd = create_proto_command(temp.path());
-    let a = cmd.arg("install").arg("node").arg("19.0.0").assert();
-
-    debug_assert(&a);
+    cmd.arg("install").arg("node").arg("19.0.0").assert();
 
     assert_eq!(
         std::fs::read_to_string(&manifest_file).unwrap(),

--- a/crates/cli/tests/install_uninstall_test.rs
+++ b/crates/cli/tests/install_uninstall_test.rs
@@ -53,3 +53,37 @@ fn doesnt_uninstall_tool_if_doesnt_exist() {
 
     assert.stderr(predicate::str::contains("Node.js v19.0.0 does not exist!"));
 }
+
+#[test]
+fn updates_the_manifest_when_installing() {
+    let temp = create_temp_dir();
+    let manifest_file = temp.join("tools/node/manifest.json");
+
+    // Install
+    let mut cmd = create_proto_command(temp.path());
+    let a = cmd.arg("install").arg("node").arg("19.0.0").assert();
+
+    debug_assert(&a);
+
+    assert_eq!(
+        std::fs::read_to_string(&manifest_file).unwrap(),
+        r#"{
+  "default_version": "19.0.0",
+  "installed_versions": [
+    "19.0.0"
+  ]
+}"#
+    );
+
+    // Uninstall
+    let mut cmd = create_proto_command(temp.path());
+    cmd.arg("uninstall").arg("node").arg("19.0.0").assert();
+
+    assert_eq!(
+        std::fs::read_to_string(&manifest_file).unwrap(),
+        r#"{
+  "default_version": null,
+  "installed_versions": []
+}"#
+    );
+}

--- a/crates/cli/tests/list_test.rs
+++ b/crates/cli/tests/list_test.rs
@@ -1,0 +1,30 @@
+mod utils;
+
+use std::fs;
+use utils::*;
+
+#[test]
+fn lists_local_versions() {
+    let temp = create_temp_dir();
+
+    fs::create_dir_all(temp.join("tools/node")).unwrap();
+    fs::write(
+        temp.join("tools/node/manifest.json"),
+        r#"{
+  "default_version": "19.0.0",
+  "installed_versions": [
+    "19.0.0",
+    "18.0.0",
+    "17.0.0"
+  ]
+}"#,
+    )
+    .unwrap();
+
+    let mut cmd = create_proto_command(temp.path());
+    let assert = cmd.arg("list").arg("node").assert();
+
+    let output = output_to_string(&assert.get_output().stdout);
+
+    assert_eq!(output.split('\n').collect::<Vec<_>>().len(), 4); // includes header
+}

--- a/crates/cli/tests/run_test.rs
+++ b/crates/cli/tests/run_test.rs
@@ -117,7 +117,11 @@ fn runs_a_tool_using_version_detection() {
     fs::remove_file(temp.path().join("package.json")).unwrap();
 
     // Global version
-    fs::write(temp.path().join("tools/node/version"), "19.0.0").unwrap();
+    fs::write(
+        temp.path().join("tools/node/manifest.json"),
+        r#"{ "default_version": "19.0.0" }"#,
+    )
+    .unwrap();
 
     let mut cmd = create_proto_command(temp.path());
     let assert = cmd
@@ -129,5 +133,5 @@ fn runs_a_tool_using_version_detection() {
 
     assert.stdout(predicate::str::contains("19.0.0"));
 
-    fs::remove_file(temp.path().join("tools/node/version")).unwrap();
+    fs::remove_file(temp.path().join("tools/node/manifest.json")).unwrap();
 }


### PR DESCRIPTION
This adds a new `manifest.json` that exists at the root of each installed tool (below the versions) that tracks the installed versions, the global default version, and in the future, aliases.