### PR TITLE
new: Support version requirements/ranges as possible versions.

### DIFF
--- a/crates/core/src/detector.rs
+++ b/crates/core/src/detector.rs
@@ -1,4 +1,5 @@
-use crate::{errors::ProtoError, is_semantic_version};
+use crate::errors::ProtoError;
+use lenient_semver::Version;
 use std::{fs, path::Path};
 
 #[async_trait::async_trait]
@@ -17,27 +18,173 @@ pub fn load_version_file(path: &Path) -> Result<String, ProtoError> {
 }
 
 pub fn get_fixed_version(version: &str) -> Option<String> {
-    if version.starts_with('^')
-        || version.starts_with('~')
-        || version.starts_with('>')
-        || version.starts_with('<')
-        || version.contains(' ')
-        || version.contains('|')
-    {
+    if version == "*" {
+        return Some("latest".into());
+    }
+
+    let version = version.replace(" ", "");
+    let version_without_stars = version.replace(".*", "");
+    let mut explicit = false;
+    let mut drop_patch = false;
+
+    // Multiple versions, unable to parse
+    if version.contains('|') {
         return None;
     }
 
-    let maybe_semver = if let Some(value) = version.strip_prefix('=') {
-        value
-    } else {
-        version
+    let semver = match &version[0..1] {
+        "^" | "~" => Version::parse(&version[1..]),
+        ">" => {
+            if let Some(v) = version.strip_prefix(">=") {
+                Version::parse(v)
+            } else {
+                drop_patch = true;
+                Version::parse(&version[1..])
+            }
+        }
+        "<" => {
+            explicit = true;
+
+            if let Some(v) = version.strip_prefix("<=") {
+                Version::parse(v)
+            } else {
+                // TODO: This isn't correct
+                Version::parse(&version[1..])
+            }
+        }
+        "=" => {
+            explicit = true;
+            Version::parse(&version_without_stars[1..])
+        }
+        _ => {
+            if version.contains('*') {
+                Version::parse(&version_without_stars)
+            } else {
+                explicit = true;
+                Version::parse(&version)
+            }
+        }
     };
 
-    let maybe_semver = &maybe_semver.replace(".*", "");
+    let Ok(semver) = semver else {
+        return None;
+    };
 
-    if is_semantic_version(maybe_semver) {
-        return Some(maybe_semver.to_owned());
+    let mut matched_version = semver.major.to_string();
+
+    if semver.minor != 0 || explicit {
+        matched_version = format!("{matched_version}.{}", semver.minor);
+
+        if (semver.patch != 0 || explicit) && !drop_patch {
+            matched_version = format!("{matched_version}.{}", semver.patch);
+        }
     }
 
-    None
+    Some(matched_version)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod fixed_version {
+        use super::*;
+
+        #[test]
+        fn ignores_invalid() {
+            assert_eq!(get_fixed_version("unknown"), None);
+            assert_eq!(get_fixed_version("1 || 2"), None);
+        }
+
+        #[test]
+        fn handles_explicit() {
+            assert_eq!(get_fixed_version("1.2.3-alpha").unwrap(), "1.2.3"); // ?
+            assert_eq!(get_fixed_version("1.2.3").unwrap(), "1.2.3");
+            assert_eq!(get_fixed_version("1.2.0").unwrap(), "1.2.0");
+            assert_eq!(get_fixed_version("1.2").unwrap(), "1.2.0");
+            assert_eq!(get_fixed_version("1.0").unwrap(), "1.0.0");
+            assert_eq!(get_fixed_version("1").unwrap(), "1.0.0");
+
+            assert_eq!(get_fixed_version("v1.2.3-alpha").unwrap(), "1.2.3"); // ?
+            assert_eq!(get_fixed_version("V1.2.3").unwrap(), "1.2.3");
+            assert_eq!(get_fixed_version("v1.2.0").unwrap(), "1.2.0");
+            assert_eq!(get_fixed_version("V1.2").unwrap(), "1.2.0");
+            assert_eq!(get_fixed_version("v1.0").unwrap(), "1.0.0");
+            assert_eq!(get_fixed_version("V1").unwrap(), "1.0.0");
+        }
+
+        #[test]
+        fn handles_equals() {
+            assert_eq!(get_fixed_version("=1.2.3-alpha").unwrap(), "1.2.3"); // ?
+            assert_eq!(get_fixed_version("=1.2.3").unwrap(), "1.2.3");
+            assert_eq!(get_fixed_version("=1.2.0").unwrap(), "1.2.0");
+            assert_eq!(get_fixed_version("=1.2").unwrap(), "1.2.0");
+            assert_eq!(get_fixed_version("=1.0").unwrap(), "1.0.0");
+            assert_eq!(get_fixed_version("=1").unwrap(), "1.0.0");
+        }
+
+        #[test]
+        fn handles_star() {
+            assert_eq!(get_fixed_version("=1.2.*").unwrap(), "1.2.0");
+            assert_eq!(get_fixed_version("=1.*").unwrap(), "1.0.0");
+            assert_eq!(get_fixed_version("1.2.*").unwrap(), "1.2");
+            assert_eq!(get_fixed_version("1.*").unwrap(), "1");
+            assert_eq!(get_fixed_version("*").unwrap(), "latest");
+        }
+
+        #[test]
+        fn handles_caret() {
+            assert_eq!(get_fixed_version("^1.2.3-alpha").unwrap(), "1.2.3"); // ?
+            assert_eq!(get_fixed_version("^1.2.3").unwrap(), "1.2.3");
+            assert_eq!(get_fixed_version("^1.2.0").unwrap(), "1.2");
+            assert_eq!(get_fixed_version("^1.2").unwrap(), "1.2");
+            assert_eq!(get_fixed_version("^1.0").unwrap(), "1");
+            assert_eq!(get_fixed_version("^1").unwrap(), "1");
+        }
+
+        #[test]
+        fn handles_tilde() {
+            assert_eq!(get_fixed_version("~1.2.3-alpha").unwrap(), "1.2.3"); // ?
+            assert_eq!(get_fixed_version("~1.2.3").unwrap(), "1.2.3");
+            assert_eq!(get_fixed_version("~1.2.0").unwrap(), "1.2");
+            assert_eq!(get_fixed_version("~1.2").unwrap(), "1.2");
+            assert_eq!(get_fixed_version("~1.0").unwrap(), "1");
+            assert_eq!(get_fixed_version("~1").unwrap(), "1");
+        }
+
+        #[test]
+        fn handles_gt() {
+            assert_eq!(get_fixed_version(">1.2.3-alpha").unwrap(), "1.2"); // ?
+            assert_eq!(get_fixed_version(">1.2.3").unwrap(), "1.2");
+            assert_eq!(get_fixed_version(">1.2.0").unwrap(), "1.2");
+            assert_eq!(get_fixed_version(">1.2").unwrap(), "1.2");
+            assert_eq!(get_fixed_version(">1.0").unwrap(), "1");
+            assert_eq!(get_fixed_version(">1").unwrap(), "1");
+
+            assert_eq!(get_fixed_version(">=1.2.3-alpha").unwrap(), "1.2.3"); // ?
+            assert_eq!(get_fixed_version(">=1.2.3").unwrap(), "1.2.3");
+            assert_eq!(get_fixed_version(">=1.2.0").unwrap(), "1.2");
+            assert_eq!(get_fixed_version(">=1.2").unwrap(), "1.2");
+            assert_eq!(get_fixed_version(">=1.0").unwrap(), "1");
+            assert_eq!(get_fixed_version(">=1").unwrap(), "1");
+        }
+
+        #[test]
+        fn handles_lt() {
+            // THIS IS WRONG, best solution? Does this even happen?
+            assert_eq!(get_fixed_version("<1.2.3-alpha").unwrap(), "1.2.3"); // ?
+            assert_eq!(get_fixed_version("<1.2.3").unwrap(), "1.2.3");
+            assert_eq!(get_fixed_version("<1.2.0").unwrap(), "1.2.0");
+            assert_eq!(get_fixed_version("<1.2").unwrap(), "1.2.0");
+            assert_eq!(get_fixed_version("<1.0").unwrap(), "1.0.0");
+            assert_eq!(get_fixed_version("<1").unwrap(), "1.0.0");
+
+            assert_eq!(get_fixed_version("<=1.2.3-alpha").unwrap(), "1.2.3"); // ?
+            assert_eq!(get_fixed_version("<=1.2.3").unwrap(), "1.2.3");
+            assert_eq!(get_fixed_version("<=1.2.0").unwrap(), "1.2.0");
+            assert_eq!(get_fixed_version("<=1.2").unwrap(), "1.2.0");
+            assert_eq!(get_fixed_version("<=1.0").unwrap(), "1.0.0");
+            assert_eq!(get_fixed_version("<=1").unwrap(), "1.0.0");
+        }
+    }
 }

--- a/crates/node/tests/node_depman_test.rs
+++ b/crates/node/tests/node_depman_test.rs
@@ -142,7 +142,7 @@ mod node_depman {
         }
 
         #[tokio::test]
-        async fn doesnt_match_if_engines_caret() {
+        async fn matches_if_engines_caret() {
             let fixture = assert_fs::TempDir::new().unwrap();
 
             fixture
@@ -154,12 +154,12 @@ mod node_depman {
 
             assert_eq!(
                 tool.detect_version_from(fixture.path()).await.unwrap(),
-                None
+                Some("1.2.3".into())
             );
         }
 
         #[tokio::test]
-        async fn doesnt_match_if_engines_tilde() {
+        async fn matches_engines_tilde() {
             let fixture = assert_fs::TempDir::new().unwrap();
 
             fixture
@@ -171,24 +171,24 @@ mod node_depman {
 
             assert_eq!(
                 tool.detect_version_from(fixture.path()).await.unwrap(),
-                None
+                Some("1.2.3".into())
             );
         }
 
         #[tokio::test]
-        async fn doesnt_match_if_engines_range() {
+        async fn matches_engines_range() {
             let fixture = assert_fs::TempDir::new().unwrap();
 
             fixture
                 .child("package.json")
-                .write_str(r#"{"engines":{"npm":">=1.2.3"}}"#)
+                .write_str(r#"{"engines":{"npm":">=1.2"}}"#)
                 .unwrap();
 
             let tool = create_depman(fixture.path());
 
             assert_eq!(
                 tool.detect_version_from(fixture.path()).await.unwrap(),
-                None
+                Some("1.2".into())
             );
         }
 
@@ -239,7 +239,7 @@ mod node_depman {
 
             assert_eq!(
                 tool.detect_version_from(fixture.path()).await.unwrap(),
-                Some("1.2".into())
+                Some("1.2.0".into())
             );
         }
 

--- a/crates/node/tests/node_test.rs
+++ b/crates/node/tests/node_test.rs
@@ -94,7 +94,7 @@ mod node {
         }
 
         #[tokio::test]
-        async fn doesnt_match_engines_caret() {
+        async fn matches_engines_caret() {
             let fixture = assert_fs::TempDir::new().unwrap();
             let tool = create_node(fixture.path());
 
@@ -105,7 +105,23 @@ mod node {
 
             assert_eq!(
                 tool.detect_version_from(fixture.path()).await.unwrap(),
-                None
+                Some("16".into())
+            );
+        }
+
+        #[tokio::test]
+        async fn matches_engines_star() {
+            let fixture = assert_fs::TempDir::new().unwrap();
+            let tool = create_node(fixture.path());
+
+            fixture
+                .child("package.json")
+                .write_str(r#"{"engines":{"node":"16.*"}}"#)
+                .unwrap();
+
+            assert_eq!(
+                tool.detect_version_from(fixture.path()).await.unwrap(),
+                Some("16".into())
             );
         }
     }


### PR DESCRIPTION
Previously versions that started with `^`, `>=`, and other variants were ignored for detection. This will now utilize those requirements and attempt to parse them to an applicable version. This isn't perfect, but is better than nothing.