### PR TITLE
new: Add a global user config at `~/.proto/config.toml`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+#### 🚀 Updates
+
+- Added a global user config at `~/.proto/config.toml`.
+  - Added a new setting `auto-install`, that will automatically install a missing tool when `proto run` is executed.
+
 #### 🐞 Fixes
 
 - Updated `proto setup` on Windows to use the Windows registry when updating `PATH`.

--- a/crates/bun/tests/bun_test.rs
+++ b/crates/bun/tests/bun_test.rs
@@ -1,7 +1,7 @@
 // Bun doesn't support windows yet!
 #[cfg(not(windows))]
 mod bun {
-    use super::*;
+    // use super::*;
     use proto_bun::BunLanguage;
     use proto_core::{
         Downloadable, Executable, Installable, Proto, Resolvable, Tool, Verifiable, Version,

--- a/crates/cli/src/commands/install_all.rs
+++ b/crates/cli/src/commands/install_all.rs
@@ -1,7 +1,7 @@
 use crate::commands::install::install;
 use crate::helpers::enable_logging;
 use crate::tools::ToolType;
-use proto_core::{ProtoError, ToolsConfig, CONFIG_NAME};
+use proto_core::{ProtoError, ToolsConfig, TOOLS_CONFIG_NAME};
 use std::{env, str::FromStr};
 
 pub async fn install_all() -> Result<(), ProtoError> {
@@ -10,7 +10,7 @@ pub async fn install_all() -> Result<(), ProtoError> {
     let current_dir = env::current_dir().expect("Invalid working directory!");
 
     let Some(config) = ToolsConfig::load_upwards(&current_dir)? else {
-        return Err(ProtoError::MissingConfig(CONFIG_NAME.to_owned()));
+        return Err(ProtoError::MissingConfig(TOOLS_CONFIG_NAME.to_owned()));
     };
 
     let mut futures = vec![];

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -1,4 +1,7 @@
+use crate::commands::install::install;
 use crate::tools::{create_tool, ToolType};
+use log::debug;
+use proto::UserConfig;
 use proto_core::{detect_version_from_environment, ProtoError};
 use std::process::exit;
 use tokio::process::Command;
@@ -12,11 +15,32 @@ pub async fn run(
     let version = detect_version_from_environment(&tool, forced_version).await?;
 
     if !tool.is_setup(&version).await? {
-        return Err(ProtoError::MissingToolForRun(
-            tool.get_name(),
-            version.to_owned(),
-            format!("proto install {} {}", tool.get_bin_name(), version),
-        ));
+        let config = UserConfig::load()?;
+
+        if !config.auto_install {
+            return Err(ProtoError::MissingToolForRun(
+                tool.get_name(),
+                version.to_owned(),
+                format!("proto install {} {}", tool.get_bin_name(), version),
+            ));
+        }
+
+        // Install the tool
+        debug!(
+            target: tool.get_log_target(),
+            "Auto-install setting is configured, attempting to install"
+        );
+
+        install(
+            tool_type,
+            Some(tool.get_resolved_version().to_owned()),
+            false,
+            vec![],
+        )
+        .await?;
+
+        // Find the new binaries
+        tool.find_bin_path().await?;
     }
 
     let status = Command::new(tool.get_bin_path()?)

--- a/crates/cli/src/commands/setup.rs
+++ b/crates/cli/src/commands/setup.rs
@@ -2,10 +2,9 @@ use crate::helpers::enable_logging;
 use crate::shell::detect_shell;
 use clap_complete::Shell;
 use log::debug;
-use proto_core::{color, get_root, ProtoError};
+use proto_core::{get_root, ProtoError};
 use std::env;
 use std::path::PathBuf;
-use std::process::Command;
 
 pub async fn setup(shell: Option<Shell>, print_profile: bool) -> Result<(), ProtoError> {
     let shell = detect_shell(shell);
@@ -58,6 +57,7 @@ fn do_setup(shell: Shell, _bin_dir: PathBuf, print_profile: bool) -> Result<(), 
 #[cfg(windows)]
 fn do_setup(shell: Shell, bin_dir: PathBuf, print_profile: bool) -> Result<(), ProtoError> {
     use log::{trace, warn};
+    use std::process::Command;
     use winreg::enums::HKEY_CURRENT_USER;
     use winreg::RegKey;
 
@@ -79,7 +79,11 @@ fn do_setup(shell: Shell, bin_dir: PathBuf, print_profile: bool) -> Result<(), P
         return Ok(());
     }
 
-    debug!(target: "proto:setup", "Updating PATH with {} command", color::shell("setx"));
+    debug!(
+        target: "proto:setup",
+        "Updating PATH with {} command",
+        proto_core::color::shell("setx"),
+    );
 
     let mut paths = vec![bin_dir];
     paths.extend(cu_paths);

--- a/crates/cli/tests/run_test.rs
+++ b/crates/cli/tests/run_test.rs
@@ -139,3 +139,21 @@ fn runs_a_tool_using_version_detection() {
 
     fs::remove_file(temp.path().join("tools/node/manifest.json")).unwrap();
 }
+
+#[test]
+fn auto_installs_if_missing() {
+    let temp = create_temp_dir();
+
+    std::fs::write(temp.path().join("config.toml"), "auto-install = true").unwrap();
+
+    let mut cmd = create_proto_command(temp.path());
+    let assert = cmd
+        .arg("run")
+        .arg("node")
+        .arg("19.0.0")
+        .arg("--")
+        .arg("--version")
+        .assert();
+
+    assert.stdout(predicate::str::contains("19.0.0"));
+}

--- a/crates/core/src/detector.rs
+++ b/crates/core/src/detector.rs
@@ -3,7 +3,7 @@
 use crate::errors::ProtoError;
 use crate::manifest::{Manifest, MANIFEST_NAME};
 use crate::tool::Tool;
-use crate::tools_config::{ToolsConfig, CONFIG_NAME};
+use crate::tools_config::{ToolsConfig, TOOLS_CONFIG_NAME};
 use crate::{color, is_version_alias};
 use lenient_semver::Version;
 use log::{debug, trace};
@@ -76,7 +76,7 @@ pub async fn detect_version_from_environment<'l, T: Tool<'l> + ?Sized>(
             trace!(
                 target: "proto:detector",
                 "Checking proto configuration file ({})",
-                CONFIG_NAME
+                TOOLS_CONFIG_NAME
             );
 
             let config = ToolsConfig::load_from(dir)?;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -11,6 +11,7 @@ mod resolver;
 mod shimmer;
 mod tool;
 mod tools_config;
+mod user_config;
 mod verifier;
 
 pub use async_trait::async_trait;
@@ -27,6 +28,7 @@ pub use resolver::*;
 pub use shimmer::*;
 pub use tool::*;
 pub use tools_config::*;
+pub use user_config::*;
 pub use verifier::*;
 
 use std::path::{Path, PathBuf};

--- a/crates/core/src/tools_config.rs
+++ b/crates/core/src/tools_config.rs
@@ -6,7 +6,7 @@ use std::{
 };
 use toml::{map::Map, Value};
 
-pub const CONFIG_NAME: &str = ".prototools";
+pub const TOOLS_CONFIG_NAME: &str = ".prototools";
 
 #[derive(Debug, Default)]
 pub struct ToolsConfig {
@@ -20,7 +20,7 @@ impl ToolsConfig {
         P: AsRef<Path>,
     {
         let dir = dir.as_ref();
-        let findable = dir.join(CONFIG_NAME);
+        let findable = dir.join(TOOLS_CONFIG_NAME);
 
         if findable.exists() {
             return Ok(Some(Self::load(&findable)?));
@@ -33,7 +33,7 @@ impl ToolsConfig {
     }
 
     pub fn load_from<P: AsRef<Path>>(dir: P) -> Result<Self, ProtoError> {
-        Self::load(dir.as_ref().join(CONFIG_NAME))
+        Self::load(dir.as_ref().join(TOOLS_CONFIG_NAME))
     }
 
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, ProtoError> {

--- a/crates/core/src/user_config.rs
+++ b/crates/core/src/user_config.rs
@@ -5,7 +5,7 @@ use std::fs;
 pub const USER_CONFIG_NAME: &str = "config.toml";
 
 #[derive(Debug, Default, Deserialize)]
-#[serde(default)]
+#[serde(default, rename_all = "kebab-case")]
 pub struct UserConfig {
     pub auto_install: bool,
 }

--- a/crates/core/src/user_config.rs
+++ b/crates/core/src/user_config.rs
@@ -2,7 +2,7 @@ use crate::{errors::ProtoError, get_root};
 use serde::Deserialize;
 use std::fs;
 
-pub const CONFIG_NAME: &str = "config.toml";
+pub const USER_CONFIG_NAME: &str = "config.toml";
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(default)]
@@ -12,7 +12,7 @@ pub struct UserConfig {
 
 impl UserConfig {
     pub fn load() -> Result<Self, ProtoError> {
-        let path = get_root()?.join(CONFIG_NAME);
+        let path = get_root()?.join(USER_CONFIG_NAME);
 
         if !path.exists() {
             return Ok(UserConfig::default());

--- a/crates/core/src/user_config.rs
+++ b/crates/core/src/user_config.rs
@@ -1,0 +1,29 @@
+use crate::{errors::ProtoError, get_root};
+use serde::Deserialize;
+use std::fs;
+
+pub const CONFIG_NAME: &str = "config.toml";
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct UserConfig {
+    pub auto_install: bool,
+}
+
+impl UserConfig {
+    pub fn load() -> Result<Self, ProtoError> {
+        let path = get_root()?.join(CONFIG_NAME);
+
+        if !path.exists() {
+            return Ok(UserConfig::default());
+        }
+
+        let contents = fs::read_to_string(&path)
+            .map_err(|e| ProtoError::Fs(path.to_path_buf(), e.to_string()))?;
+
+        let config: UserConfig = toml::from_str(&contents)
+            .map_err(|e| ProtoError::Toml(path.to_path_buf(), e.to_string()))?;
+
+        Ok(config)
+    }
+}


### PR DESCRIPTION
This will support settings that apply globally to all projects, with the first setting being `auto-install`.