### PR TITLE
fix: Move manifest logic to core.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,8 +1320,6 @@ dependencies = [
  "proto_go",
  "proto_node",
  "rustc-hash",
- "serde",
- "serde_json",
  "tokio",
  "toml",
 ]
@@ -1339,6 +1337,7 @@ dependencies = [
  "lenient_semver",
  "log",
  "reqwest",
+ "rustc-hash",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -31,8 +31,6 @@ futures = "0.3.26"
 human-sort = "0.2.2"
 log = { workspace = true }
 rustc-hash = { workspace = true }
-serde = { workspace = true }
-serde_json = { workspace = true }
 tokio = { workspace = true }
 toml = "0.7.0"
 

--- a/crates/cli/src/bin.rs
+++ b/crates/cli/src/bin.rs
@@ -2,7 +2,6 @@ mod app;
 mod commands;
 mod config;
 mod helpers;
-mod manifest;
 pub mod tools;
 
 use app::{App, Commands};

--- a/crates/cli/src/commands/global.rs
+++ b/crates/cli/src/commands/global.rs
@@ -1,8 +1,7 @@
 use crate::helpers::enable_logging;
-use crate::manifest::Manifest;
 use crate::tools::{create_tool, ToolType};
 use log::{info, trace};
-use proto_core::{color, ProtoError};
+use proto_core::{color, Manifest, ProtoError};
 
 pub async fn global(tool_type: ToolType, version: String) -> Result<(), ProtoError> {
     enable_logging();

--- a/crates/cli/src/commands/install.rs
+++ b/crates/cli/src/commands/install.rs
@@ -1,5 +1,4 @@
 use crate::helpers::enable_logging;
-use crate::manifest::Manifest;
 use crate::tools::{create_tool, ToolType};
 use log::info;
 use proto_core::{color, ProtoError};
@@ -29,16 +28,6 @@ pub async fn install(tool_type: ToolType, version: Option<String>) -> Result<(),
     );
 
     tool.setup(&version).await?;
-
-    let version = tool.get_resolved_version();
-    let mut manifest = Manifest::load_for_tool(&tool)?;
-
-    if manifest.default_version.is_none() {
-        manifest.default_version = Some(version.to_owned());
-    }
-
-    manifest.installed_versions.insert(version.to_owned());
-    manifest.save()?;
 
     info!(
         target: "proto:install", "{} has been installed at {}!",

--- a/crates/cli/src/commands/list.rs
+++ b/crates/cli/src/commands/list.rs
@@ -1,9 +1,8 @@
 use crate::helpers::enable_logging;
-use crate::manifest::Manifest;
 use crate::tools::{create_tool, ToolType};
 use human_sort::compare;
 use log::{debug, info};
-use proto_core::{color, ProtoError};
+use proto_core::{color, Manifest, ProtoError};
 
 pub async fn list(tool_type: ToolType) -> Result<(), ProtoError> {
     enable_logging();

--- a/crates/cli/src/commands/uninstall.rs
+++ b/crates/cli/src/commands/uninstall.rs
@@ -1,5 +1,4 @@
 use crate::helpers::enable_logging;
-use crate::manifest::Manifest;
 use crate::tools::{create_tool, ToolType};
 use log::info;
 use proto_core::ProtoError;
@@ -28,21 +27,6 @@ pub async fn uninstall(tool_type: ToolType, version: String) -> Result<(), Proto
     );
 
     tool.teardown().await?;
-
-    let version = tool.get_resolved_version().to_owned();
-    let mut manifest = Manifest::load_for_tool(&tool)?;
-
-    manifest.installed_versions.remove(&version);
-
-    // Remove default version if nothing available
-    if manifest.installed_versions.is_empty() || manifest.default_version.as_ref() == Some(&version)
-    {
-        info!(target: "proto:uninstall", "Unpinning default global version");
-
-        manifest.default_version = None;
-    }
-
-    manifest.save()?;
 
     info!(
         target: "proto:uninstall",

--- a/crates/cli/src/helpers.rs
+++ b/crates/cli/src/helpers.rs
@@ -84,7 +84,7 @@ pub async fn detect_version_from_environment(
                 "Checking proto configuration file"
             );
 
-            let config = Config::load_from(&dir)?;
+            let config = Config::load_from(dir)?;
 
             if let Some(local_version) = config.tools.get(tool_type) {
                 debug!(
@@ -126,7 +126,7 @@ pub async fn detect_version_from_environment(
             "Attempting to find global version"
         );
 
-        let manifest = Manifest::load_for_tool(&tool)?;
+        let manifest = Manifest::load_for_tool(tool)?;
 
         if let Some(global_version) = manifest.default_version {
             debug!(

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,9 +1,7 @@
 pub mod config;
-pub mod manifest;
 pub mod tools;
 
 pub use config::*;
-pub use manifest::*;
 pub use proto_bun as bun;
 pub use proto_core::*;
 pub use proto_deno as deno;

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -17,6 +17,7 @@ human-sort = "0.2.2"
 lenient_semver = { version = "0.4.2", features = ["version_lite", "version_serde"] }
 log = { workspace = true }
 reqwest = { workspace = true }
+rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.10.6"

--- a/crates/core/src/manifest.rs
+++ b/crates/core/src/manifest.rs
@@ -21,7 +21,7 @@ pub struct Manifest {
 
 impl Manifest {
     pub fn insert_version(path: PathBuf, version: &str) -> Result<(), ProtoError> {
-        let mut manifest = Manifest::load(&path)?;
+        let mut manifest = Manifest::load(path)?;
 
         if manifest.default_version.is_none() {
             manifest.default_version = Some(version.to_owned());
@@ -34,12 +34,12 @@ impl Manifest {
     }
 
     pub fn remove_version(path: PathBuf, version: &str) -> Result<(), ProtoError> {
-        let mut manifest = Manifest::load(&path)?;
+        let mut manifest = Manifest::load(path)?;
 
         manifest.installed_versions.remove(version);
 
         // Remove default version if nothing available
-        if manifest.installed_versions.is_empty()
+        if (manifest.installed_versions.is_empty() && manifest.default_version.is_some())
             || manifest.default_version.as_ref() == Some(&version.to_owned())
         {
             info!(target: "proto:uninstall", "Unpinning default global version");
@@ -52,6 +52,7 @@ impl Manifest {
         Ok(())
     }
 
+    #[allow(clippy::borrowed_box)]
     pub fn load_for_tool(tool: &Box<dyn Tool<'_>>) -> Result<Self, ProtoError> {
         let dir = get_tools_dir()?.join(tool.get_bin_name());
 

--- a/crates/core/src/manifest.rs
+++ b/crates/core/src/manifest.rs
@@ -1,4 +1,5 @@
-use proto_core::{get_tools_dir, ProtoError, Tool};
+use crate::{get_tools_dir, ProtoError, Tool};
+use log::info;
 use rustc_hash::FxHashSet;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -19,6 +20,38 @@ pub struct Manifest {
 }
 
 impl Manifest {
+    pub fn insert_version(path: PathBuf, version: &str) -> Result<(), ProtoError> {
+        let mut manifest = Manifest::load(&path)?;
+
+        if manifest.default_version.is_none() {
+            manifest.default_version = Some(version.to_owned());
+        }
+
+        manifest.installed_versions.insert(version.to_owned());
+        manifest.save()?;
+
+        Ok(())
+    }
+
+    pub fn remove_version(path: PathBuf, version: &str) -> Result<(), ProtoError> {
+        let mut manifest = Manifest::load(&path)?;
+
+        manifest.installed_versions.remove(version);
+
+        // Remove default version if nothing available
+        if manifest.installed_versions.is_empty()
+            || manifest.default_version.as_ref() == Some(&version.to_owned())
+        {
+            info!(target: "proto:uninstall", "Unpinning default global version");
+
+            manifest.default_version = None;
+        }
+
+        manifest.save()?;
+
+        Ok(())
+    }
+
     pub fn load_for_tool(tool: &Box<dyn Tool<'_>>) -> Result<Self, ProtoError> {
         let dir = get_tools_dir()?.join(tool.get_bin_name());
 


### PR DESCRIPTION
In a previous PR I added a manifest layer: https://github.com/moonrepo/proto/pull/24

While this works fine, it dawned on me that this would not work with moon, as moon does not use proto's CLI but uses the core/lang crates directly.

If someone was using moon and proto together, the manifest would get out of sync rather quickly. To remedy this, I'm moving the manifest logic into core.