### PR TITLE
new: Add `alias` and `unalias` commands.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 #### 🚀 Updates
 
-- Added a `proto install-global` command, for installing global packages for a tool.
+- Added a `proto install-global` command for installing global packages for a tool.
+- Added `proto alias` and `proto unalias` commands for creating custom version aliases.
 
 ## 0.4.0
 

--- a/crates/bun/src/lib.rs
+++ b/crates/bun/src/lib.rs
@@ -8,7 +8,7 @@ mod shim;
 mod verify;
 
 use proto_core::{Describable, Proto, Tool};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug)]
 pub struct BunLanguage {
@@ -47,4 +47,8 @@ impl Describable<'_> for BunLanguage {
     }
 }
 
-impl Tool<'_> for BunLanguage {}
+impl Tool<'_> for BunLanguage {
+    fn get_tool_dir(&self) -> &Path {
+        &self.base_dir
+    }
+}

--- a/crates/bun/src/resolve.rs
+++ b/crates/bun/src/resolve.rs
@@ -3,7 +3,7 @@ use core::str;
 use log::debug;
 use proto_core::{
     async_trait, create_version_manifest_from_tags, is_offline, is_semantic_version, load_git_tags,
-    remove_v_prefix, Describable, ProtoError, Resolvable, VersionManifest,
+    remove_v_prefix, Describable, Manifest, ProtoError, Resolvable, VersionManifest,
 };
 
 #[async_trait]
@@ -23,7 +23,9 @@ impl Resolvable<'_> for BunLanguage {
             .map(|t| t.strip_prefix("bun-v").unwrap().to_owned())
             .collect::<Vec<_>>();
 
-        let manifest = create_version_manifest_from_tags(tags);
+        let mut manifest = create_version_manifest_from_tags(tags);
+
+        manifest.inherit_aliases(&Manifest::load_for_tool(self.get_bin_name())?.aliases);
 
         Ok(manifest)
     }

--- a/crates/bun/src/resolve.rs
+++ b/crates/bun/src/resolve.rs
@@ -50,12 +50,7 @@ impl Resolvable<'_> for BunLanguage {
         );
 
         let manifest = self.load_version_manifest().await?;
-
-        let candidate = if initial_version == "latest" {
-            manifest.find_version_from_alias(&initial_version)?
-        } else {
-            manifest.find_version(&initial_version)?
-        };
+        let candidate = manifest.find_version(&initial_version)?;
 
         debug!(target: self.get_log_target(), "Resolved to {}", candidate);
 

--- a/crates/bun/src/resolve.rs
+++ b/crates/bun/src/resolve.rs
@@ -3,7 +3,7 @@ use core::str;
 use log::debug;
 use proto_core::{
     async_trait, create_version_manifest_from_tags, is_offline, is_semantic_version, load_git_tags,
-    remove_v_prefix, Describable, Manifest, ProtoError, Resolvable, VersionManifest,
+    remove_v_prefix, Describable, Manifest, ProtoError, Resolvable, Tool, VersionManifest,
 };
 
 #[async_trait]
@@ -25,7 +25,7 @@ impl Resolvable<'_> for BunLanguage {
 
         let mut manifest = create_version_manifest_from_tags(tags);
 
-        manifest.inherit_aliases(&Manifest::load_for_tool(self.get_bin_name())?.aliases);
+        manifest.inherit_aliases(&Manifest::load(self.get_manifest_path())?.aliases);
 
         Ok(manifest)
     }

--- a/crates/bun/tests/bun_test.rs
+++ b/crates/bun/tests/bun_test.rs
@@ -2,6 +2,7 @@
 #[cfg(not(windows))]
 mod bun {
     // use super::*;
+    use assert_fs::prelude::{FileWriteStr, PathChild};
     use proto_bun::BunLanguage;
     use proto_core::{
         Downloadable, Executable, Installable, Proto, Resolvable, Tool, Verifiable, Version,
@@ -157,6 +158,19 @@ mod bun {
             let current_latest_version = Version::parse("0.5.7").unwrap();
 
             assert!(latest_version >= current_latest_version);
+        }
+
+        #[tokio::test]
+        async fn resolve_custom_alias() {
+            let (mut tool, fixture) = create_tool();
+            tool.version = None;
+
+            fixture
+                .child("tools/bun/manifest.json")
+                .write_str(r#"{"aliases":{"example":"0.5.0"}}"#)
+                .unwrap();
+
+            assert_eq!(tool.resolve_version("example").await.unwrap(), "0.5.0");
         }
     }
 

--- a/crates/cli/src/app.rs
+++ b/crates/cli/src/app.rs
@@ -18,9 +18,25 @@ pub struct App {
     pub command: Commands,
 }
 
-// TODO: alias, unalias
 #[derive(Debug, Subcommand)]
 pub enum Commands {
+    #[command(
+        name = "a",
+        name = "alias",
+        about = "Add an alias to a tool.",
+        long_about = "Add an alias to a tool, that maps to a specific version, or another alias."
+    )]
+    Alias {
+        #[arg(required = true, value_enum, help = "Type of tool")]
+        tool: ToolType,
+
+        #[arg(required = true, help = "Alias name")]
+        alias: String,
+
+        #[arg(required = true, help = "Version (or alias) to associate with")]
+        semver: String,
+    },
+
     #[command(
         name = "bin",
         about = "Display the absolute path to a tools binary.",
@@ -157,6 +173,15 @@ pub enum Commands {
 
         #[arg(long, help = "Return the profile path if setup")]
         profile: bool,
+    },
+
+    #[command(name = "ua", name = "unalias", about = "Remove an alias from a tool.")]
+    Unalias {
+        #[arg(required = true, value_enum, help = "Type of tool")]
+        tool: ToolType,
+
+        #[arg(required = true, help = "Alias name")]
+        alias: String,
     },
 
     #[command(

--- a/crates/cli/src/bin.rs
+++ b/crates/cli/src/bin.rs
@@ -15,6 +15,11 @@ async fn main() {
     let app = App::parse();
 
     let result = match app.command {
+        Commands::Alias {
+            tool,
+            alias,
+            semver,
+        } => commands::alias(tool, alias, semver).await,
         Commands::Bin { tool, semver, shim } => commands::bin(tool, semver, shim).await,
         Commands::Completions { shell } => commands::completions(shell).await,
         Commands::Install {
@@ -36,6 +41,7 @@ async fn main() {
             passthrough,
         } => commands::run(tool, semver, passthrough).await,
         Commands::Setup { shell, profile } => commands::setup(shell, profile).await,
+        Commands::Unalias { tool, alias } => commands::unalias(tool, alias).await,
         Commands::Uninstall { tool, semver } => commands::uninstall(tool, semver).await,
         Commands::Upgrade => commands::upgrade().await,
         Commands::Use => commands::install_all().await,

--- a/crates/cli/src/commands/alias.rs
+++ b/crates/cli/src/commands/alias.rs
@@ -1,10 +1,14 @@
 use crate::helpers::enable_logging;
 use crate::tools::{create_tool, ToolType};
 use log::info;
-use proto_core::{Manifest, ProtoError};
+use proto_core::{color, Manifest, ProtoError};
 
 pub async fn alias(tool_type: ToolType, alias: String, version: String) -> Result<(), ProtoError> {
     enable_logging();
+
+    if alias == version {
+        return Err(ProtoError::Message("Cannot map an alias to itself.".into()));
+    }
 
     let tool = create_tool(&tool_type)?;
 
@@ -15,8 +19,8 @@ pub async fn alias(tool_type: ToolType, alias: String, version: String) -> Resul
     info!(
         target: "proto:alias",
         "Added alias {} ({}) for {}",
-        alias,
-        version,
+        color::id(alias),
+        color::muted_light(version),
         tool.get_name(),
     );
 

--- a/crates/cli/src/commands/alias.rs
+++ b/crates/cli/src/commands/alias.rs
@@ -1,6 +1,7 @@
 use crate::helpers::enable_logging;
 use crate::tools::{create_tool, ToolType};
 use log::info;
+use proto::is_alias_name;
 use proto_core::{color, Manifest, ProtoError};
 
 pub async fn alias(tool_type: ToolType, alias: String, version: String) -> Result<(), ProtoError> {
@@ -8,6 +9,12 @@ pub async fn alias(tool_type: ToolType, alias: String, version: String) -> Resul
 
     if alias == version {
         return Err(ProtoError::Message("Cannot map an alias to itself.".into()));
+    }
+
+    if !is_alias_name(&alias) {
+        return Err(ProtoError::Message(
+            "Versions cannot be aliases. Use alpha-only words instead.".into(),
+        ));
     }
 
     let tool = create_tool(&tool_type)?;

--- a/crates/cli/src/commands/alias.rs
+++ b/crates/cli/src/commands/alias.rs
@@ -19,7 +19,7 @@ pub async fn alias(tool_type: ToolType, alias: String, version: String) -> Resul
 
     let tool = create_tool(&tool_type)?;
 
-    let mut manifest = Manifest::load_for_tool(tool.get_bin_name())?;
+    let mut manifest = Manifest::load(tool.get_manifest_path())?;
     manifest.aliases.insert(alias.clone(), version.clone());
     manifest.save()?;
 

--- a/crates/cli/src/commands/alias.rs
+++ b/crates/cli/src/commands/alias.rs
@@ -1,0 +1,24 @@
+use crate::helpers::enable_logging;
+use crate::tools::{create_tool, ToolType};
+use log::info;
+use proto_core::{Manifest, ProtoError};
+
+pub async fn alias(tool_type: ToolType, alias: String, version: String) -> Result<(), ProtoError> {
+    enable_logging();
+
+    let tool = create_tool(&tool_type)?;
+
+    let mut manifest = Manifest::load_for_tool(tool.get_bin_name())?;
+    manifest.aliases.insert(alias.clone(), version.clone());
+    manifest.save()?;
+
+    info!(
+        target: "proto:alias",
+        "Added alias {} ({}) for {}",
+        alias,
+        version,
+        tool.get_name(),
+    );
+
+    Ok(())
+}

--- a/crates/cli/src/commands/alias.rs
+++ b/crates/cli/src/commands/alias.rs
@@ -1,8 +1,7 @@
 use crate::helpers::enable_logging;
 use crate::tools::{create_tool, ToolType};
 use log::info;
-use proto::is_alias_name;
-use proto_core::{color, Manifest, ProtoError};
+use proto_core::{color, is_alias_name, Manifest, ProtoError};
 
 pub async fn alias(tool_type: ToolType, alias: String, version: String) -> Result<(), ProtoError> {
     enable_logging();
@@ -13,7 +12,7 @@ pub async fn alias(tool_type: ToolType, alias: String, version: String) -> Resul
 
     if !is_alias_name(&alias) {
         return Err(ProtoError::Message(
-            "Versions cannot be aliases. Use alpha-only words instead.".into(),
+            "Versions cannot be aliases. Use alphanumeric words instead.".into(),
         ));
     }
 

--- a/crates/cli/src/commands/global.rs
+++ b/crates/cli/src/commands/global.rs
@@ -8,7 +8,7 @@ pub async fn global(tool_type: ToolType, version: String) -> Result<(), ProtoErr
 
     let tool = create_tool(&tool_type)?;
 
-    let mut manifest = Manifest::load_for_tool(tool.get_bin_name())?;
+    let mut manifest = Manifest::load(tool.get_manifest_path())?;
     manifest.default_version = Some(version.clone());
     manifest.save()?;
 

--- a/crates/cli/src/commands/install.rs
+++ b/crates/cli/src/commands/install.rs
@@ -50,7 +50,7 @@ pub async fn install(
     tool.cleanup().await?;
 
     if pin_version {
-        let mut manifest = Manifest::load_for_tool(tool.get_bin_name())?;
+        let mut manifest = Manifest::load(tool.get_manifest_path())?;
         manifest.default_version = Some(tool.get_resolved_version().to_owned());
         manifest.save()?;
     }

--- a/crates/cli/src/commands/install_global.rs
+++ b/crates/cli/src/commands/install_global.rs
@@ -25,7 +25,7 @@ pub async fn install_global(tool_type: ToolType, dependency: String) -> Result<(
 
     match tool_type {
         ToolType::Bun => {
-            global_dir = get_home_dir()?.join("bun");
+            global_dir = get_home_dir()?.join(".bun");
 
             command = Command::new(get_bin_or_fallback(tool).await?);
             command.args(["add", "--global"]).arg(&dependency);

--- a/crates/cli/src/commands/list.rs
+++ b/crates/cli/src/commands/list.rs
@@ -8,7 +8,7 @@ pub async fn list(tool_type: ToolType) -> Result<(), ProtoError> {
     enable_logging();
 
     let tool = create_tool(&tool_type)?;
-    let manifest = Manifest::load_for_tool(tool.get_bin_name())?;
+    let manifest = Manifest::load(tool.get_manifest_path())?;
 
     debug!(target: "proto:list", "Using versions from {}", color::path(&manifest.path));
 

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
+mod alias;
 mod bin;
 mod completions;
 mod global;
@@ -9,9 +10,11 @@ mod list_remote;
 mod local;
 mod run;
 mod setup;
+mod unalias;
 mod uninstall;
 mod upgrade;
 
+pub use alias::*;
 pub use bin::*;
 pub use completions::*;
 pub use global::*;
@@ -23,5 +26,6 @@ pub use list_remote::*;
 pub use local::*;
 pub use run::*;
 pub use setup::*;
+pub use unalias::*;
 pub use uninstall::*;
 pub use upgrade::*;

--- a/crates/cli/src/commands/unalias.rs
+++ b/crates/cli/src/commands/unalias.rs
@@ -8,7 +8,7 @@ pub async fn unalias(tool_type: ToolType, alias: String) -> Result<(), ProtoErro
 
     let tool = create_tool(&tool_type)?;
 
-    let mut manifest = Manifest::load_for_tool(tool.get_bin_name())?;
+    let mut manifest = Manifest::load(tool.get_manifest_path())?;
     let value = manifest.aliases.remove(&alias);
     manifest.save()?;
 

--- a/crates/cli/src/commands/unalias.rs
+++ b/crates/cli/src/commands/unalias.rs
@@ -1,0 +1,33 @@
+use crate::helpers::enable_logging;
+use crate::tools::{create_tool, ToolType};
+use log::info;
+use proto_core::{Manifest, ProtoError};
+
+pub async fn unalias(tool_type: ToolType, alias: String) -> Result<(), ProtoError> {
+    enable_logging();
+
+    let tool = create_tool(&tool_type)?;
+
+    let mut manifest = Manifest::load_for_tool(tool.get_bin_name())?;
+    let value = manifest.aliases.remove(&alias);
+    manifest.save()?;
+
+    if let Some(version) = value {
+        info!(
+            target: "proto:unalias",
+            "Removed alias {} ({}) from {}",
+            alias,
+            version,
+            tool.get_name(),
+        );
+    } else {
+        info!(
+            target: "proto:unalias",
+            "Alias {} not found for {}",
+            alias,
+            tool.get_name(),
+        );
+    }
+
+    Ok(())
+}

--- a/crates/cli/src/commands/unalias.rs
+++ b/crates/cli/src/commands/unalias.rs
@@ -1,7 +1,7 @@
 use crate::helpers::enable_logging;
 use crate::tools::{create_tool, ToolType};
 use log::info;
-use proto_core::{Manifest, ProtoError};
+use proto_core::{color, Manifest, ProtoError};
 
 pub async fn unalias(tool_type: ToolType, alias: String) -> Result<(), ProtoError> {
     enable_logging();
@@ -16,15 +16,15 @@ pub async fn unalias(tool_type: ToolType, alias: String) -> Result<(), ProtoErro
         info!(
             target: "proto:unalias",
             "Removed alias {} ({}) from {}",
-            alias,
-            version,
+            color::id(alias),
+            color::muted_light(version),
             tool.get_name(),
         );
     } else {
         info!(
             target: "proto:unalias",
             "Alias {} not found for {}",
-            alias,
+            color::id(alias),
             tool.get_name(),
         );
     }

--- a/crates/cli/tests/alias_test.rs
+++ b/crates/cli/tests/alias_test.rs
@@ -71,6 +71,26 @@ fn can_overwrite_existing_alias() {
 }
 
 #[test]
+fn errors_when_using_version() {
+    let temp = create_temp_dir();
+    let manifest_file = temp.join("tools/node/manifest.json");
+
+    assert!(!manifest_file.exists());
+
+    let mut cmd = create_proto_command(temp.path());
+    let assert = cmd
+        .arg("alias")
+        .arg("node")
+        .arg("1.2.3")
+        .arg("4.5.6")
+        .assert();
+
+    assert.stderr(predicate::str::contains(
+        "Versions cannot be aliases. Use alpha-only words instead.",
+    ));
+}
+
+#[test]
 fn errors_when_aliasing_self() {
     let temp = create_temp_dir();
     let manifest_file = temp.join("tools/node/manifest.json");

--- a/crates/cli/tests/alias_test.rs
+++ b/crates/cli/tests/alias_test.rs
@@ -1,0 +1,89 @@
+mod utils;
+
+use predicates::prelude::*;
+use std::fs;
+use utils::*;
+
+#[test]
+fn updates_manifest_file() {
+    let temp = create_temp_dir();
+    let manifest_file = temp.join("tools/node/manifest.json");
+
+    assert!(!manifest_file.exists());
+
+    let mut cmd = create_proto_command(temp.path());
+    cmd.arg("alias")
+        .arg("node")
+        .arg("example")
+        .arg("19.0.0")
+        .assert()
+        .success();
+
+    assert!(manifest_file.exists());
+    assert_eq!(
+        fs::read_to_string(manifest_file).unwrap(),
+        r#"{
+  "aliases": {
+    "example": "19.0.0"
+  },
+  "default_version": null,
+  "installed_versions": []
+}"#
+    );
+}
+
+#[test]
+fn can_overwrite_existing_alias() {
+    let temp = create_temp_dir();
+    let manifest_file = temp.join("tools/node/manifest.json");
+
+    fs::create_dir_all(manifest_file.parent().unwrap()).unwrap();
+    fs::write(
+        &manifest_file,
+        r#"{
+  "aliases": {
+    "example": "19.0.0"
+  },
+  "default_version": null,
+  "installed_versions": []
+}"#,
+    )
+    .unwrap();
+
+    let mut cmd = create_proto_command(temp.path());
+    cmd.arg("alias")
+        .arg("node")
+        .arg("example")
+        .arg("20.0.0")
+        .assert()
+        .success();
+
+    assert_eq!(
+        fs::read_to_string(manifest_file).unwrap(),
+        r#"{
+  "aliases": {
+    "example": "20.0.0"
+  },
+  "default_version": null,
+  "installed_versions": []
+}"#
+    );
+}
+
+#[test]
+fn errors_when_aliasing_self() {
+    let temp = create_temp_dir();
+    let manifest_file = temp.join("tools/node/manifest.json");
+
+    assert!(!manifest_file.exists());
+
+    let mut cmd = create_proto_command(temp.path());
+    let assert = cmd
+        .arg("alias")
+        .arg("node")
+        .arg("example")
+        .arg("example")
+        .assert();
+
+    assert.stderr(predicate::str::contains("Cannot map an alias to itself."));
+}

--- a/crates/cli/tests/alias_test.rs
+++ b/crates/cli/tests/alias_test.rs
@@ -86,7 +86,7 @@ fn errors_when_using_version() {
         .assert();
 
     assert.stderr(predicate::str::contains(
-        "Versions cannot be aliases. Use alpha-only words instead.",
+        "Versions cannot be aliases. Use alphanumeric words instead.",
     ));
 }
 

--- a/crates/cli/tests/global_test.rs
+++ b/crates/cli/tests/global_test.rs
@@ -20,6 +20,7 @@ fn updates_manifest_file() {
     assert_eq!(
         std::fs::read_to_string(manifest_file).unwrap(),
         r#"{
+  "aliases": {},
   "default_version": "19.0.0",
   "installed_versions": []
 }"#
@@ -27,7 +28,7 @@ fn updates_manifest_file() {
 }
 
 #[test]
-fn can_set_aliases() {
+fn can_set_alias_as_default() {
     let temp = create_temp_dir();
     let manifest_file = temp.join("tools/npm/manifest.json");
 
@@ -44,6 +45,7 @@ fn can_set_aliases() {
     assert_eq!(
         std::fs::read_to_string(manifest_file).unwrap(),
         r#"{
+  "aliases": {},
   "default_version": "bundled",
   "installed_versions": []
 }"#

--- a/crates/cli/tests/install_lang_test.rs
+++ b/crates/cli/tests/install_lang_test.rs
@@ -68,6 +68,7 @@ mod node {
         assert_eq!(
             fs::read_to_string(temp.join("tools/npm/manifest.json")).unwrap(),
             r#"{
+  "aliases": {},
   "default_version": "bundled",
   "installed_versions": [
     "8.19.2"

--- a/crates/cli/tests/install_uninstall_test.rs
+++ b/crates/cli/tests/install_uninstall_test.rs
@@ -75,6 +75,7 @@ fn updates_the_manifest_when_installing() {
     assert_eq!(
         fs::read_to_string(&manifest_file).unwrap(),
         r#"{
+  "aliases": {},
   "default_version": "19.0.0",
   "installed_versions": [
     "19.0.0"
@@ -93,6 +94,7 @@ fn updates_the_manifest_when_installing() {
     assert_eq!(
         fs::read_to_string(&manifest_file).unwrap(),
         r#"{
+  "aliases": {},
   "default_version": null,
   "installed_versions": []
 }"#
@@ -108,6 +110,7 @@ fn can_pin_when_installing() {
     fs::write(
         &manifest_file,
         r#"{
+  "aliases": {},
   "default_version": "18.0.0",
   "installed_versions": [
     "18.0.0"
@@ -126,6 +129,7 @@ fn can_pin_when_installing() {
     assert_eq!(
         fs::read_to_string(&manifest_file).unwrap(),
         r#"{
+  "aliases": {},
   "default_version": "19.0.0",
   "installed_versions": [
     "18.0.0",

--- a/crates/cli/tests/list_test.rs
+++ b/crates/cli/tests/list_test.rs
@@ -11,6 +11,7 @@ fn lists_local_versions() {
     fs::write(
         temp.join("tools/node/manifest.json"),
         r#"{
+  "aliases": {},
   "default_version": "19.0.0",
   "installed_versions": [
     "19.0.0",

--- a/crates/cli/tests/unalias_test.rs
+++ b/crates/cli/tests/unalias_test.rs
@@ -1,0 +1,76 @@
+mod utils;
+
+use std::fs;
+use utils::*;
+
+#[test]
+fn removes_existing_alias() {
+    let temp = create_temp_dir();
+    let manifest_file = temp.join("tools/node/manifest.json");
+
+    fs::create_dir_all(manifest_file.parent().unwrap()).unwrap();
+    fs::write(
+        &manifest_file,
+        r#"{
+  "aliases": {
+    "example": "19.0.0"
+  },
+  "default_version": null,
+  "installed_versions": []
+}"#,
+    )
+    .unwrap();
+
+    let mut cmd = create_proto_command(temp.path());
+    cmd.arg("unalias")
+        .arg("node")
+        .arg("example")
+        .assert()
+        .success();
+
+    assert_eq!(
+        fs::read_to_string(manifest_file).unwrap(),
+        r#"{
+  "aliases": {},
+  "default_version": null,
+  "installed_versions": []
+}"#
+    );
+}
+
+#[test]
+fn does_nothing_for_unknown_alias() {
+    let temp = create_temp_dir();
+    let manifest_file = temp.join("tools/node/manifest.json");
+
+    fs::create_dir_all(manifest_file.parent().unwrap()).unwrap();
+    fs::write(
+        &manifest_file,
+        r#"{
+  "aliases": {
+    "example": "19.0.0"
+  },
+  "default_version": null,
+  "installed_versions": []
+}"#,
+    )
+    .unwrap();
+
+    let mut cmd = create_proto_command(temp.path());
+    cmd.arg("unalias")
+        .arg("node")
+        .arg("unknown")
+        .assert()
+        .success();
+
+    assert_eq!(
+        fs::read_to_string(manifest_file).unwrap(),
+        r#"{
+  "aliases": {
+    "example": "19.0.0"
+  },
+  "default_version": null,
+  "installed_versions": []
+}"#
+    );
+}

--- a/crates/core/src/detector.rs
+++ b/crates/core/src/detector.rs
@@ -4,7 +4,7 @@ use crate::errors::ProtoError;
 use crate::manifest::{Manifest, MANIFEST_NAME};
 use crate::tool::Tool;
 use crate::tools_config::{ToolsConfig, TOOLS_CONFIG_NAME};
-use crate::{color, is_version_alias};
+use crate::{color, is_alias_name};
 use lenient_semver::Version;
 use log::{debug, trace};
 use std::{env, fs, path::Path};
@@ -149,7 +149,7 @@ pub fn detect_fixed_version<P: AsRef<Path>>(
     version: &str,
     manifest_path: P,
 ) -> Result<Option<String>, ProtoError> {
-    if is_version_alias(version) {
+    if is_alias_name(version) {
         return Ok(None);
     }
 

--- a/crates/core/src/detector.rs
+++ b/crates/core/src/detector.rs
@@ -122,7 +122,7 @@ pub async fn detect_version_from_environment<'l, T: Tool<'l> + ?Sized>(
             MANIFEST_NAME
         );
 
-        let manifest = Manifest::load_for_tool(tool.get_bin_name())?;
+        let manifest = Manifest::load(tool.get_manifest_path())?;
 
         if let Some(global_version) = manifest.default_version {
             debug!(

--- a/crates/core/src/helpers.rs
+++ b/crates/core/src/helpers.rs
@@ -30,9 +30,13 @@ pub fn get_tools_dir() -> Result<PathBuf, ProtoError> {
 
 // Aliases are words that map to version. For example, "latest" -> "1.2.3".
 pub fn is_alias_name(value: &str) -> bool {
-    value
-        .chars()
-        .all(|c| char::is_ascii_alphabetic(&c) || c == '-')
+    value.chars().enumerate().all(|(i, c)| {
+        if i == 0 {
+            char::is_ascii_alphabetic(&c) && c != 'v' && c != 'V'
+        } else {
+            char::is_ascii_alphanumeric(&c) || c == '-'
+        }
+    })
 }
 
 pub fn add_v_prefix(value: &str) -> String {

--- a/crates/core/src/helpers.rs
+++ b/crates/core/src/helpers.rs
@@ -29,7 +29,7 @@ pub fn get_tools_dir() -> Result<PathBuf, ProtoError> {
 }
 
 // Aliases are words that map to version. For example, "latest" -> "1.2.3".
-pub fn is_version_alias(value: &str) -> bool {
+pub fn is_alias_name(value: &str) -> bool {
     value
         .chars()
         .all(|c| char::is_ascii_alphabetic(&c) || c == '-')

--- a/crates/core/src/manifest.rs
+++ b/crates/core/src/manifest.rs
@@ -1,4 +1,4 @@
-use crate::{color, get_tools_dir, ProtoError};
+use crate::{color, ProtoError};
 use log::{info, trace};
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
@@ -55,10 +55,6 @@ impl Manifest {
         manifest.save()?;
 
         Ok(())
-    }
-
-    pub fn load_for_tool(bin: &str) -> Result<Self, ProtoError> {
-        Self::load_from(get_tools_dir()?.join(bin))
     }
 
     pub fn load_from<P: AsRef<Path>>(dir: P) -> Result<Self, ProtoError> {

--- a/crates/core/src/manifest.rs
+++ b/crates/core/src/manifest.rs
@@ -1,6 +1,6 @@
-use crate::{get_tools_dir, ProtoError};
-use log::info;
-use rustc_hash::FxHashSet;
+use crate::{color, get_tools_dir, ProtoError};
+use log::{info, trace};
+use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 use std::{
     fs,
@@ -12,6 +12,7 @@ pub const MANIFEST_NAME: &str = "manifest.json";
 #[derive(Debug, Default, Deserialize, Serialize)]
 #[serde(default)]
 pub struct Manifest {
+    pub aliases: FxHashMap<String, String>,
     pub default_version: Option<String>,
     pub installed_versions: FxHashSet<String>,
 
@@ -46,7 +47,7 @@ impl Manifest {
         if (manifest.installed_versions.is_empty() && manifest.default_version.is_some())
             || manifest.default_version.as_ref() == Some(&version.to_owned())
         {
-            info!(target: "proto:uninstall", "Unpinning default global version");
+            info!(target: "proto:manifest", "Unpinning default global version");
 
             manifest.default_version = None;
         }
@@ -67,6 +68,8 @@ impl Manifest {
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, ProtoError> {
         let path = path.as_ref();
 
+        trace!(target: "proto:manifest", "Loading manifest {}", color::path(path));
+
         let mut manifest: Manifest = if path.exists() {
             let contents = fs::read_to_string(path)
                 .map_err(|e| ProtoError::Fs(path.to_path_buf(), e.to_string()))?;
@@ -83,6 +86,8 @@ impl Manifest {
     }
 
     pub fn save(&self) -> Result<(), ProtoError> {
+        trace!(target: "proto:manifest", "Saving manifest {}", color::path(&self.path));
+
         let data = serde_json::to_string_pretty(self)
             .map_err(|e| ProtoError::Json(self.path.to_path_buf(), e.to_string()))?;
 

--- a/crates/core/src/resolver.rs
+++ b/crates/core/src/resolver.rs
@@ -4,6 +4,7 @@ use crate::{get_temp_dir, is_alias_name, remove_v_prefix};
 use human_sort::compare;
 use lenient_semver::Version;
 use log::trace;
+use rustc_hash::FxHashMap;
 use serde::de::DeserializeOwned;
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
@@ -94,6 +95,12 @@ impl VersionManifest {
         }
 
         Err(ProtoError::VersionResolveFailed(version.to_owned()))
+    }
+
+    pub fn inherit_aliases(&mut self, aliases: &FxHashMap<String, String>) {
+        for (alias, version) in aliases {
+            self.aliases.insert(alias.to_owned(), version.to_owned());
+        }
     }
 }
 

--- a/crates/core/src/resolver.rs
+++ b/crates/core/src/resolver.rs
@@ -18,7 +18,7 @@ pub struct VersionManifestEntry {
     pub version: String,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct VersionManifest {
     pub aliases: BTreeMap<String, String>,
     pub versions: BTreeMap<String, VersionManifestEntry>,

--- a/crates/core/tests/version_manifest_test.rs
+++ b/crates/core/tests/version_manifest_test.rs
@@ -1,0 +1,17 @@
+use proto_core::VersionManifest;
+
+#[test]
+fn recursively_unwraps_aliases() {
+    let mut manifest = VersionManifest::default();
+    manifest
+        .aliases
+        .insert("first".to_owned(), "second".to_owned());
+    manifest
+        .aliases
+        .insert("second".to_owned(), "third".to_owned());
+    manifest
+        .aliases
+        .insert("third".to_owned(), "1.2.3".to_owned());
+
+    assert_eq!(manifest.get_version_from_alias("first").unwrap(), "1.2.3");
+}

--- a/crates/deno/src/lib.rs
+++ b/crates/deno/src/lib.rs
@@ -8,7 +8,7 @@ mod shim;
 mod verify;
 
 use proto_core::{Describable, Proto, Tool};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug)]
 pub struct DenoLanguage {
@@ -47,4 +47,8 @@ impl Describable<'_> for DenoLanguage {
     }
 }
 
-impl Tool<'_> for DenoLanguage {}
+impl Tool<'_> for DenoLanguage {
+    fn get_tool_dir(&self) -> &Path {
+        &self.base_dir
+    }
+}

--- a/crates/deno/src/resolve.rs
+++ b/crates/deno/src/resolve.rs
@@ -3,7 +3,7 @@ use core::str;
 use log::debug;
 use proto_core::{
     async_trait, create_version_manifest_from_tags, is_offline, is_semantic_version, load_git_tags,
-    remove_v_prefix, Describable, ProtoError, Resolvable, VersionManifest,
+    remove_v_prefix, Describable, Manifest, ProtoError, Resolvable, VersionManifest,
 };
 
 #[async_trait]
@@ -23,7 +23,9 @@ impl Resolvable<'_> for DenoLanguage {
             .map(|t| remove_v_prefix(t))
             .collect::<Vec<_>>();
 
-        let manifest = create_version_manifest_from_tags(tags);
+        let mut manifest = create_version_manifest_from_tags(tags);
+
+        manifest.inherit_aliases(&Manifest::load_for_tool(self.get_bin_name())?.aliases);
 
         Ok(manifest)
     }

--- a/crates/deno/src/resolve.rs
+++ b/crates/deno/src/resolve.rs
@@ -3,7 +3,7 @@ use core::str;
 use log::debug;
 use proto_core::{
     async_trait, create_version_manifest_from_tags, is_offline, is_semantic_version, load_git_tags,
-    remove_v_prefix, Describable, Manifest, ProtoError, Resolvable, VersionManifest,
+    remove_v_prefix, Describable, Manifest, ProtoError, Resolvable, Tool, VersionManifest,
 };
 
 #[async_trait]
@@ -25,7 +25,7 @@ impl Resolvable<'_> for DenoLanguage {
 
         let mut manifest = create_version_manifest_from_tags(tags);
 
-        manifest.inherit_aliases(&Manifest::load_for_tool(self.get_bin_name())?.aliases);
+        manifest.inherit_aliases(&Manifest::load(self.get_manifest_path())?.aliases);
 
         Ok(manifest)
     }

--- a/crates/deno/src/resolve.rs
+++ b/crates/deno/src/resolve.rs
@@ -50,12 +50,7 @@ impl Resolvable<'_> for DenoLanguage {
         );
 
         let manifest = self.load_version_manifest().await?;
-
-        let candidate = if initial_version == "latest" {
-            manifest.find_version_from_alias(&initial_version)?
-        } else {
-            manifest.find_version(&initial_version)?
-        };
+        let candidate = manifest.find_version(&initial_version)?;
 
         debug!(target: self.get_log_target(), "Resolved to {}", candidate);
 

--- a/crates/deno/tests/deno_test.rs
+++ b/crates/deno/tests/deno_test.rs
@@ -187,5 +187,17 @@ mod deno {
 
             assert!(latest_version > current_latest_version);
         }
+
+        #[tokio::test]
+        async fn resolve_custom_alias() {
+            let (mut tool, fixture) = create_tool();
+
+            fixture
+                .child("tools/deno/manifest.json")
+                .write_str(r#"{"aliases":{"example":"1.30.0"}}"#)
+                .unwrap();
+
+            assert_eq!(tool.resolve_version("example").await.unwrap(), "1.30.0");
+        }
     }
 }

--- a/crates/go/src/lib.rs
+++ b/crates/go/src/lib.rs
@@ -8,7 +8,7 @@ mod shim;
 mod verify;
 
 use proto_core::{Describable, Proto, Tool};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug)]
 pub struct GoLanguage {
@@ -47,4 +47,8 @@ impl Describable<'_> for GoLanguage {
     }
 }
 
-impl Tool<'_> for GoLanguage {}
+impl Tool<'_> for GoLanguage {
+    fn get_tool_dir(&self) -> &Path {
+        &self.base_dir
+    }
+}

--- a/crates/go/src/resolve.rs
+++ b/crates/go/src/resolve.rs
@@ -2,7 +2,7 @@ use crate::GoLanguage;
 use log::debug;
 use proto_core::{
     async_trait, create_version_manifest_from_tags, is_offline, is_semantic_version, load_git_tags,
-    remove_v_prefix, Describable, ProtoError, Resolvable, Version, VersionManifest,
+    remove_v_prefix, Describable, Manifest, ProtoError, Resolvable, Version, VersionManifest,
 };
 
 trait BaseVersion {
@@ -40,7 +40,9 @@ impl Resolvable<'_> for GoLanguage {
             })
             .collect::<Vec<_>>();
 
-        let manifest = create_version_manifest_from_tags(tags);
+        let mut manifest = create_version_manifest_from_tags(tags);
+
+        manifest.inherit_aliases(&Manifest::load_for_tool(self.get_bin_name())?.aliases);
 
         Ok(manifest)
     }

--- a/crates/go/src/resolve.rs
+++ b/crates/go/src/resolve.rs
@@ -71,10 +71,7 @@ impl Resolvable<'_> for GoLanguage {
         let candidate = if initial_version.contains("rc") || initial_version.contains("beta") {
             manifest.get_version(&initial_version)?
         } else {
-            match manifest.find_version_from_alias(&initial_version) {
-                Ok(found) => found,
-                _ => manifest.find_version(&initial_version)?,
-            }
+            manifest.find_version(&initial_version)?
         };
 
         debug!(target: self.get_log_target(), "Resolved to {}", candidate);

--- a/crates/go/src/resolve.rs
+++ b/crates/go/src/resolve.rs
@@ -2,7 +2,7 @@ use crate::GoLanguage;
 use log::debug;
 use proto_core::{
     async_trait, create_version_manifest_from_tags, is_offline, is_semantic_version, load_git_tags,
-    remove_v_prefix, Describable, Manifest, ProtoError, Resolvable, Version, VersionManifest,
+    remove_v_prefix, Describable, Manifest, ProtoError, Resolvable, Tool, Version, VersionManifest,
 };
 
 trait BaseVersion {
@@ -42,7 +42,7 @@ impl Resolvable<'_> for GoLanguage {
 
         let mut manifest = create_version_manifest_from_tags(tags);
 
-        manifest.inherit_aliases(&Manifest::load_for_tool(self.get_bin_name())?.aliases);
+        manifest.inherit_aliases(&Manifest::load(self.get_manifest_path())?.aliases);
 
         Ok(manifest)
     }

--- a/crates/go/tests/go_test.rs
+++ b/crates/go/tests/go_test.rs
@@ -230,6 +230,18 @@ mod go {
         }
 
         #[tokio::test]
+        async fn resolve_custom_alias() {
+            let (mut tool, fixture) = create_tool();
+
+            fixture
+                .child("tools/go/manifest.json")
+                .write_str(r#"{"aliases":{"example":"1.20.0"}}"#)
+                .unwrap();
+
+            assert_eq!(tool.resolve_version("example").await.unwrap(), "1.20.0");
+        }
+
+        #[tokio::test]
         async fn resolve_latest_version() {
             let (mut tool, _fixture) = create_tool();
 

--- a/crates/node/src/depman/detect.rs
+++ b/crates/node/src/depman/detect.rs
@@ -23,7 +23,7 @@ impl Detector<'_> for NodeDependencyManager {
 
             if let Some(engines) = package_json.engines {
                 if let Some(constraint) = engines.get(&self.package_name) {
-                    return detect_fixed_version(constraint, self.get_manifest_path()?);
+                    return detect_fixed_version(constraint, self.get_manifest_path());
                 }
             }
         }

--- a/crates/node/src/depman/mod.rs
+++ b/crates/node/src/depman/mod.rs
@@ -8,7 +8,7 @@ mod verify;
 
 use proto_core::{Describable, Proto, Tool};
 // use resolve::NDMVersionDist;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug)]
 pub enum NodeDependencyManagerType {
@@ -79,4 +79,8 @@ impl Describable<'_> for NodeDependencyManager {
     }
 }
 
-impl Tool<'_> for NodeDependencyManager {}
+impl Tool<'_> for NodeDependencyManager {
+    fn get_tool_dir(&self) -> &Path {
+        &self.base_dir
+    }
+}

--- a/crates/node/src/depman/resolve.rs
+++ b/crates/node/src/depman/resolve.rs
@@ -4,8 +4,8 @@ use crate::NodeLanguage;
 use log::debug;
 use proto_core::{
     async_trait, detect_version_from_environment, is_offline, is_semantic_version,
-    load_versions_manifest, parse_version, remove_v_prefix, Describable, Proto, ProtoError,
-    Resolvable, VersionManifest, VersionManifestEntry,
+    load_versions_manifest, remove_v_prefix, Describable, Proto, ProtoError, Resolvable,
+    VersionManifest, VersionManifestEntry,
 };
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
@@ -156,11 +156,11 @@ impl Resolvable<'_> for NodeDependencyManager {
         );
 
         let manifest = self.load_version_manifest().await?;
-        let version = parse_version(manifest.find_version(&initial_version)?)?.to_string();
+        let candidate = manifest.find_version(&initial_version)?;
 
-        debug!(target: self.get_log_target(), "Resolved to {}", version);
+        debug!(target: self.get_log_target(), "Resolved to {}", candidate);
 
-        self.set_version(&version);
+        self.set_version(candidate);
 
         // Extract dist information for use in downloading and verifying
         // self.dist = Some(
@@ -172,7 +172,7 @@ impl Resolvable<'_> for NodeDependencyManager {
         //         .clone(),
         // );
 
-        Ok(version)
+        Ok(candidate.to_owned())
     }
 
     fn set_version(&mut self, version: &str) {

--- a/crates/node/src/depman/resolve.rs
+++ b/crates/node/src/depman/resolve.rs
@@ -5,7 +5,7 @@ use log::debug;
 use proto_core::{
     async_trait, detect_version_from_environment, is_offline, is_semantic_version,
     load_versions_manifest, remove_v_prefix, Describable, Manifest, Proto, ProtoError, Resolvable,
-    VersionManifest, VersionManifestEntry,
+    Tool, VersionManifest, VersionManifestEntry,
 };
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
@@ -81,7 +81,7 @@ impl Resolvable<'_> for NodeDependencyManager {
             versions,
         };
 
-        manifest.inherit_aliases(&Manifest::load_for_tool(self.get_bin_name())?.aliases);
+        manifest.inherit_aliases(&Manifest::load(self.get_manifest_path())?.aliases);
 
         Ok(manifest)
     }

--- a/crates/node/src/detect.rs
+++ b/crates/node/src/detect.rs
@@ -27,7 +27,7 @@ impl Detector<'_> for NodeLanguage {
 
             if let Some(engines) = package_json.engines {
                 if let Some(constraint) = engines.get("node") {
-                    return detect_fixed_version(constraint, self.get_manifest_path()?);
+                    return detect_fixed_version(constraint, self.get_manifest_path());
                 }
             }
         }

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -10,7 +10,7 @@ mod verify;
 
 pub use depman::*;
 use proto_core::{Describable, Proto, Tool};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug)]
 pub struct NodeLanguage {
@@ -51,4 +51,8 @@ impl Describable<'_> for NodeLanguage {
     }
 }
 
-impl Tool<'_> for NodeLanguage {}
+impl Tool<'_> for NodeLanguage {
+    fn get_tool_dir(&self) -> &Path {
+        &self.base_dir
+    }
+}

--- a/crates/node/src/resolve.rs
+++ b/crates/node/src/resolve.rs
@@ -2,7 +2,7 @@ use crate::NodeLanguage;
 use log::debug;
 use proto_core::{
     async_trait, is_offline, is_semantic_version, load_versions_manifest, parse_version,
-    remove_v_prefix, Describable, Manifest, ProtoError, Resolvable, VersionManifest,
+    remove_v_prefix, Describable, Manifest, ProtoError, Resolvable, Tool, VersionManifest,
     VersionManifestEntry,
 };
 use serde::Deserialize;
@@ -68,7 +68,7 @@ impl Resolvable<'_> for NodeLanguage {
 
         let mut manifest = VersionManifest { aliases, versions };
 
-        manifest.inherit_aliases(&Manifest::load_for_tool(self.get_bin_name())?.aliases);
+        manifest.inherit_aliases(&Manifest::load(self.get_manifest_path())?.aliases);
 
         Ok(manifest)
     }
@@ -96,6 +96,8 @@ impl Resolvable<'_> for NodeLanguage {
 
         let manifest = self.load_version_manifest().await?;
         let candidate;
+
+        dbg!(&manifest);
 
         // Latest version is always at the top
         if initial_version == "node" || initial_version == "latest" {

--- a/crates/node/src/resolve.rs
+++ b/crates/node/src/resolve.rs
@@ -2,7 +2,8 @@ use crate::NodeLanguage;
 use log::debug;
 use proto_core::{
     async_trait, is_offline, is_semantic_version, load_versions_manifest, parse_version,
-    remove_v_prefix, Describable, ProtoError, Resolvable, VersionManifest, VersionManifestEntry,
+    remove_v_prefix, Describable, Manifest, ProtoError, Resolvable, VersionManifest,
+    VersionManifestEntry,
 };
 use serde::Deserialize;
 use std::collections::BTreeMap;
@@ -65,7 +66,11 @@ impl Resolvable<'_> for NodeLanguage {
             versions.insert(entry.version.clone(), entry);
         }
 
-        Ok(VersionManifest { aliases, versions })
+        let mut manifest = VersionManifest { aliases, versions };
+
+        manifest.inherit_aliases(&Manifest::load_for_tool(self.get_bin_name())?.aliases);
+
+        Ok(manifest)
     }
 
     async fn resolve_version(&mut self, initial_version: &str) -> Result<String, ProtoError> {

--- a/crates/node/src/resolve.rs
+++ b/crates/node/src/resolve.rs
@@ -94,18 +94,18 @@ impl Resolvable<'_> for NodeLanguage {
 
         // Latest version is always at the top
         if initial_version == "node" || initial_version == "latest" {
-            candidate = manifest.find_version_from_alias("latest")?;
+            candidate = manifest.get_version_from_alias("latest")?;
 
         // Stable version is the first with an LTS
         } else if initial_version == "stable"
             || initial_version == "lts-*"
             || initial_version == "lts/*"
         {
-            candidate = manifest.find_version_from_alias("stable")?;
+            candidate = manifest.get_version_from_alias("stable")?;
 
             // Find the first version with a matching LTS
         } else if initial_version.starts_with("lts-") || initial_version.starts_with("lts/") {
-            candidate = manifest.find_version_from_alias(&initial_version[4..])?;
+            candidate = manifest.get_version_from_alias(&initial_version[4..])?;
 
             // Either an alias or version
         } else {

--- a/crates/node/src/resolve.rs
+++ b/crates/node/src/resolve.rs
@@ -97,8 +97,6 @@ impl Resolvable<'_> for NodeLanguage {
         let manifest = self.load_version_manifest().await?;
         let candidate;
 
-        dbg!(&manifest);
-
         // Latest version is always at the top
         if initial_version == "node" || initial_version == "latest" {
             candidate = manifest.get_version_from_alias("latest")?;

--- a/crates/node/tests/node_depman_test.rs
+++ b/crates/node/tests/node_depman_test.rs
@@ -1,3 +1,4 @@
+use assert_fs::prelude::{FileWriteStr, PathChild};
 use proto_core::{
     Detector, Downloadable, Executable, Installable, Proto, Resolvable, Shimable, Tool,
 };
@@ -387,6 +388,22 @@ mod node_depman {
             );
 
             assert_ne!(tool.resolve_version("berry").await.unwrap(), "berry");
+        }
+
+        #[tokio::test]
+        async fn resolve_custom_alias() {
+            let fixture = assert_fs::TempDir::new().unwrap();
+            let mut tool = NodeDependencyManager::new(
+                Proto::from(fixture.path()),
+                NodeDependencyManagerType::Npm,
+            );
+
+            fixture
+                .child("tools/npm/manifest.json")
+                .write_str(r#"{"aliases":{"example":"9.0.0"}}"#)
+                .unwrap();
+
+            assert_eq!(tool.resolve_version("example").await.unwrap(), "9.0.0");
         }
 
         #[tokio::test]

--- a/crates/node/tests/node_test.rs
+++ b/crates/node/tests/node_test.rs
@@ -289,10 +289,10 @@ mod node {
 
             fixture
                 .child("tools/node/manifest.json")
-                .write_str(r#"{"aliases":{"example":"1.2.3"}}"#)
+                .write_str(r#"{"aliases":{"example":"10.0.0"}}"#)
                 .unwrap();
 
-            assert_ne!(tool.resolve_version("example").await.unwrap(), "1.2.3");
+            assert_eq!(tool.resolve_version("example").await.unwrap(), "10.0.0");
         }
 
         #[tokio::test]

--- a/crates/node/tests/node_test.rs
+++ b/crates/node/tests/node_test.rs
@@ -1,3 +1,4 @@
+use assert_fs::prelude::{FileWriteStr, PathChild};
 use proto_core::{
     Detector, Downloadable, Executable, Installable, Proto, Resolvable, Tool, Verifiable,
 };
@@ -38,7 +39,6 @@ mod node {
 
     mod detector {
         use super::*;
-        use assert_fs::prelude::{FileWriteStr, PathChild};
 
         #[tokio::test]
         async fn doesnt_match_if_no_files() {
@@ -280,6 +280,19 @@ mod node {
             let mut tool = NodeLanguage::new(Proto::from(fixture.path()));
 
             assert_eq!(tool.resolve_version("10.1").await.unwrap(), "10.1.0");
+        }
+
+        #[tokio::test]
+        async fn resolve_custom_alias() {
+            let fixture = assert_fs::TempDir::new().unwrap();
+            let mut tool = NodeLanguage::new(Proto::from(fixture.path()));
+
+            fixture
+                .child("tools/node/manifest.json")
+                .write_str(r#"{"aliases":{"example":"1.2.3"}}"#)
+                .unwrap();
+
+            assert_ne!(tool.resolve_version("example").await.unwrap(), "1.2.3");
         }
 
         #[tokio::test]

--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -7,7 +7,7 @@ mod shim;
 mod verify;
 
 use proto_core::{Describable, Proto, Tool};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug)]
 pub struct RustLanguage {
@@ -46,4 +46,8 @@ impl Describable<'_> for RustLanguage {
     }
 }
 
-impl Tool<'_> for RustLanguage {}
+impl Tool<'_> for RustLanguage {
+    fn get_tool_dir(&self) -> &Path {
+        &self.base_dir
+    }
+}

--- a/crates/rust/src/resolve.rs
+++ b/crates/rust/src/resolve.rs
@@ -2,7 +2,7 @@ use crate::RustLanguage;
 use log::debug;
 use proto_core::{
     async_trait, create_version_manifest_from_tags, is_offline, is_semantic_version, load_git_tags,
-    remove_v_prefix, Describable, Manifest, ProtoError, Resolvable, VersionManifest,
+    remove_v_prefix, Describable, Manifest, ProtoError, Resolvable, Tool, VersionManifest,
 };
 
 #[async_trait]
@@ -23,7 +23,7 @@ impl Resolvable<'_> for RustLanguage {
 
         let mut manifest = create_version_manifest_from_tags(tags);
 
-        manifest.inherit_aliases(&Manifest::load_for_tool(self.get_bin_name())?.aliases);
+        manifest.inherit_aliases(&Manifest::load(self.get_manifest_path())?.aliases);
 
         Ok(manifest)
     }

--- a/crates/rust/src/resolve.rs
+++ b/crates/rust/src/resolve.rs
@@ -2,7 +2,7 @@ use crate::RustLanguage;
 use log::debug;
 use proto_core::{
     async_trait, create_version_manifest_from_tags, is_offline, is_semantic_version, load_git_tags,
-    remove_v_prefix, Describable, ProtoError, Resolvable, VersionManifest,
+    remove_v_prefix, Describable, Manifest, ProtoError, Resolvable, VersionManifest,
 };
 
 #[async_trait]
@@ -21,7 +21,9 @@ impl Resolvable<'_> for RustLanguage {
             .filter(|t| !t.ends_with("^{}"))
             .collect::<Vec<_>>();
 
-        let manifest = create_version_manifest_from_tags(tags);
+        let mut manifest = create_version_manifest_from_tags(tags);
+
+        manifest.inherit_aliases(&Manifest::load_for_tool(self.get_bin_name())?.aliases);
 
         Ok(manifest)
     }


### PR DESCRIPTION
This allows users to define their own aliases that'll be used during version resolution.