### PR TITLE
breaking: Rework handling of version requirement detection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+#### 💥 Breaking
+
+- When detecting a version and proto encounters a range/requirement using `^`, `~`, `>=`, etc, proto will now resolve the version against the currently installed versions in `~/.proto`, instead of resolving to an arbitray fixed version.
+
 #### 🚀 Updates
 
 - Added "bundled" as a supported alias for `npm`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1239,6 +1239,7 @@ dependencies = [
 name = "proto_core"
 version = "0.2.1"
 dependencies = [
+ "assert_fs",
  "async-trait",
  "cached",
  "console",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1249,6 +1249,7 @@ dependencies = [
  "log",
  "reqwest",
  "rustc-hash",
+ "semver",
  "serde",
  "serde_json",
  "sha2",
@@ -1481,6 +1482,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,7 +932,6 @@ checksum = "de8de3f4f3754c280ce1c8c42ed8dd26a9c8385c2e5ad4ec5a77e774cea9c1ec"
 dependencies = [
  "lenient_semver_parser",
  "lenient_version",
- "semver",
 ]
 
 [[package]]
@@ -942,7 +941,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f650c1d024ddc26b4bb79c3076b30030f2cf2b18292af698c81f7337a64d7d6"
 dependencies = [
  "lenient_semver_version_builder",
- "semver",
 ]
 
 [[package]]
@@ -950,9 +948,6 @@ name = "lenient_semver_version_builder"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9049f8ff49f75b946f95557148e70230499c8a642bf2d6528246afc7d0282d17"
-dependencies = [
- "semver",
-]
 
 [[package]]
 name = "lenient_version"
@@ -962,7 +957,6 @@ checksum = "bad7b41cc0ad9b8a9f8d8fcb7c2ab6703a6da4b369cbb7e3a63ee0840769b4eb"
 dependencies = [
  "lenient_semver_parser",
  "lenient_semver_version_builder",
- "serde",
 ]
 
 [[package]]
@@ -1487,12 +1481,6 @@ dependencies = [
  "ring",
  "untrusted",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 
 [[package]]
 name = "serde"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -28,3 +28,6 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 toml = "0.7.0"
 zip = "0.6.4"
+
+[dev-dependencies]
+assert_fs = { workspace = true }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -18,6 +18,7 @@ lenient_semver = { version = "0.4.2", default-features = false, features = ["ver
 log = { workspace = true }
 reqwest = { workspace = true }
 rustc-hash = { workspace = true }
+semver = "1.0.17"
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.10.6"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -14,7 +14,7 @@ console = { workspace = true }
 dirs = "4.0.0"
 flate2 = "1.0.25"
 human-sort = "0.2.2"
-lenient_semver = { version = "0.4.2", features = ["version_lite", "version_serde"] }
+lenient_semver = { version = "0.4.2", default-features = false, features = ["version_lite"] }
 log = { workspace = true }
 reqwest = { workspace = true }
 rustc-hash = { workspace = true }

--- a/crates/core/src/detector.rs
+++ b/crates/core/src/detector.rs
@@ -377,59 +377,219 @@ mod tests {
             );
         }
 
-        // #[test]
-        // fn handles_caret() {
-        //     assert_eq!(detect_fixed_version("^1.2.3-alpha").unwrap(), "1.2.3"); // ?
-        //     assert_eq!(detect_fixed_version("^1.2.3").unwrap(), "1.2.3");
-        //     assert_eq!(detect_fixed_version("^1.2.0").unwrap(), "1.2");
-        //     assert_eq!(detect_fixed_version("^1.2").unwrap(), "1.2");
-        //     assert_eq!(detect_fixed_version("^1.0").unwrap(), "1");
-        //     assert_eq!(detect_fixed_version("^1").unwrap(), "1");
-        // }
+        #[test]
+        fn handles_caret() {
+            let temp = create_temp_dir();
+            let manifest_path = create_manifest(
+                temp.path(),
+                Manifest {
+                    installed_versions: FxHashSet::from_iter(["1.5.9".into()]),
+                    ..Manifest::default()
+                },
+            );
 
-        // #[test]
-        // fn handles_tilde() {
-        //     assert_eq!(detect_fixed_version("~1.2.3-alpha").unwrap(), "1.2.3"); // ?
-        //     assert_eq!(detect_fixed_version("~1.2.3").unwrap(), "1.2.3");
-        //     assert_eq!(detect_fixed_version("~1.2.0").unwrap(), "1.2");
-        //     assert_eq!(detect_fixed_version("~1.2").unwrap(), "1.2");
-        //     assert_eq!(detect_fixed_version("~1.0").unwrap(), "1");
-        //     assert_eq!(detect_fixed_version("~1").unwrap(), "1");
-        // }
+            assert_eq!(
+                detect_fixed_version("^1.2.3-alpha", &manifest_path)
+                    .unwrap()
+                    .unwrap(),
+                "1.5.9"
+            );
+            assert_eq!(
+                detect_fixed_version("^1.2.3", &manifest_path)
+                    .unwrap()
+                    .unwrap(),
+                "1.5.9"
+            );
+            assert_eq!(
+                detect_fixed_version("^1.2.0", &manifest_path)
+                    .unwrap()
+                    .unwrap(),
+                "1.5.9"
+            );
+            assert_eq!(
+                detect_fixed_version("^1.2", &manifest_path)
+                    .unwrap()
+                    .unwrap(),
+                "1.5.9"
+            );
+            assert_eq!(
+                detect_fixed_version("^1.0", &manifest_path)
+                    .unwrap()
+                    .unwrap(),
+                "1.5.9"
+            );
+            assert_eq!(
+                detect_fixed_version("^1", &manifest_path).unwrap().unwrap(),
+                "1.5.9"
+            );
 
-        // #[test]
-        // fn handles_gt() {
-        //     assert_eq!(detect_fixed_version(">1.2.3-alpha").unwrap(), "1.2"); // ?
-        //     assert_eq!(detect_fixed_version(">1.2.3").unwrap(), "1.2");
-        //     assert_eq!(detect_fixed_version(">1.2.0").unwrap(), "1.2");
-        //     assert_eq!(detect_fixed_version(">1.2").unwrap(), "1.2");
-        //     assert_eq!(detect_fixed_version(">1.0").unwrap(), "1");
-        //     assert_eq!(detect_fixed_version(">1").unwrap(), "1");
+            // Failures
+            assert_eq!(detect_fixed_version("^1.6", &manifest_path).unwrap(), None);
+            assert_eq!(detect_fixed_version("^2", &manifest_path).unwrap(), None);
+            assert_eq!(detect_fixed_version("^0", &manifest_path).unwrap(), None);
+        }
 
-        //     assert_eq!(detect_fixed_version(">=1.2.3-alpha").unwrap(), "1.2.3"); // ?
-        //     assert_eq!(detect_fixed_version(">=1.2.3").unwrap(), "1.2.3");
-        //     assert_eq!(detect_fixed_version(">=1.2.0").unwrap(), "1.2");
-        //     assert_eq!(detect_fixed_version(">=1.2").unwrap(), "1.2");
-        //     assert_eq!(detect_fixed_version(">=1.0").unwrap(), "1");
-        //     assert_eq!(detect_fixed_version(">=1").unwrap(), "1");
-        // }
+        #[test]
+        fn handles_tilde() {
+            let temp = create_temp_dir();
+            let manifest_path = create_manifest(
+                temp.path(),
+                Manifest {
+                    installed_versions: FxHashSet::from_iter(["1.2.9".into()]),
+                    ..Manifest::default()
+                },
+            );
 
-        // #[test]
-        // fn handles_lt() {
-        //     // THIS IS WRONG, best solution? Does this even happen?
-        //     assert_eq!(detect_fixed_version("<1.2.3-alpha").unwrap(), "1.2.3"); // ?
-        //     assert_eq!(detect_fixed_version("<1.2.3").unwrap(), "1.2.3");
-        //     assert_eq!(detect_fixed_version("<1.2.0").unwrap(), "1.2.0");
-        //     assert_eq!(detect_fixed_version("<1.2").unwrap(), "1.2.0");
-        //     assert_eq!(detect_fixed_version("<1.0").unwrap(), "1.0.0");
-        //     assert_eq!(detect_fixed_version("<1").unwrap(), "1.0.0");
+            assert_eq!(
+                detect_fixed_version("~1.2.3-alpha", &manifest_path)
+                    .unwrap()
+                    .unwrap(),
+                "1.2.9"
+            );
+            assert_eq!(
+                detect_fixed_version("~1.2.3", &manifest_path)
+                    .unwrap()
+                    .unwrap(),
+                "1.2.9"
+            );
+            assert_eq!(
+                detect_fixed_version("~1.2.0", &manifest_path)
+                    .unwrap()
+                    .unwrap(),
+                "1.2.9"
+            );
+            assert_eq!(
+                detect_fixed_version("~1.2", &manifest_path)
+                    .unwrap()
+                    .unwrap(),
+                "1.2.9"
+            );
+            assert_eq!(
+                detect_fixed_version("~1", &manifest_path).unwrap().unwrap(),
+                "1.2.9"
+            );
 
-        //     assert_eq!(detect_fixed_version("<=1.2.3-alpha").unwrap(), "1.2.3"); // ?
-        //     assert_eq!(detect_fixed_version("<=1.2.3").unwrap(), "1.2.3");
-        //     assert_eq!(detect_fixed_version("<=1.2.0").unwrap(), "1.2.0");
-        //     assert_eq!(detect_fixed_version("<=1.2").unwrap(), "1.2.0");
-        //     assert_eq!(detect_fixed_version("<=1.0").unwrap(), "1.0.0");
-        //     assert_eq!(detect_fixed_version("<=1").unwrap(), "1.0.0");
-        // }
+            // Failures
+            assert_eq!(detect_fixed_version("~1.3", &manifest_path).unwrap(), None);
+            assert_eq!(detect_fixed_version("~1.1", &manifest_path).unwrap(), None);
+            assert_eq!(detect_fixed_version("~1.0", &manifest_path).unwrap(), None);
+            assert_eq!(detect_fixed_version("~2", &manifest_path).unwrap(), None);
+            assert_eq!(detect_fixed_version("~0", &manifest_path).unwrap(), None);
+        }
+
+        #[test]
+        fn handles_gt() {
+            let temp = create_temp_dir();
+            let manifest_path = create_manifest(
+                temp.path(),
+                Manifest {
+                    installed_versions: FxHashSet::from_iter(["1.5.9".into()]),
+                    ..Manifest::default()
+                },
+            );
+
+            assert_eq!(
+                detect_fixed_version(">1.2.3-alpha", &manifest_path)
+                    .unwrap()
+                    .unwrap(),
+                "1.5.9"
+            );
+            assert_eq!(
+                detect_fixed_version(">1.2.3", &manifest_path)
+                    .unwrap()
+                    .unwrap(),
+                "1.5.9"
+            );
+            assert_eq!(
+                detect_fixed_version(">1.2.0", &manifest_path)
+                    .unwrap()
+                    .unwrap(),
+                "1.5.9"
+            );
+            assert_eq!(
+                detect_fixed_version(">1.2", &manifest_path)
+                    .unwrap()
+                    .unwrap(),
+                "1.5.9"
+            );
+            assert_eq!(
+                detect_fixed_version(">1.0", &manifest_path)
+                    .unwrap()
+                    .unwrap(),
+                "1.5.9"
+            );
+            assert_eq!(
+                detect_fixed_version(">0", &manifest_path).unwrap().unwrap(),
+                "1.5.9"
+            );
+
+            // Failures
+            assert_eq!(detect_fixed_version(">1.6", &manifest_path).unwrap(), None);
+            assert_eq!(
+                detect_fixed_version(">1.5.9", &manifest_path).unwrap(),
+                None
+            );
+            assert_eq!(detect_fixed_version(">2", &manifest_path).unwrap(), None);
+            assert_eq!(detect_fixed_version(">1", &manifest_path).unwrap(), None);
+        }
+
+        #[test]
+        fn handles_gte() {
+            let temp = create_temp_dir();
+            let manifest_path = create_manifest(
+                temp.path(),
+                Manifest {
+                    installed_versions: FxHashSet::from_iter(["1.5.9".into()]),
+                    ..Manifest::default()
+                },
+            );
+
+            assert_eq!(
+                detect_fixed_version(">=1.2.3-alpha", &manifest_path)
+                    .unwrap()
+                    .unwrap(),
+                "1.5.9"
+            );
+            assert_eq!(
+                detect_fixed_version(">=1.2.3", &manifest_path)
+                    .unwrap()
+                    .unwrap(),
+                "1.5.9"
+            );
+            assert_eq!(
+                detect_fixed_version(">=1.2.0", &manifest_path)
+                    .unwrap()
+                    .unwrap(),
+                "1.5.9"
+            );
+            assert_eq!(
+                detect_fixed_version(">=1.2", &manifest_path)
+                    .unwrap()
+                    .unwrap(),
+                "1.5.9"
+            );
+            assert_eq!(
+                detect_fixed_version(">=1.0", &manifest_path)
+                    .unwrap()
+                    .unwrap(),
+                "1.5.9"
+            );
+            assert_eq!(
+                detect_fixed_version(">=1", &manifest_path)
+                    .unwrap()
+                    .unwrap(),
+                "1.5.9"
+            );
+            assert_eq!(
+                detect_fixed_version(">=0", &manifest_path)
+                    .unwrap()
+                    .unwrap(),
+                "1.5.9"
+            );
+
+            // Failures
+            assert_eq!(detect_fixed_version(">1.6", &manifest_path).unwrap(), None);
+            assert_eq!(detect_fixed_version(">=2", &manifest_path).unwrap(), None);
+        }
     }
 }

--- a/crates/core/src/detector.rs
+++ b/crates/core/src/detector.rs
@@ -157,7 +157,7 @@ pub fn detect_fixed_version<P: AsRef<Path>>(
         "^" | "~" | ">" | "<" | "*" => {
             let req = semver::VersionReq::parse(&version)
                 .map_err(|e| ProtoError::Semver(version.to_owned(), e.to_string()))?;
-            let manifest = Manifest::load_from(manifest_path.as_ref())?;
+            let manifest = Manifest::load(manifest_path.as_ref())?;
 
             for installed_version in manifest.installed_versions {
                 let version_inst = semver::Version::parse(&installed_version)
@@ -200,174 +200,236 @@ pub fn detect_fixed_version<P: AsRef<Path>>(
     Ok(Some(matched_version))
 }
 
-pub fn get_fixed_version(version: &str) -> Option<String> {
-    if version == "*" {
-        return Some("latest".into());
-    }
-
-    let version = version.replace(' ', "");
-    let version_without_stars = version.replace(".*", "");
-    let mut explicit = false;
-    let mut drop_patch = false;
-
-    // Multiple versions, unable to parse
-    if version.contains('|') {
-        return None;
-    }
-
-    let semver = match &version[0..1] {
-        "^" | "~" => Version::parse(&version[1..]),
-        ">" => {
-            if let Some(v) = version.strip_prefix(">=") {
-                Version::parse(v)
-            } else {
-                drop_patch = true;
-                Version::parse(&version[1..])
-            }
-        }
-        "<" => {
-            explicit = true;
-
-            if let Some(v) = version.strip_prefix("<=") {
-                Version::parse(v)
-            } else {
-                // TODO: This isn't correct
-                Version::parse(&version[1..])
-            }
-        }
-        "=" => {
-            explicit = true;
-            Version::parse(&version_without_stars[1..])
-        }
-        _ => {
-            if version.contains('*') {
-                Version::parse(&version_without_stars)
-            } else {
-                explicit = true;
-                Version::parse(&version)
-            }
-        }
-    };
-
-    let Ok(semver) = semver else {
-        return None;
-    };
-
-    let mut matched_version = semver.major.to_string();
-
-    if semver.minor != 0 || explicit {
-        matched_version = format!("{matched_version}.{}", semver.minor);
-
-        if (semver.patch != 0 || explicit) && !drop_patch {
-            matched_version = format!("{matched_version}.{}", semver.patch);
-        }
-    }
-
-    Some(matched_version)
-}
-
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use super::*;
 
+    pub fn create_temp_dir() -> assert_fs::TempDir {
+        assert_fs::TempDir::new().unwrap()
+    }
+
+    pub fn create_manifest(dir: &Path, manifest: Manifest) -> PathBuf {
+        let manifest_path = dir.join(MANIFEST_NAME);
+        let manifest_str = serde_json::to_string_pretty(&manifest).unwrap();
+
+        dbg!(&manifest_str);
+
+        std::fs::write(&manifest_path, manifest_str).unwrap();
+
+        manifest_path
+    }
+
     mod fixed_version {
+        use rustc_hash::FxHashSet;
+
         use super::*;
 
-        #[test]
-        fn ignores_invalid() {
-            assert_eq!(get_fixed_version("unknown"), None);
-            assert_eq!(get_fixed_version("1 || 2"), None);
-        }
+        // #[test]
+        // fn ignores_invalid() {
+        //     assert_eq!(detect_fixed_version("unknown"), None);
+        //     assert_eq!(detect_fixed_version("1 || 2"), None);
+        // }
 
         #[test]
         fn handles_explicit() {
-            assert_eq!(get_fixed_version("1.2.3-alpha").unwrap(), "1.2.3"); // ?
-            assert_eq!(get_fixed_version("1.2.3").unwrap(), "1.2.3");
-            assert_eq!(get_fixed_version("1.2.0").unwrap(), "1.2.0");
-            assert_eq!(get_fixed_version("1.2").unwrap(), "1.2.0");
-            assert_eq!(get_fixed_version("1.0").unwrap(), "1.0.0");
-            assert_eq!(get_fixed_version("1").unwrap(), "1.0.0");
+            let temp = create_temp_dir();
 
-            assert_eq!(get_fixed_version("v1.2.3-alpha").unwrap(), "1.2.3"); // ?
-            assert_eq!(get_fixed_version("V1.2.3").unwrap(), "1.2.3");
-            assert_eq!(get_fixed_version("v1.2.0").unwrap(), "1.2.0");
-            assert_eq!(get_fixed_version("V1.2").unwrap(), "1.2.0");
-            assert_eq!(get_fixed_version("v1.0").unwrap(), "1.0.0");
-            assert_eq!(get_fixed_version("V1").unwrap(), "1.0.0");
+            assert_eq!(
+                detect_fixed_version("1.2.3-alpha", temp.path())
+                    .unwrap()
+                    .unwrap(),
+                "1.2.3"
+            ); // ?
+            assert_eq!(
+                detect_fixed_version("1.2.3", temp.path()).unwrap().unwrap(),
+                "1.2.3"
+            );
+            assert_eq!(
+                detect_fixed_version("1.2.0", temp.path()).unwrap().unwrap(),
+                "1.2"
+            );
+            assert_eq!(
+                detect_fixed_version("1.2", temp.path()).unwrap().unwrap(),
+                "1.2"
+            );
+            assert_eq!(
+                detect_fixed_version("1.0", temp.path()).unwrap().unwrap(),
+                "1"
+            );
+            assert_eq!(
+                detect_fixed_version("1", temp.path()).unwrap().unwrap(),
+                "1"
+            );
+
+            assert_eq!(
+                detect_fixed_version("v1.2.3-alpha", temp.path())
+                    .unwrap()
+                    .unwrap(),
+                "1.2.3"
+            ); // ?
+            assert_eq!(
+                detect_fixed_version("V1.2.3", temp.path())
+                    .unwrap()
+                    .unwrap(),
+                "1.2.3"
+            );
+            assert_eq!(
+                detect_fixed_version("v1.2.0", temp.path())
+                    .unwrap()
+                    .unwrap(),
+                "1.2"
+            );
+            assert_eq!(
+                detect_fixed_version("V1.2", temp.path()).unwrap().unwrap(),
+                "1.2"
+            );
+            assert_eq!(
+                detect_fixed_version("v1.0", temp.path()).unwrap().unwrap(),
+                "1"
+            );
+            assert_eq!(
+                detect_fixed_version("V1", temp.path()).unwrap().unwrap(),
+                "1"
+            );
         }
 
         #[test]
         fn handles_equals() {
-            assert_eq!(get_fixed_version("=1.2.3-alpha").unwrap(), "1.2.3"); // ?
-            assert_eq!(get_fixed_version("=1.2.3").unwrap(), "1.2.3");
-            assert_eq!(get_fixed_version("=1.2.0").unwrap(), "1.2.0");
-            assert_eq!(get_fixed_version("=1.2").unwrap(), "1.2.0");
-            assert_eq!(get_fixed_version("=1.0").unwrap(), "1.0.0");
-            assert_eq!(get_fixed_version("=1").unwrap(), "1.0.0");
+            let temp = create_temp_dir();
+
+            assert_eq!(
+                detect_fixed_version("=1.2.3-alpha", temp.path())
+                    .unwrap()
+                    .unwrap(),
+                "1.2.3"
+            ); // ?
+            assert_eq!(
+                detect_fixed_version("=1.2.3", temp.path())
+                    .unwrap()
+                    .unwrap(),
+                "1.2.3"
+            );
+            assert_eq!(
+                detect_fixed_version("=1.2.0", temp.path())
+                    .unwrap()
+                    .unwrap(),
+                "1.2"
+            );
+            assert_eq!(
+                detect_fixed_version("=1.2", temp.path()).unwrap().unwrap(),
+                "1.2"
+            );
+            assert_eq!(
+                detect_fixed_version("=1.0", temp.path()).unwrap().unwrap(),
+                "1"
+            );
+            assert_eq!(
+                detect_fixed_version("=1", temp.path()).unwrap().unwrap(),
+                "1"
+            );
         }
 
         #[test]
         fn handles_star() {
-            assert_eq!(get_fixed_version("=1.2.*").unwrap(), "1.2.0");
-            assert_eq!(get_fixed_version("=1.*").unwrap(), "1.0.0");
-            assert_eq!(get_fixed_version("1.2.*").unwrap(), "1.2");
-            assert_eq!(get_fixed_version("1.*").unwrap(), "1");
-            assert_eq!(get_fixed_version("*").unwrap(), "latest");
+            let temp = create_temp_dir();
+
+            assert_eq!(
+                detect_fixed_version("=1.2.*", temp.path())
+                    .unwrap()
+                    .unwrap(),
+                "1.2"
+            );
+            assert_eq!(
+                detect_fixed_version("=1.*", temp.path()).unwrap().unwrap(),
+                "1"
+            );
+            assert_eq!(
+                detect_fixed_version("1.2.*", temp.path()).unwrap().unwrap(),
+                "1.2"
+            );
+            assert_eq!(
+                detect_fixed_version("1.*", temp.path()).unwrap().unwrap(),
+                "1"
+            );
         }
 
         #[test]
-        fn handles_caret() {
-            assert_eq!(get_fixed_version("^1.2.3-alpha").unwrap(), "1.2.3"); // ?
-            assert_eq!(get_fixed_version("^1.2.3").unwrap(), "1.2.3");
-            assert_eq!(get_fixed_version("^1.2.0").unwrap(), "1.2");
-            assert_eq!(get_fixed_version("^1.2").unwrap(), "1.2");
-            assert_eq!(get_fixed_version("^1.0").unwrap(), "1");
-            assert_eq!(get_fixed_version("^1").unwrap(), "1");
+        fn handles_star_all() {
+            let temp = create_temp_dir();
+
+            let manifest_path = create_manifest(temp.path(), Manifest::default());
+
+            assert_eq!(detect_fixed_version("*", manifest_path).unwrap(), None);
+
+            let manifest_path = create_manifest(
+                temp.path(),
+                Manifest {
+                    installed_versions: FxHashSet::from_iter(["1.2.3".into()]),
+                    ..Manifest::default()
+                },
+            );
+
+            assert_eq!(
+                detect_fixed_version("*", manifest_path).unwrap().unwrap(),
+                "1.2.3"
+            );
         }
 
-        #[test]
-        fn handles_tilde() {
-            assert_eq!(get_fixed_version("~1.2.3-alpha").unwrap(), "1.2.3"); // ?
-            assert_eq!(get_fixed_version("~1.2.3").unwrap(), "1.2.3");
-            assert_eq!(get_fixed_version("~1.2.0").unwrap(), "1.2");
-            assert_eq!(get_fixed_version("~1.2").unwrap(), "1.2");
-            assert_eq!(get_fixed_version("~1.0").unwrap(), "1");
-            assert_eq!(get_fixed_version("~1").unwrap(), "1");
-        }
+        // #[test]
+        // fn handles_caret() {
+        //     assert_eq!(detect_fixed_version("^1.2.3-alpha").unwrap(), "1.2.3"); // ?
+        //     assert_eq!(detect_fixed_version("^1.2.3").unwrap(), "1.2.3");
+        //     assert_eq!(detect_fixed_version("^1.2.0").unwrap(), "1.2");
+        //     assert_eq!(detect_fixed_version("^1.2").unwrap(), "1.2");
+        //     assert_eq!(detect_fixed_version("^1.0").unwrap(), "1");
+        //     assert_eq!(detect_fixed_version("^1").unwrap(), "1");
+        // }
 
-        #[test]
-        fn handles_gt() {
-            assert_eq!(get_fixed_version(">1.2.3-alpha").unwrap(), "1.2"); // ?
-            assert_eq!(get_fixed_version(">1.2.3").unwrap(), "1.2");
-            assert_eq!(get_fixed_version(">1.2.0").unwrap(), "1.2");
-            assert_eq!(get_fixed_version(">1.2").unwrap(), "1.2");
-            assert_eq!(get_fixed_version(">1.0").unwrap(), "1");
-            assert_eq!(get_fixed_version(">1").unwrap(), "1");
+        // #[test]
+        // fn handles_tilde() {
+        //     assert_eq!(detect_fixed_version("~1.2.3-alpha").unwrap(), "1.2.3"); // ?
+        //     assert_eq!(detect_fixed_version("~1.2.3").unwrap(), "1.2.3");
+        //     assert_eq!(detect_fixed_version("~1.2.0").unwrap(), "1.2");
+        //     assert_eq!(detect_fixed_version("~1.2").unwrap(), "1.2");
+        //     assert_eq!(detect_fixed_version("~1.0").unwrap(), "1");
+        //     assert_eq!(detect_fixed_version("~1").unwrap(), "1");
+        // }
 
-            assert_eq!(get_fixed_version(">=1.2.3-alpha").unwrap(), "1.2.3"); // ?
-            assert_eq!(get_fixed_version(">=1.2.3").unwrap(), "1.2.3");
-            assert_eq!(get_fixed_version(">=1.2.0").unwrap(), "1.2");
-            assert_eq!(get_fixed_version(">=1.2").unwrap(), "1.2");
-            assert_eq!(get_fixed_version(">=1.0").unwrap(), "1");
-            assert_eq!(get_fixed_version(">=1").unwrap(), "1");
-        }
+        // #[test]
+        // fn handles_gt() {
+        //     assert_eq!(detect_fixed_version(">1.2.3-alpha").unwrap(), "1.2"); // ?
+        //     assert_eq!(detect_fixed_version(">1.2.3").unwrap(), "1.2");
+        //     assert_eq!(detect_fixed_version(">1.2.0").unwrap(), "1.2");
+        //     assert_eq!(detect_fixed_version(">1.2").unwrap(), "1.2");
+        //     assert_eq!(detect_fixed_version(">1.0").unwrap(), "1");
+        //     assert_eq!(detect_fixed_version(">1").unwrap(), "1");
 
-        #[test]
-        fn handles_lt() {
-            // THIS IS WRONG, best solution? Does this even happen?
-            assert_eq!(get_fixed_version("<1.2.3-alpha").unwrap(), "1.2.3"); // ?
-            assert_eq!(get_fixed_version("<1.2.3").unwrap(), "1.2.3");
-            assert_eq!(get_fixed_version("<1.2.0").unwrap(), "1.2.0");
-            assert_eq!(get_fixed_version("<1.2").unwrap(), "1.2.0");
-            assert_eq!(get_fixed_version("<1.0").unwrap(), "1.0.0");
-            assert_eq!(get_fixed_version("<1").unwrap(), "1.0.0");
+        //     assert_eq!(detect_fixed_version(">=1.2.3-alpha").unwrap(), "1.2.3"); // ?
+        //     assert_eq!(detect_fixed_version(">=1.2.3").unwrap(), "1.2.3");
+        //     assert_eq!(detect_fixed_version(">=1.2.0").unwrap(), "1.2");
+        //     assert_eq!(detect_fixed_version(">=1.2").unwrap(), "1.2");
+        //     assert_eq!(detect_fixed_version(">=1.0").unwrap(), "1");
+        //     assert_eq!(detect_fixed_version(">=1").unwrap(), "1");
+        // }
 
-            assert_eq!(get_fixed_version("<=1.2.3-alpha").unwrap(), "1.2.3"); // ?
-            assert_eq!(get_fixed_version("<=1.2.3").unwrap(), "1.2.3");
-            assert_eq!(get_fixed_version("<=1.2.0").unwrap(), "1.2.0");
-            assert_eq!(get_fixed_version("<=1.2").unwrap(), "1.2.0");
-            assert_eq!(get_fixed_version("<=1.0").unwrap(), "1.0.0");
-            assert_eq!(get_fixed_version("<=1").unwrap(), "1.0.0");
-        }
+        // #[test]
+        // fn handles_lt() {
+        //     // THIS IS WRONG, best solution? Does this even happen?
+        //     assert_eq!(detect_fixed_version("<1.2.3-alpha").unwrap(), "1.2.3"); // ?
+        //     assert_eq!(detect_fixed_version("<1.2.3").unwrap(), "1.2.3");
+        //     assert_eq!(detect_fixed_version("<1.2.0").unwrap(), "1.2.0");
+        //     assert_eq!(detect_fixed_version("<1.2").unwrap(), "1.2.0");
+        //     assert_eq!(detect_fixed_version("<1.0").unwrap(), "1.0.0");
+        //     assert_eq!(detect_fixed_version("<1").unwrap(), "1.0.0");
+
+        //     assert_eq!(detect_fixed_version("<=1.2.3-alpha").unwrap(), "1.2.3"); // ?
+        //     assert_eq!(detect_fixed_version("<=1.2.3").unwrap(), "1.2.3");
+        //     assert_eq!(detect_fixed_version("<=1.2.0").unwrap(), "1.2.0");
+        //     assert_eq!(detect_fixed_version("<=1.2").unwrap(), "1.2.0");
+        //     assert_eq!(detect_fixed_version("<=1.0").unwrap(), "1.0.0");
+        //     assert_eq!(detect_fixed_version("<=1").unwrap(), "1.0.0");
+        // }
     }
 }

--- a/crates/core/src/detector.rs
+++ b/crates/core/src/detector.rs
@@ -145,9 +145,9 @@ pub async fn detect_version_from_environment<'l, T: Tool<'l> + ?Sized>(
     }
 }
 
-pub fn detect_fixed_version(
+pub fn detect_fixed_version<P: AsRef<Path>>(
     version: &str,
-    manifest_path: &Path,
+    manifest_path: P,
 ) -> Result<Option<String>, ProtoError> {
     let version = version.replace(' ', "");
     let version_without_stars = version.replace(".*", "");
@@ -157,7 +157,7 @@ pub fn detect_fixed_version(
         "^" | "~" | ">" | "<" | "*" => {
             let req = semver::VersionReq::parse(&version)
                 .map_err(|e| ProtoError::Semver(version.to_owned(), e.to_string()))?;
-            let manifest = Manifest::load_from(manifest_path)?;
+            let manifest = Manifest::load_from(manifest_path.as_ref())?;
 
             for installed_version in manifest.installed_versions {
                 let version_inst = semver::Version::parse(&installed_version)

--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -47,6 +47,9 @@ pub enum ProtoError {
     )]
     MissingToolForRun(String, String, String),
 
+    #[error("Invalid version {0}: {1}")]
+    Semver(String, String),
+
     #[error("Failed shim: {0}")]
     Shim(String),
 

--- a/crates/node/src/depman/detect.rs
+++ b/crates/node/src/depman/detect.rs
@@ -1,6 +1,6 @@
 use crate::depman::NodeDependencyManager;
 use crate::platform::PackageJson;
-use proto_core::{async_trait, get_fixed_version, Detector, ProtoError};
+use proto_core::{async_trait, detect_fixed_version, Detector, ProtoError, Tool};
 use std::path::Path;
 
 // https://nodejs.org/api/packages.html#packagemanager
@@ -23,7 +23,7 @@ impl Detector<'_> for NodeDependencyManager {
 
             if let Some(engines) = package_json.engines {
                 if let Some(constraint) = engines.get(&self.package_name) {
-                    return Ok(get_fixed_version(constraint));
+                    return detect_fixed_version(constraint, self.get_manifest_path()?);
                 }
             }
         }

--- a/crates/node/src/detect.rs
+++ b/crates/node/src/detect.rs
@@ -1,6 +1,8 @@
 use crate::platform::PackageJson;
 use crate::NodeLanguage;
-use proto_core::{async_trait, get_fixed_version, load_version_file, Detector, ProtoError};
+use proto_core::{
+    async_trait, detect_fixed_version, load_version_file, Detector, ProtoError, Tool,
+};
 use std::path::Path;
 
 #[async_trait]
@@ -25,7 +27,7 @@ impl Detector<'_> for NodeLanguage {
 
             if let Some(engines) = package_json.engines {
                 if let Some(constraint) = engines.get("node") {
-                    return Ok(get_fixed_version(constraint));
+                    return detect_fixed_version(constraint, self.get_manifest_path()?);
                 }
             }
         }

--- a/crates/node/tests/node_depman_test.rs
+++ b/crates/node/tests/node_depman_test.rs
@@ -141,57 +141,6 @@ mod node_depman {
         }
 
         #[tokio::test]
-        async fn matches_if_engines_caret() {
-            let fixture = assert_fs::TempDir::new().unwrap();
-
-            fixture
-                .child("package.json")
-                .write_str(r#"{"engines":{"npm":"^1.2.3"}}"#)
-                .unwrap();
-
-            let tool = create_depman(fixture.path());
-
-            assert_eq!(
-                tool.detect_version_from(fixture.path()).await.unwrap(),
-                Some("1.2.3".into())
-            );
-        }
-
-        #[tokio::test]
-        async fn matches_engines_tilde() {
-            let fixture = assert_fs::TempDir::new().unwrap();
-
-            fixture
-                .child("package.json")
-                .write_str(r#"{"engines":{"npm":"~1.2.3"}}"#)
-                .unwrap();
-
-            let tool = create_depman(fixture.path());
-
-            assert_eq!(
-                tool.detect_version_from(fixture.path()).await.unwrap(),
-                Some("1.2.3".into())
-            );
-        }
-
-        #[tokio::test]
-        async fn matches_engines_range() {
-            let fixture = assert_fs::TempDir::new().unwrap();
-
-            fixture
-                .child("package.json")
-                .write_str(r#"{"engines":{"npm":">=1.2"}}"#)
-                .unwrap();
-
-            let tool = create_depman(fixture.path());
-
-            assert_eq!(
-                tool.detect_version_from(fixture.path()).await.unwrap(),
-                Some("1.2".into())
-            );
-        }
-
-        #[tokio::test]
         async fn defaults_to_latest_version() {
             let fixture = assert_fs::TempDir::new().unwrap();
 
@@ -238,7 +187,7 @@ mod node_depman {
 
             assert_eq!(
                 tool.detect_version_from(fixture.path()).await.unwrap(),
-                Some("1.2.0".into())
+                Some("1.2".into())
             );
         }
 

--- a/crates/node/tests/node_test.rs
+++ b/crates/node/tests/node_test.rs
@@ -94,22 +94,6 @@ mod node {
         }
 
         #[tokio::test]
-        async fn matches_engines_caret() {
-            let fixture = assert_fs::TempDir::new().unwrap();
-            let tool = create_node(fixture.path());
-
-            fixture
-                .child("package.json")
-                .write_str(r#"{"engines":{"node":"^16"}}"#)
-                .unwrap();
-
-            assert_eq!(
-                tool.detect_version_from(fixture.path()).await.unwrap(),
-                Some("16".into())
-            );
-        }
-
-        #[tokio::test]
         async fn matches_engines_star() {
             let fixture = assert_fs::TempDir::new().unwrap();
             let tool = create_node(fixture.path());


### PR DESCRIPTION
When we encounter a `^`, `>=`, or other version requirement, we compare against currently installed versions, instead of trying to resolve some random fixed version.