### PR TITLE
new: Add `--pin` flag to `install`.

### DIFF
--- a/crates/cli/src/app.rs
+++ b/crates/cli/src/app.rs
@@ -58,6 +58,9 @@ pub enum Commands {
 
         #[arg(default_value = "latest", help = "Version of tool")]
         semver: Option<String>,
+
+        #[arg(help = "Pin version as the global default")]
+        pin: bool,
     },
 
     #[command(

--- a/crates/cli/src/app.rs
+++ b/crates/cli/src/app.rs
@@ -59,14 +59,14 @@ pub enum Commands {
         #[arg(default_value = "latest", help = "Version of tool")]
         semver: Option<String>,
 
-        #[arg(help = "Pin version as the global default")]
+        #[arg(long, help = "Pin version as the global default")]
         pin: bool,
     },
 
     #[command(
         name = "global",
         about = "Set the global default version of a tool.",
-        long_about = "Set the global default version of a tool. This will create a version file in the ~/.proto/tools installation directory."
+        long_about = "Set the global default version of a tool. This will pin the version in the ~/.proto/tools installation directory."
     )]
     Global {
         #[arg(required = true, value_enum, help = "Type of tool")]

--- a/crates/cli/src/bin.rs
+++ b/crates/cli/src/bin.rs
@@ -16,7 +16,7 @@ async fn main() {
     let result = match app.command {
         Commands::Bin { tool, semver, shim } => commands::bin(tool, semver, shim).await,
         Commands::Completions { shell } => commands::completions(shell).await,
-        Commands::Install { tool, semver } => commands::install(tool, semver).await,
+        Commands::Install { tool, semver, pin } => commands::install(tool, semver, pin).await,
         Commands::Global { tool, semver } => commands::global(tool, semver).await,
         Commands::List { tool } => commands::list(tool).await,
         Commands::ListRemote { tool } => commands::list_remote(tool).await,

--- a/crates/cli/src/commands/install.rs
+++ b/crates/cli/src/commands/install.rs
@@ -1,9 +1,13 @@
 use crate::helpers::enable_logging;
 use crate::tools::{create_tool, ToolType};
 use log::info;
-use proto_core::{color, ProtoError};
+use proto_core::{color, Manifest, ProtoError};
 
-pub async fn install(tool_type: ToolType, version: Option<String>) -> Result<(), ProtoError> {
+pub async fn install(
+    tool_type: ToolType,
+    version: Option<String>,
+    pin_version: bool,
+) -> Result<(), ProtoError> {
     enable_logging();
 
     let version = version.unwrap_or_else(|| "latest".into());
@@ -28,6 +32,12 @@ pub async fn install(tool_type: ToolType, version: Option<String>) -> Result<(),
     );
 
     tool.setup(&version).await?;
+
+    if pin_version {
+        let mut manifest = Manifest::load_for_tool(&tool)?;
+        manifest.default_version = Some(tool.get_resolved_version().to_owned());
+        manifest.save()?;
+    }
 
     info!(
         target: "proto:install", "{} has been installed at {}!",

--- a/crates/cli/src/commands/install_all.rs
+++ b/crates/cli/src/commands/install_all.rs
@@ -17,7 +17,7 @@ pub async fn install_all() -> Result<(), ProtoError> {
     let mut futures = vec![];
 
     for (tool, version) in config.tools {
-        futures.push(install(tool, Some(version)));
+        futures.push(install(tool, Some(version), false));
     }
 
     futures::future::try_join_all(futures).await?;

--- a/crates/cli/tests/bin_test.rs
+++ b/crates/cli/tests/bin_test.rs
@@ -20,7 +20,11 @@ fn returns_path_if_installed() {
     let temp = create_temp_dir();
 
     let mut cmd = create_proto_command(temp.path());
-    cmd.arg("install").arg("npm").arg("9.0.0").assert();
+    cmd.arg("install")
+        .arg("npm")
+        .arg("9.0.0")
+        .assert()
+        .success();
 
     let mut cmd = create_proto_command(temp.path());
     let assert = cmd.arg("bin").arg("npm").arg("9.0.0").assert();

--- a/crates/cli/tests/global_test.rs
+++ b/crates/cli/tests/global_test.rs
@@ -10,7 +10,11 @@ fn updates_manifest_file() {
     assert!(!manifest_file.exists());
 
     let mut cmd = create_proto_command(temp.path());
-    cmd.arg("global").arg("node").arg("19.0.0").assert();
+    cmd.arg("global")
+        .arg("node")
+        .arg("19.0.0")
+        .assert()
+        .success();
 
     assert!(manifest_file.exists());
     assert_eq!(

--- a/crates/cli/tests/install_uninstall_test.rs
+++ b/crates/cli/tests/install_uninstall_test.rs
@@ -35,7 +35,11 @@ fn doesnt_install_tool_if_exists() {
     let temp = create_temp_dir();
 
     let mut cmd = create_proto_command(temp.path());
-    cmd.arg("install").arg("node").arg("19.0.0").assert();
+    cmd.arg("install")
+        .arg("node")
+        .arg("19.0.0")
+        .assert()
+        .success();
 
     let mut cmd = create_proto_command(temp.path());
     let assert = cmd.arg("install").arg("node").arg("19.0.0").assert();
@@ -62,7 +66,11 @@ fn updates_the_manifest_when_installing() {
 
     // Install
     let mut cmd = create_proto_command(temp.path());
-    cmd.arg("install").arg("node").arg("19.0.0").assert();
+    cmd.arg("install")
+        .arg("node")
+        .arg("19.0.0")
+        .assert()
+        .success();
 
     assert_eq!(
         fs::read_to_string(&manifest_file).unwrap(),
@@ -76,7 +84,11 @@ fn updates_the_manifest_when_installing() {
 
     // Uninstall
     let mut cmd = create_proto_command(temp.path());
-    cmd.arg("uninstall").arg("node").arg("19.0.0").assert();
+    cmd.arg("uninstall")
+        .arg("node")
+        .arg("19.0.0")
+        .assert()
+        .success();
 
     assert_eq!(
         fs::read_to_string(&manifest_file).unwrap(),

--- a/crates/cli/tests/local_test.rs
+++ b/crates/cli/tests/local_test.rs
@@ -11,7 +11,11 @@ fn writes_local_version_file() {
     assert!(!version_file.exists());
 
     let mut cmd = create_proto_command(temp.path());
-    cmd.arg("local").arg("node").arg("19.0.0").assert();
+    cmd.arg("local")
+        .arg("node")
+        .arg("19.0.0")
+        .assert()
+        .success();
 
     assert!(version_file.exists());
     assert_eq!(
@@ -26,10 +30,14 @@ fn appends_multiple_tools() {
     let version_file = temp.join(".prototools");
 
     let mut cmd = create_proto_command(temp.path());
-    cmd.arg("local").arg("node").arg("19.0.0").assert();
+    cmd.arg("local")
+        .arg("node")
+        .arg("19.0.0")
+        .assert()
+        .success();
 
     let mut cmd = create_proto_command(temp.path());
-    cmd.arg("local").arg("npm").arg("9.0.0").assert();
+    cmd.arg("local").arg("npm").arg("9.0.0").assert().success();
 
     assert_eq!(
         fs::read_to_string(version_file).unwrap(),
@@ -53,7 +61,11 @@ npm = "9.0.0"
     .unwrap();
 
     let mut cmd = create_proto_command(temp.path());
-    cmd.arg("local").arg("node").arg("19.0.0").assert();
+    cmd.arg("local")
+        .arg("node")
+        .arg("19.0.0")
+        .assert()
+        .success();
 
     assert_eq!(
         fs::read_to_string(version_file).unwrap(),

--- a/crates/cli/tests/run_test.rs
+++ b/crates/cli/tests/run_test.rs
@@ -11,8 +11,6 @@ fn errors_if_not_installed() {
     let mut cmd = create_proto_command(temp.path());
     let assert = cmd.arg("run").arg("node").arg("19.0.0").assert();
 
-    debug_assert(&assert);
-
     assert.stderr(predicate::str::contains(
         "Attempted to run Node.js v19.0.0, but this version has not been installed. Install it with `proto install node 19.0.0`!",
     ));
@@ -25,8 +23,6 @@ fn errors_if_no_version_detected() {
     let mut cmd = create_proto_command(temp.path());
     let assert = cmd.arg("run").arg("node").assert();
 
-    debug_assert(&assert);
-
     assert.stderr(predicate::str::contains(
         "Unable to detect an applicable version",
     ));
@@ -37,7 +33,11 @@ fn runs_a_tool() {
     let temp = create_temp_dir();
 
     let mut cmd = create_proto_command(temp.path());
-    cmd.arg("install").arg("node").arg("19.0.0").assert();
+    cmd.arg("install")
+        .arg("node")
+        .arg("19.0.0")
+        .assert()
+        .success();
 
     let mut cmd = create_proto_command(temp.path());
     let assert = cmd
@@ -56,7 +56,11 @@ fn runs_a_tool_using_version_detection() {
     let temp = create_temp_dir();
 
     let mut cmd = create_proto_command(temp.path());
-    cmd.arg("install").arg("node").arg("19.0.0").assert();
+    cmd.arg("install")
+        .arg("node")
+        .arg("19.0.0")
+        .assert()
+        .success();
 
     // Arg
     let mut cmd = create_proto_command(temp.path());

--- a/crates/cli/tests/use_test.rs
+++ b/crates/cli/tests/use_test.rs
@@ -37,7 +37,7 @@ deno = "1.30.0"
     assert!(!deno_path.exists());
 
     let mut cmd = create_proto_command(temp.path());
-    cmd.arg("use").assert();
+    cmd.arg("use").assert().success();
 
     assert!(node_path.exists());
     assert!(npm_path.exists());


### PR DESCRIPTION
This allows the global version to be pinned based on the newly installed tool.