### PR TITLE
internal: Track installed at/last used at timestamps.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 #### ⚙️ Internal
 
 - Greatly improved error messages.
+- We now track install/last used timestamps for future functionality.
 
 ## 0.5.0
 

--- a/crates/cli/src/commands/bin.rs
+++ b/crates/cli/src/commands/bin.rs
@@ -1,5 +1,5 @@
 use crate::tools::{create_tool, ToolType};
-use proto_core::detect_version;
+use proto_core::{detect_version, Manifest};
 use starbase::SystemResult;
 
 pub async fn bin(
@@ -8,7 +8,8 @@ pub async fn bin(
     use_shim: bool,
 ) -> SystemResult {
     let mut tool = create_tool(&tool_type)?;
-    let version = detect_version(&tool, forced_version).await?;
+    let manifest = Manifest::load(tool.get_manifest_path())?;
+    let version = detect_version(&tool, &manifest, forced_version).await?;
 
     tool.resolve_version(&version).await?;
     tool.find_bin_path().await?;

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -12,7 +12,7 @@ pub async fn run(
     args: Vec<String>,
 ) -> SystemResult {
     let mut tool = create_tool(&tool_type)?;
-    let manifest = Manifest::load(tool.get_manifest_path())?;
+    let mut manifest = Manifest::load(tool.get_manifest_path())?;
     let version = detect_version(&tool, &manifest, forced_version).await?;
 
     if !tool.is_setup(&version).await? {
@@ -41,6 +41,11 @@ pub async fn run(
         tool.find_bin_path().await?;
     }
 
+    // Update the last used timestamp
+    manifest.track_used_at(tool.get_resolved_version());
+    manifest.save()?;
+
+    // Run the command
     let status = Command::new(tool.get_bin_path()?)
         .args(&args)
         .env(

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -43,7 +43,10 @@ pub async fn run(
 
     // Update the last used timestamp
     manifest.track_used_at(tool.get_resolved_version());
-    manifest.save()?;
+
+    // Ignore errors in case of race conditions...
+    // this timestamp isn't *super* important
+    let _ = manifest.save();
 
     // Run the command
     let status = Command::new(tool.get_bin_path()?)

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -1,6 +1,6 @@
 use crate::commands::install::install;
 use crate::tools::{create_tool, ToolType};
-use proto_core::{color, detect_version, ProtoError, UserConfig};
+use proto_core::{color, detect_version, Manifest, ProtoError, UserConfig};
 use starbase::SystemResult;
 use std::process::exit;
 use tokio::process::Command;
@@ -12,7 +12,8 @@ pub async fn run(
     args: Vec<String>,
 ) -> SystemResult {
     let mut tool = create_tool(&tool_type)?;
-    let version = detect_version(&tool, forced_version).await?;
+    let manifest = Manifest::load(tool.get_manifest_path())?;
+    let version = detect_version(&tool, &manifest, forced_version).await?;
 
     if !tool.is_setup(&version).await? {
         let config = UserConfig::load()?;

--- a/crates/cli/tests/global_test.rs
+++ b/crates/cli/tests/global_test.rs
@@ -1,5 +1,6 @@
 mod utils;
 
+use proto_core::Manifest;
 use utils::*;
 
 #[test]
@@ -17,14 +18,10 @@ fn updates_manifest_file() {
         .success();
 
     assert!(manifest_file.exists());
-    assert_eq!(
-        std::fs::read_to_string(manifest_file).unwrap(),
-        r#"{
-  "aliases": {},
-  "default_version": "19.0.0",
-  "installed_versions": []
-}"#
-    );
+
+    let manifest = Manifest::load(manifest_file).unwrap();
+
+    assert_eq!(manifest.default_version, Some("19.0.0".into()));
 }
 
 #[test]
@@ -42,12 +39,8 @@ fn can_set_alias_as_default() {
         .success();
 
     assert!(manifest_file.exists());
-    assert_eq!(
-        std::fs::read_to_string(manifest_file).unwrap(),
-        r#"{
-  "aliases": {},
-  "default_version": "bundled",
-  "installed_versions": []
-}"#
-    );
+
+    let manifest = Manifest::load(manifest_file).unwrap();
+
+    assert_eq!(manifest.default_version, Some("bundled".into()));
 }

--- a/crates/cli/tests/install_lang_test.rs
+++ b/crates/cli/tests/install_lang_test.rs
@@ -1,6 +1,7 @@
 mod utils;
 
 use predicates::prelude::*;
+use proto_core::Manifest;
 use std::fs;
 use utils::*;
 
@@ -48,6 +49,8 @@ mod go {
 }
 
 mod node {
+    use rustc_hash::FxHashSet;
+
     use super::*;
 
     #[test]
@@ -65,15 +68,12 @@ mod node {
         assert!(temp.join("tools/node/19.0.0").exists());
         assert!(temp.join("tools/npm/8.19.2").exists());
 
+        let manifest = Manifest::load(temp.join("tools/npm/manifest.json")).unwrap();
+
+        assert_eq!(manifest.default_version, Some("bundled".into()));
         assert_eq!(
-            fs::read_to_string(temp.join("tools/npm/manifest.json")).unwrap(),
-            r#"{
-  "aliases": {},
-  "default_version": "bundled",
-  "installed_versions": [
-    "8.19.2"
-  ]
-}"#
+            manifest.installed_versions,
+            FxHashSet::from_iter(["8.19.2".into()])
         );
     }
 

--- a/crates/cli/tests/install_lang_test.rs
+++ b/crates/cli/tests/install_lang_test.rs
@@ -2,6 +2,7 @@ mod utils;
 
 use predicates::prelude::*;
 use proto_core::Manifest;
+use rustc_hash::FxHashSet;
 use std::fs;
 use utils::*;
 
@@ -49,8 +50,6 @@ mod go {
 }
 
 mod node {
-    use rustc_hash::FxHashSet;
-
     use super::*;
 
     #[test]

--- a/crates/cli/tests/install_uninstall_test.rs
+++ b/crates/cli/tests/install_uninstall_test.rs
@@ -80,6 +80,7 @@ fn updates_the_manifest_when_installing() {
         manifest.installed_versions,
         FxHashSet::from_iter(["19.0.0".into()])
     );
+    assert!(manifest.versions.contains_key("19.0.0"));
 
     // Uninstall
     let mut cmd = create_proto_command(temp.path());
@@ -93,6 +94,7 @@ fn updates_the_manifest_when_installing() {
 
     assert_eq!(manifest.default_version, None);
     assert_eq!(manifest.installed_versions, FxHashSet::default());
+    assert!(!manifest.versions.contains_key("19.0.0"));
 }
 
 #[test]

--- a/crates/cli/tests/install_uninstall_test.rs
+++ b/crates/cli/tests/install_uninstall_test.rs
@@ -1,7 +1,8 @@
 mod utils;
 
 use predicates::prelude::*;
-use std::fs;
+use proto_core::Manifest;
+use rustc_hash::FxHashSet;
 use utils::*;
 
 #[test]
@@ -72,15 +73,12 @@ fn updates_the_manifest_when_installing() {
         .assert()
         .success();
 
+    let manifest = Manifest::load(&manifest_file).unwrap();
+
+    assert_eq!(manifest.default_version, Some("19.0.0".into()));
     assert_eq!(
-        fs::read_to_string(&manifest_file).unwrap(),
-        r#"{
-  "aliases": {},
-  "default_version": "19.0.0",
-  "installed_versions": [
-    "19.0.0"
-  ]
-}"#
+        manifest.installed_versions,
+        FxHashSet::from_iter(["19.0.0".into()])
     );
 
     // Uninstall
@@ -91,14 +89,10 @@ fn updates_the_manifest_when_installing() {
         .assert()
         .success();
 
-    assert_eq!(
-        fs::read_to_string(&manifest_file).unwrap(),
-        r#"{
-  "aliases": {},
-  "default_version": null,
-  "installed_versions": []
-}"#
-    );
+    let manifest = Manifest::load(&manifest_file).unwrap();
+
+    assert_eq!(manifest.default_version, None);
+    assert_eq!(manifest.installed_versions, FxHashSet::default());
 }
 
 #[test]
@@ -106,18 +100,10 @@ fn can_pin_when_installing() {
     let temp = create_temp_dir();
     let manifest_file = temp.join("tools/node/manifest.json");
 
-    fs::create_dir_all(manifest_file.parent().unwrap()).unwrap();
-    fs::write(
-        &manifest_file,
-        r#"{
-  "aliases": {},
-  "default_version": "18.0.0",
-  "installed_versions": [
-    "18.0.0"
-  ]
-}"#,
-    )
-    .unwrap();
+    let mut manifest = Manifest::load(&manifest_file).unwrap();
+    manifest.default_version = Some("18.0.0".into());
+    manifest.installed_versions.insert("18.0.0".into());
+    manifest.save().unwrap();
 
     let mut cmd = create_proto_command(temp.path());
     cmd.arg("install")
@@ -126,15 +112,11 @@ fn can_pin_when_installing() {
         .arg("--pin")
         .assert();
 
+    let manifest = Manifest::load(&manifest_file).unwrap();
+
+    assert_eq!(manifest.default_version, Some("19.0.0".into()));
     assert_eq!(
-        fs::read_to_string(&manifest_file).unwrap(),
-        r#"{
-  "aliases": {},
-  "default_version": "19.0.0",
-  "installed_versions": [
-    "18.0.0",
-    "19.0.0"
-  ]
-}"#
+        manifest.installed_versions,
+        FxHashSet::from_iter(["18.0.0".into(), "19.0.0".into()])
     );
 }

--- a/crates/cli/tests/list_test.rs
+++ b/crates/cli/tests/list_test.rs
@@ -1,26 +1,18 @@
 mod utils;
 
-use std::fs;
+use proto_core::Manifest;
 use utils::*;
 
 #[test]
 fn lists_local_versions() {
     let temp = create_temp_dir();
 
-    fs::create_dir_all(temp.join("tools/node")).unwrap();
-    fs::write(
-        temp.join("tools/node/manifest.json"),
-        r#"{
-  "aliases": {},
-  "default_version": "19.0.0",
-  "installed_versions": [
-    "19.0.0",
-    "18.0.0",
-    "17.0.0"
-  ]
-}"#,
-    )
-    .unwrap();
+    let mut manifest = Manifest::load(temp.join("tools/node/manifest.json")).unwrap();
+    manifest.default_version = Some("19.0.0".into());
+    manifest.installed_versions.insert("19.0.0".into());
+    manifest.installed_versions.insert("18.0.0".into());
+    manifest.installed_versions.insert("17.0.0".into());
+    manifest.save().unwrap();
 
     let mut cmd = create_proto_command(temp.path());
     let assert = cmd.arg("list").arg("node").assert();

--- a/crates/core/src/detector.rs
+++ b/crates/core/src/detector.rs
@@ -26,6 +26,7 @@ pub fn load_version_file(path: &Path) -> Result<String, ProtoError> {
 #[tracing::instrument(skip_all)]
 pub async fn detect_version<'l, T: Tool<'l> + ?Sized>(
     tool: &Box<T>,
+    manifest: &Manifest,
     forced_version: Option<String>,
 ) -> Result<String, ProtoError> {
     let mut version = forced_version;
@@ -99,16 +100,14 @@ pub async fn detect_version<'l, T: Tool<'l> + ?Sized>(
             MANIFEST_NAME
         );
 
-        let manifest = Manifest::load(tool.get_manifest_path())?;
-
-        if let Some(global_version) = manifest.default_version {
+        if let Some(global_version) = &manifest.default_version {
             debug!(
                 "Detected global version {} from {}",
                 global_version,
                 color::path(&manifest.path)
             );
 
-            version = Some(global_version);
+            version = Some(global_version.to_owned());
         }
     }
 

--- a/crates/node/src/depman/resolve.rs
+++ b/crates/node/src/depman/resolve.rs
@@ -99,8 +99,10 @@ impl Resolvable<'_> for NodeDependencyManager {
             NodeDependencyManagerType::Npm => {
                 if initial_version == "bundled" {
                     let node_tool = Box::new(NodeLanguage::new(Proto::new()?));
+                    let node_manifest = Manifest::load(node_tool.get_manifest_path())?;
 
-                    if let Ok(node_version) = detect_version(&node_tool, None).await {
+                    if let Ok(node_version) = detect_version(&node_tool, &node_manifest, None).await
+                    {
                         let npm_package_path = node_tool
                             .base_dir
                             .join(node_version)


### PR DESCRIPTION
We'll be using this information for future functionality.