### PR TITLE
new: Allow tools to define a default version via a trait method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 #### 🚀 Updates
 
 - Added "bundled" as a supported alias for `npm`.
+- Updated `proto local` and `proto global` to support aliases as well as versions.
 - Updated `go` to automatically set `GOBIN` in your shell profile if has not been.
 - Updated `node` to automatically install the `npm` version that comes bundled with Node.js.
 

--- a/crates/bun/src/resolve.rs
+++ b/crates/bun/src/resolve.rs
@@ -15,7 +15,7 @@ impl Resolvable<'_> for BunLanguage {
         }
     }
 
-    async fn load_manifest(&self) -> Result<VersionManifest, ProtoError> {
+    async fn load_version_manifest(&self) -> Result<VersionManifest, ProtoError> {
         let tags = load_git_tags("https://github.com/oven-sh/bun")
             .await?
             .iter()
@@ -49,7 +49,7 @@ impl Resolvable<'_> for BunLanguage {
             initial_version,
         );
 
-        let manifest = self.load_manifest().await?;
+        let manifest = self.load_version_manifest().await?;
 
         let candidate = if initial_version == "latest" {
             manifest.find_version_from_alias(&initial_version)?

--- a/crates/cli/src/commands/global.rs
+++ b/crates/cli/src/commands/global.rs
@@ -6,12 +6,10 @@ use proto_core::{color, Manifest, ProtoError};
 pub async fn global(tool_type: ToolType, version: String) -> Result<(), ProtoError> {
     enable_logging();
 
-    let mut tool = create_tool(&tool_type)?;
-
-    tool.resolve_version(&version).await?;
+    let tool = create_tool(&tool_type)?;
 
     let mut manifest = Manifest::load_for_tool(tool.get_bin_name())?;
-    manifest.default_version = Some(tool.get_resolved_version().to_owned());
+    manifest.default_version = Some(version.clone());
     manifest.save()?;
 
     trace!(
@@ -24,7 +22,7 @@ pub async fn global(tool_type: ToolType, version: String) -> Result<(), ProtoErr
         target: "proto:global",
         "Set the global {} version to {}",
         tool.get_name(),
-        tool.get_resolved_version(),
+        version,
     );
 
     Ok(())

--- a/crates/cli/src/commands/list_remote.rs
+++ b/crates/cli/src/commands/list_remote.rs
@@ -13,7 +13,7 @@ pub async fn list_remote(tool_type: ToolType) -> Result<(), ProtoError> {
 
     debug!(target: "proto:list-remote", "Loading manifest");
 
-    let manifest = tool.load_manifest().await?;
+    let manifest = tool.load_version_manifest().await?;
 
     info!(target: "proto:list-remote", "Available versions:");
 

--- a/crates/cli/src/commands/local.rs
+++ b/crates/cli/src/commands/local.rs
@@ -7,17 +7,14 @@ use std::{env, path::PathBuf};
 pub async fn local(tool_type: ToolType, version: String) -> Result<(), ProtoError> {
     enable_logging();
 
-    let mut tool = create_tool(&tool_type)?;
-
-    tool.resolve_version(&version).await?;
+    let tool = create_tool(&tool_type)?;
 
     let local_path = env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let mut config = Config::load_from(&local_path)?;
 
-    config.tools.insert(
-        tool.get_bin_name().to_owned(),
-        tool.get_resolved_version().to_owned(),
-    );
+    config
+        .tools
+        .insert(tool.get_bin_name().to_owned(), version.clone());
 
     config.save()?;
 
@@ -31,7 +28,7 @@ pub async fn local(tool_type: ToolType, version: String) -> Result<(), ProtoErro
         target: "proto:local",
         "Set the local {} version to {}",
         tool.get_name(),
-        tool.get_resolved_version(),
+        version,
     );
 
     Ok(())

--- a/crates/cli/tests/global_test.rs
+++ b/crates/cli/tests/global_test.rs
@@ -25,3 +25,27 @@ fn updates_manifest_file() {
 }"#
     );
 }
+
+#[test]
+fn can_set_aliases() {
+    let temp = create_temp_dir();
+    let manifest_file = temp.join("tools/npm/manifest.json");
+
+    assert!(!manifest_file.exists());
+
+    let mut cmd = create_proto_command(temp.path());
+    cmd.arg("global")
+        .arg("npm")
+        .arg("bundled")
+        .assert()
+        .success();
+
+    assert!(manifest_file.exists());
+    assert_eq!(
+        std::fs::read_to_string(manifest_file).unwrap(),
+        r#"{
+  "default_version": "bundled",
+  "installed_versions": []
+}"#
+    );
+}

--- a/crates/cli/tests/install_lang_test.rs
+++ b/crates/cli/tests/install_lang_test.rs
@@ -15,14 +15,12 @@ mod go {
 
         let mut cmd = create_proto_command(temp.path());
 
-        let assert = cmd
-            .env("TEST_PROFILE", &profile)
+        cmd.env("TEST_PROFILE", &profile)
             .arg("install")
             .arg("go")
             .arg("1.20.0")
-            .assert();
-
-        debug_assert(&assert);
+            .assert()
+            .success();
 
         let output = fs::read_to_string(profile).unwrap();
 
@@ -37,16 +35,14 @@ mod go {
 
         let mut cmd = create_proto_command(temp.path());
 
-        let assert = cmd
-            .env("TEST_PROFILE", &profile)
+        cmd.env("TEST_PROFILE", &profile)
             .arg("install")
             .arg("go")
             .arg("1.20.0")
             .arg("--")
             .arg("--no-gobin")
-            .assert();
-
-        debug_assert(&assert);
+            .assert()
+            .success();
 
         assert!(!profile.exists());
     }
@@ -69,6 +65,16 @@ mod node {
 
         assert!(temp.join("tools/node/19.0.0").exists());
         assert!(temp.join("tools/npm/8.19.2").exists());
+
+        assert_eq!(
+            fs::read_to_string(temp.join("tools/npm/manifest.json")).unwrap(),
+            r#"{
+  "default_version": "bundled",
+  "installed_versions": [
+    "8.19.2"
+  ]
+}"#
+        );
     }
 
     #[test]

--- a/crates/cli/tests/local_test.rs
+++ b/crates/cli/tests/local_test.rs
@@ -74,3 +74,24 @@ npm = "9.0.0"
 "#
     )
 }
+
+#[test]
+fn can_set_aliases() {
+    let temp = create_temp_dir();
+    let version_file = temp.join(".prototools");
+
+    assert!(!version_file.exists());
+
+    let mut cmd = create_proto_command(temp.path());
+    cmd.arg("local")
+        .arg("npm")
+        .arg("bundled")
+        .assert()
+        .success();
+
+    assert!(version_file.exists());
+    assert_eq!(
+        fs::read_to_string(version_file).unwrap(),
+        "npm = \"bundled\"\n"
+    )
+}

--- a/crates/cli/tests/run_test.rs
+++ b/crates/cli/tests/run_test.rs
@@ -12,7 +12,7 @@ fn errors_if_not_installed() {
     let assert = cmd.arg("run").arg("node").arg("19.0.0").assert();
 
     assert.stderr(predicate::str::contains(
-        "This project requires Node.js v19.0.0, but this version has not been installed. Install it with `proto install node 19.0.0`!",
+        "This project requires Node.js 19.0.0, but this version has not been installed. Install it with `proto install node 19.0.0`!",
     ));
 }
 

--- a/crates/cli/tests/run_test.rs
+++ b/crates/cli/tests/run_test.rs
@@ -12,7 +12,7 @@ fn errors_if_not_installed() {
     let assert = cmd.arg("run").arg("node").arg("19.0.0").assert();
 
     assert.stderr(predicate::str::contains(
-        "Attempted to run Node.js v19.0.0, but this version has not been installed. Install it with `proto install node 19.0.0`!",
+        "This project requires Node.js v19.0.0, but this version has not been installed. Install it with `proto install node 19.0.0`!",
     ));
 }
 

--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -43,7 +43,7 @@ pub enum ProtoError {
     MissingTool(String),
 
     #[error(
-        "Attempted to run {0} v{1}, but this version has not been installed. Install it with `{2}`!"
+        "This project requires {0} {1}, but this version has not been installed. Install it with `{2}`!"
     )]
     MissingToolForRun(String, String, String),
 

--- a/crates/core/src/manifest.rs
+++ b/crates/core/src/manifest.rs
@@ -20,11 +20,15 @@ pub struct Manifest {
 }
 
 impl Manifest {
-    pub fn insert_version(path: PathBuf, version: &str) -> Result<(), ProtoError> {
+    pub fn insert_version(
+        path: PathBuf,
+        version: &str,
+        default_version: Option<&str>,
+    ) -> Result<(), ProtoError> {
         let mut manifest = Manifest::load(path)?;
 
         if manifest.default_version.is_none() {
-            manifest.default_version = Some(version.to_owned());
+            manifest.default_version = Some(default_version.unwrap_or(version).to_owned());
         }
 
         manifest.installed_versions.insert(version.to_owned());

--- a/crates/core/src/resolver.rs
+++ b/crates/core/src/resolver.rs
@@ -92,11 +92,16 @@ impl VersionManifest {
 
 #[async_trait::async_trait]
 pub trait Resolvable<'tool>: Send + Sync {
+    /// Return the version to be used as the global default.
+    fn get_default_version(&self) -> Option<&str> {
+        None
+    }
+
     /// Return the resolved version.
     fn get_resolved_version(&self) -> &str;
 
     /// Load the upstream version and release manifest.
-    async fn load_manifest(&self) -> Result<VersionManifest, ProtoError>;
+    async fn load_version_manifest(&self) -> Result<VersionManifest, ProtoError>;
 
     /// Given an initial version, resolve it to a fully qualifed and semantic version
     /// according to the tool's ecosystem.

--- a/crates/core/src/tool.rs
+++ b/crates/core/src/tool.rs
@@ -64,7 +64,11 @@ pub trait Tool<'tool>:
         self.create_shims().await?;
 
         // Update the manifest
-        Manifest::insert_version(self.get_manifest_path()?, self.get_resolved_version())?;
+        Manifest::insert_version(
+            self.get_manifest_path()?,
+            self.get_resolved_version(),
+            self.get_default_version(),
+        )?;
 
         self.after_setup().await?;
 

--- a/crates/deno/src/resolve.rs
+++ b/crates/deno/src/resolve.rs
@@ -15,7 +15,7 @@ impl Resolvable<'_> for DenoLanguage {
         }
     }
 
-    async fn load_manifest(&self) -> Result<VersionManifest, ProtoError> {
+    async fn load_version_manifest(&self) -> Result<VersionManifest, ProtoError> {
         let tags = load_git_tags("https://github.com/denoland/deno")
             .await?
             .iter()
@@ -49,7 +49,7 @@ impl Resolvable<'_> for DenoLanguage {
             initial_version,
         );
 
-        let manifest = self.load_manifest().await?;
+        let manifest = self.load_version_manifest().await?;
 
         let candidate = if initial_version == "latest" {
             manifest.find_version_from_alias(&initial_version)?

--- a/crates/go/src/resolve.rs
+++ b/crates/go/src/resolve.rs
@@ -25,7 +25,7 @@ impl Resolvable<'_> for GoLanguage {
     }
 
     // https://go.dev/dl/?mode=json&include=all
-    async fn load_manifest(&self) -> Result<VersionManifest, ProtoError> {
+    async fn load_version_manifest(&self) -> Result<VersionManifest, ProtoError> {
         let tags = load_git_tags("https://github.com/golang/go")
             .await?
             .iter()
@@ -66,7 +66,7 @@ impl Resolvable<'_> for GoLanguage {
             initial_version,
         );
 
-        let manifest = self.load_manifest().await?;
+        let manifest = self.load_version_manifest().await?;
 
         let candidate = if initial_version.contains("rc") || initial_version.contains("beta") {
             manifest.get_version(&initial_version)?

--- a/crates/node/src/depman/resolve.rs
+++ b/crates/node/src/depman/resolve.rs
@@ -44,6 +44,14 @@ struct NDMManifest {
 
 #[async_trait]
 impl Resolvable<'_> for NodeDependencyManager {
+    fn get_default_version(&self) -> Option<&str> {
+        if matches!(self.type_of, NodeDependencyManagerType::Npm) {
+            Some("bundled")
+        } else {
+            None
+        }
+    }
+
     fn get_resolved_version(&self) -> &str {
         match self.version.as_ref() {
             Some(version) => version,

--- a/crates/node/src/depman/resolve.rs
+++ b/crates/node/src/depman/resolve.rs
@@ -51,7 +51,7 @@ impl Resolvable<'_> for NodeDependencyManager {
         }
     }
 
-    async fn load_manifest(&self) -> Result<VersionManifest, ProtoError> {
+    async fn load_version_manifest(&self) -> Result<VersionManifest, ProtoError> {
         let mut versions = BTreeMap::new();
         let response: NDMManifest =
             load_versions_manifest(format!("https://registry.npmjs.org/{}/", self.package_name))
@@ -147,7 +147,7 @@ impl Resolvable<'_> for NodeDependencyManager {
             initial_version,
         );
 
-        let manifest = self.load_manifest().await?;
+        let manifest = self.load_version_manifest().await?;
         let version = parse_version(manifest.find_version(&initial_version)?)?.to_string();
 
         debug!(target: self.get_log_target(), "Resolved to {}", version);

--- a/crates/node/src/resolve.rs
+++ b/crates/node/src/resolve.rs
@@ -29,7 +29,7 @@ impl Resolvable<'_> for NodeLanguage {
         }
     }
 
-    async fn load_manifest(&self) -> Result<VersionManifest, ProtoError> {
+    async fn load_version_manifest(&self) -> Result<VersionManifest, ProtoError> {
         let mut aliases = BTreeMap::new();
         let mut versions = BTreeMap::new();
         let response: Vec<NodeDistVersion> =
@@ -89,7 +89,7 @@ impl Resolvable<'_> for NodeLanguage {
             initial_version,
         );
 
-        let manifest = self.load_manifest().await?;
+        let manifest = self.load_version_manifest().await?;
         let candidate;
 
         // Latest version is always at the top


### PR DESCRIPTION
With this, npm will always default to "bundled" unless explicitly overridden by a user.