### PR TITLE
internal: Rename `Config` to `ToolsConfig`.

### DIFF
--- a/crates/cli/src/commands/install_all.rs
+++ b/crates/cli/src/commands/install_all.rs
@@ -1,7 +1,7 @@
 use crate::commands::install::install;
 use crate::helpers::enable_logging;
 use crate::tools::ToolType;
-use proto_core::{Config, ProtoError, CONFIG_NAME};
+use proto_core::{ProtoError, ToolsConfig, CONFIG_NAME};
 use std::{env, str::FromStr};
 
 pub async fn install_all() -> Result<(), ProtoError> {
@@ -9,7 +9,7 @@ pub async fn install_all() -> Result<(), ProtoError> {
 
     let current_dir = env::current_dir().expect("Invalid working directory!");
 
-    let Some(config) = Config::load_upwards(&current_dir)? else {
+    let Some(config) = ToolsConfig::load_upwards(&current_dir)? else {
         return Err(ProtoError::MissingConfig(CONFIG_NAME.to_owned()));
     };
 

--- a/crates/cli/src/commands/local.rs
+++ b/crates/cli/src/commands/local.rs
@@ -1,7 +1,7 @@
 use crate::helpers::enable_logging;
 use crate::tools::{create_tool, ToolType};
 use log::{info, trace};
-use proto_core::{color, Config, ProtoError};
+use proto_core::{color, ProtoError, ToolsConfig};
 use std::{env, path::PathBuf};
 
 pub async fn local(tool_type: ToolType, version: String) -> Result<(), ProtoError> {
@@ -10,7 +10,7 @@ pub async fn local(tool_type: ToolType, version: String) -> Result<(), ProtoErro
     let tool = create_tool(&tool_type)?;
 
     let local_path = env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    let mut config = Config::load_from(&local_path)?;
+    let mut config = ToolsConfig::load_from(&local_path)?;
 
     config
         .tools

--- a/crates/cli/src/shell.rs
+++ b/crates/cli/src/shell.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 pub fn detect_shell(shell: Option<Shell>) -> Shell {
-    shell.or_else(Shell::from_env).unwrap_or_else(|| {
+    shell.or_else(Shell::from_env).unwrap_or({
         if cfg!(windows) {
             Shell::PowerShell
         } else {

--- a/crates/core/src/detector.rs
+++ b/crates/core/src/detector.rs
@@ -1,9 +1,9 @@
 #![allow(clippy::borrowed_box)]
 
-use crate::config::{Config, CONFIG_NAME};
 use crate::errors::ProtoError;
 use crate::manifest::{Manifest, MANIFEST_NAME};
 use crate::tool::Tool;
+use crate::tools_config::{ToolsConfig, CONFIG_NAME};
 use crate::{color, is_version_alias};
 use lenient_semver::Version;
 use log::{debug, trace};
@@ -79,7 +79,7 @@ pub async fn detect_version_from_environment<'l, T: Tool<'l> + ?Sized>(
                 CONFIG_NAME
             );
 
-            let config = Config::load_from(dir)?;
+            let config = ToolsConfig::load_from(dir)?;
 
             if let Some(local_version) = config.tools.get(tool.get_bin_name()) {
                 debug!(

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,5 +1,4 @@
 pub mod color;
-mod config;
 mod describer;
 mod detector;
 mod downloader;
@@ -11,10 +10,10 @@ mod manifest;
 mod resolver;
 mod shimmer;
 mod tool;
+mod tools_config;
 mod verifier;
 
 pub use async_trait::async_trait;
-pub use config::*;
 pub use describer::*;
 pub use detector::*;
 pub use downloader::*;
@@ -27,6 +26,7 @@ pub use manifest::*;
 pub use resolver::*;
 pub use shimmer::*;
 pub use tool::*;
+pub use tools_config::*;
 pub use verifier::*;
 
 use std::path::{Path, PathBuf};

--- a/crates/core/src/tools_config.rs
+++ b/crates/core/src/tools_config.rs
@@ -9,12 +9,12 @@ use toml::{map::Map, Value};
 pub const CONFIG_NAME: &str = ".prototools";
 
 #[derive(Debug, Default)]
-pub struct Config {
+pub struct ToolsConfig {
     pub tools: FxHashMap<String, String>,
     pub path: PathBuf,
 }
 
-impl Config {
+impl ToolsConfig {
     pub fn load_upwards<P>(dir: P) -> Result<Option<Self>, ProtoError>
     where
         P: AsRef<Path>,
@@ -40,9 +40,9 @@ impl Config {
         let path = path.as_ref();
 
         if !path.exists() {
-            return Ok(Config {
+            return Ok(ToolsConfig {
                 path: path.to_owned(),
-                ..Config::default()
+                ..ToolsConfig::default()
             });
         }
 
@@ -73,7 +73,7 @@ impl Config {
             ));
         }
 
-        Ok(Config {
+        Ok(ToolsConfig {
             tools,
             path: path.to_owned(),
         })


### PR DESCRIPTION
We'll be adding another config type, so renaming to not be generic.