### PR TITLE
new: Use Windows Registry when setting `PATH`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+#### 🐞 Fixes
+
+- Updated `proto setup` on Windows to use the Windows registry when updating `PATH`.
+
 ## 0.3.2
 
 #### 🐞 Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1233,6 +1233,7 @@ dependencies = [
  "proto_node",
  "rustc-hash",
  "tokio",
+ "winreg 0.11.0",
 ]
 
 [[package]]
@@ -1394,7 +1395,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
- "winreg",
+ "winreg 0.10.1",
 ]
 
 [[package]]
@@ -2174,6 +2175,16 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winreg"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a1a57ff50e9b408431e8f97d5456f2807f8eb2a2cd79b06068fc87f8ecf189"
+dependencies = [
+ "cfg-if",
  "winapi",
 ]
 

--- a/crates/bun/tests/bun_test.rs
+++ b/crates/bun/tests/bun_test.rs
@@ -1,21 +1,20 @@
-use proto_bun::BunLanguage;
-use proto_core::{
-    Downloadable, Executable, Installable, Proto, Resolvable, Tool, Verifiable, Version,
-};
-use std::fs;
-
-fn create_tool() -> (BunLanguage, assert_fs::TempDir) {
-    let fixture = assert_fs::TempDir::new().unwrap();
-    let mut tool = BunLanguage::new(Proto::from(fixture.path()));
-    tool.version = Some(String::from("0.5.7"));
-
-    (tool, fixture)
-}
-
 // Bun doesn't support windows yet!
 #[cfg(not(windows))]
 mod bun {
     use super::*;
+    use proto_bun::BunLanguage;
+    use proto_core::{
+        Downloadable, Executable, Installable, Proto, Resolvable, Tool, Verifiable, Version,
+    };
+    use std::fs;
+
+    fn create_tool() -> (BunLanguage, assert_fs::TempDir) {
+        let fixture = assert_fs::TempDir::new().unwrap();
+        let mut tool = BunLanguage::new(Proto::from(fixture.path()));
+        tool.version = Some(String::from("0.5.7"));
+
+        (tool, fixture)
+    }
 
     #[tokio::test]
     async fn downloads_verifies_installs_tool() {

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -33,6 +33,7 @@ human-sort = "0.2.2"
 log = { workspace = true }
 rustc-hash = { workspace = true }
 tokio = { workspace = true }
+winreg = "0.11.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.8"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -33,6 +33,8 @@ human-sort = "0.2.2"
 log = { workspace = true }
 rustc-hash = { workspace = true }
 tokio = { workspace = true }
+
+[target.'cfg(windows)'.dependencies]
 winreg = "0.11.0"
 
 [dev-dependencies]

--- a/crates/cli/src/commands/setup.rs
+++ b/crates/cli/src/commands/setup.rs
@@ -1,7 +1,7 @@
 use crate::helpers::enable_logging;
-use crate::shell::{detect_shell};
+use crate::shell::detect_shell;
 use clap_complete::Shell;
-use log::{debug};
+use log::debug;
 use proto_core::{color, get_root, ProtoError};
 use std::env;
 use std::path::PathBuf;

--- a/crates/cli/tests/install_lang_test.rs
+++ b/crates/cli/tests/install_lang_test.rs
@@ -4,10 +4,10 @@ use predicates::prelude::*;
 use std::fs;
 use utils::*;
 
+#[cfg(not(windows))]
 mod go {
     use super::*;
 
-    #[cfg(not(windows))]
     #[test]
     fn sets_gobin_to_shell() {
         let temp = create_temp_dir();
@@ -27,7 +27,6 @@ mod go {
         assert!(predicate::str::contains("GOBIN=\"$HOME/go/bin\"").eval(&output));
     }
 
-    #[cfg(not(windows))]
     #[test]
     fn doesnt_set_gobin() {
         let temp = create_temp_dir();


### PR DESCRIPTION
This is more accurate as it doesn't pull in all system level paths, since `setx` is user level.