### PR TITLE
internal: Add an `uninstall` method to installer trait.

### DIFF
--- a/crates/cli/src/commands/install.rs
+++ b/crates/cli/src/commands/install.rs
@@ -47,6 +47,7 @@ pub async fn install(
     ));
 
     tool.setup(&version).await?;
+    tool.cleanup().await?;
 
     if pin_version {
         let mut manifest = Manifest::load_for_tool(tool.get_bin_name())?;

--- a/crates/core/src/installer.rs
+++ b/crates/core/src/installer.rs
@@ -48,6 +48,28 @@ pub trait Installable<'tool>: Send + Sync + Describable<'tool> {
 
         Ok(true)
     }
+
+    /// Uninstall the tool by deleting the install directory.
+    async fn uninstall(&self, install_dir: &Path) -> Result<bool, ProtoError> {
+        if !install_dir.exists() {
+            debug!(target: self.get_log_target(), "Tool has not been installed, aborting");
+
+            return Ok(false);
+        }
+
+        debug!(
+            target: self.get_log_target(),
+            "Deleting install directory {}",
+            color::path(&install_dir)
+        );
+
+        fs::remove_dir_all(&install_dir)
+            .map_err(|e| ProtoError::Fs(install_dir.to_path_buf(), e.to_string()))?;
+
+        debug!(target: self.get_log_target(), "Successfully uninstalled tool");
+
+        Ok(true)
+    }
 }
 
 pub fn unpack<I: AsRef<Path>, O: AsRef<Path>>(

--- a/crates/core/src/installer.rs
+++ b/crates/core/src/installer.rs
@@ -60,10 +60,10 @@ pub trait Installable<'tool>: Send + Sync + Describable<'tool> {
         debug!(
             target: self.get_log_target(),
             "Deleting install directory {}",
-            color::path(&install_dir)
+            color::path(install_dir)
         );
 
-        fs::remove_dir_all(&install_dir)
+        fs::remove_dir_all(install_dir)
             .map_err(|e| ProtoError::Fs(install_dir.to_path_buf(), e.to_string()))?;
 
         debug!(target: self.get_log_target(), "Successfully uninstalled tool");

--- a/crates/core/src/tool.rs
+++ b/crates/core/src/tool.rs
@@ -152,21 +152,11 @@ pub trait Tool<'tool>:
 
         let install_dir = self.get_install_dir()?;
 
-        if install_dir.exists() {
-            debug!(
-                target: self.get_log_target(),
-                "Deleting install directory {}",
-                color::path(&install_dir)
-            );
-
-            fs::remove_dir_all(&install_dir)
-                .map_err(|e| ProtoError::Fs(install_dir, e.to_string()))?;
-
-            // Update the manifest
+        if self.uninstall(&install_dir).await? {
             Manifest::remove_version(self.get_manifest_path()?, self.get_resolved_version())?;
-        }
 
-        self.after_teardown().await?;
+            self.after_teardown().await?;
+        }
 
         Ok(())
     }

--- a/crates/core/src/tool.rs
+++ b/crates/core/src/tool.rs
@@ -56,23 +56,26 @@ pub trait Tool<'tool>:
 
         // Install the tool
         let install_dir = self.get_install_dir()?;
-        let installed = self.install(&install_dir, &download_path).await?;
 
-        self.find_bin_path().await?;
+        if self.install(&install_dir, &download_path).await? {
+            self.find_bin_path().await?;
 
-        // Create shims after paths are found
-        self.create_shims().await?;
+            // Create shims after paths are found
+            self.create_shims().await?;
 
-        // Update the manifest
-        Manifest::insert_version(
-            self.get_manifest_path()?,
-            self.get_resolved_version(),
-            self.get_default_version(),
-        )?;
+            // Update the manifest
+            Manifest::insert_version(
+                self.get_manifest_path()?,
+                self.get_resolved_version(),
+                self.get_default_version(),
+            )?;
 
-        self.after_setup().await?;
+            self.after_setup().await?;
 
-        Ok(installed)
+            return Ok(true);
+        }
+
+        Ok(false)
     }
 
     async fn is_setup(&mut self, initial_version: &str) -> Result<bool, ProtoError> {
@@ -145,7 +148,7 @@ pub trait Tool<'tool>:
         Ok(())
     }
 
-    async fn teardown(&mut self) -> Result<(), ProtoError> {
+    async fn teardown(&mut self) -> Result<bool, ProtoError> {
         self.before_teardown().await?;
 
         self.cleanup().await?;
@@ -156,9 +159,11 @@ pub trait Tool<'tool>:
             Manifest::remove_version(self.get_manifest_path()?, self.get_resolved_version())?;
 
             self.after_teardown().await?;
+
+            return Ok(true);
         }
 
-        Ok(())
+        Ok(false)
     }
 
     async fn after_teardown(&mut self) -> Result<(), ProtoError> {

--- a/crates/rust/src/install.rs
+++ b/crates/rust/src/install.rs
@@ -5,12 +5,49 @@ use std::env::consts;
 use std::path::{Path, PathBuf};
 use tokio::process::Command;
 
+fn handle_error(e: std::io::Error) -> ProtoError {
+    ProtoError::Message(format!(
+        "Failed to run {}: {}",
+        color::shell("rustup"),
+        color::muted_light(e.to_string())
+    ))
+}
+
 fn is_musl() -> bool {
     let Ok(output) = std::process::Command::new("ldd").arg("--version").output() else {
         return false;
     };
 
     String::from_utf8_lossy(&output.stdout).contains("musl")
+}
+
+async fn is_installed_in_rustup(install_dir: &Path) -> Result<bool, ProtoError> {
+    let output = Command::new("rustup")
+        .args(["toolchain", "list"])
+        .output()
+        .await
+        .map_err(handle_error)?;
+
+    let installed_list = String::from_utf8_lossy(&output.stdout);
+    let install_target = install_dir
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+
+    Ok(installed_list.contains(&install_target))
+}
+
+async fn run_rustup_toolchain(command: &str, version: &str) -> Result<bool, ProtoError> {
+    let status = Command::new("rustup")
+        .args(["toolchain", command, version])
+        .spawn()
+        .map_err(handle_error)?
+        .wait()
+        .await
+        .map_err(handle_error)?;
+
+    Ok(status.success())
 }
 
 #[async_trait]
@@ -38,43 +75,30 @@ impl Installable<'_> for RustLanguage {
     }
 
     async fn install(&self, install_dir: &Path, _download_path: &Path) -> Result<bool, ProtoError> {
-        let handle_error = |e: std::io::Error| {
-            ProtoError::Message(format!(
-                "Failed to run {}: {}",
-                color::shell("rustup"),
-                color::muted_light(e.to_string())
-            ))
-        };
-
-        let output = Command::new("rustup")
-            .args(["toolchain", "list"])
-            .output()
-            .await
-            .map_err(handle_error)?;
-
-        let installed_list = String::from_utf8_lossy(&output.stdout);
-        let install_target = install_dir
-            .file_name()
-            .unwrap()
-            .to_string_lossy()
-            .to_string();
-
-        if installed_list.contains(&install_target) {
+        if is_installed_in_rustup(install_dir).await? {
             debug!(target: self.get_log_target(), "Toolchain already installed, continuing");
 
             return Ok(false);
         }
 
-        let mut cmd = Command::new("rustup");
-        cmd.args(["toolchain", "install", self.get_resolved_version()]);
+        let success = run_rustup_toolchain("install", self.get_resolved_version()).await?;
 
-        let status = cmd
-            .spawn()
-            .map_err(handle_error)?
-            .wait()
-            .await
-            .map_err(handle_error)?;
+        debug!(target: self.get_log_target(), "Successfully installed tool");
 
-        Ok(status.success())
+        Ok(success)
+    }
+
+    async fn uninstall(&self, install_dir: &Path) -> Result<bool, ProtoError> {
+        if !is_installed_in_rustup(install_dir).await? {
+            debug!(target: self.get_log_target(), "Tool has not been installed, aborting");
+
+            return Ok(false);
+        }
+
+        let success = run_rustup_toolchain("uninstall", self.get_resolved_version()).await?;
+
+        debug!(target: self.get_log_target(), "Successfully uninstalled tool");
+
+        Ok(success)
     }
 }

--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -34,7 +34,7 @@ impl RustLanguage {
 
 impl Describable<'_> for RustLanguage {
     fn get_bin_name(&self) -> &str {
-        "rustc"
+        "rust"
     }
 
     fn get_log_target(&self) -> &str {


### PR DESCRIPTION
Since Rust works differently, we need to overwrite the default functionality.