### PR TITLE
new: Add read/write file locking for the manifest.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+#### ⚙️ Internal
+
+- Added read/write file locking for the `manifest.json` file.
+
 ## 0.6.0
 
 #### 🚀 Updates

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -649,6 +649,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "errno-dragonfly"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -665,6 +676,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "fd-lock"
+version = "3.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ae6b3d9530211fb3b12a95374b8b0823be812f53d09e18c5675c0146b09642"
+dependencies = [
+ "cfg-if",
+ "rustix 0.37.7",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1106,7 +1128,7 @@ checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
- "rustix",
+ "rustix 0.36.9",
  "windows-sys 0.45.0",
 ]
 
@@ -1216,6 +1238,12 @@ name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
 
 [[package]]
 name = "lock_api"
@@ -1557,6 +1585,7 @@ dependencies = [
  "async-trait",
  "cached",
  "dirs",
+ "fd-lock",
  "flate2",
  "human-sort",
  "lenient_semver",
@@ -1769,10 +1798,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
 dependencies = [
  "bitflags",
- "errno",
+ "errno 0.2.8",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.1.4",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aae838e49b3d63e9274e1c01833cc8139d3fec468c3b84688c628f44b1ae11d"
+dependencies = [
+ "bitflags",
+ "errno 0.3.1",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.1",
  "windows-sys 0.45.0",
 ]
 
@@ -2021,9 +2064,9 @@ dependencies = [
 
 [[package]]
 name = "starbase_styles"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac7677a4dfa4c81c0972b9fc227c0a7d339a2d3d360bc7fef4c5a7cb328b2cab"
+checksum = "22e279cef5503c65933ac1e8f7e050fff1e74362d584ddfec1887e39f8b6d3ce"
 dependencies = [
  "dirs",
  "miette",
@@ -2033,9 +2076,9 @@ dependencies = [
 
 [[package]]
 name = "starbase_utils"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92acc8843be98afe41caf1925e383fd2dc2b385a893bc6973eaa3597d0ff92eb"
+checksum = "f5ad87e0614bd3e9f1421bd61e7fcf73046d11ab34a1f3165540a22194ac21e4"
 dependencies = [
  "dirs",
  "json_comments",
@@ -2048,6 +2091,7 @@ dependencies = [
  "starbase_styles",
  "thiserror",
  "toml",
+ "tracing",
 ]
 
 [[package]]
@@ -2132,7 +2176,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall",
- "rustix",
+ "rustix 0.36.9",
  "windows-sys 0.42.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -649,17 +649,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "errno"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "errno-dragonfly"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -676,17 +665,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
-]
-
-[[package]]
-name = "fd-lock"
-version = "3.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ae6b3d9530211fb3b12a95374b8b0823be812f53d09e18c5675c0146b09642"
-dependencies = [
- "cfg-if",
- "rustix 0.37.7",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -733,6 +711,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs4"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea55201cc351fdb478217c0fb641b59813da9b4efe4c414a9d8f989a657d149"
+dependencies = [
+ "libc",
+ "rustix 0.35.13",
+ "winapi",
 ]
 
 [[package]]
@@ -1106,6 +1095,12 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ce5ef949d49ee85593fc4d3f3f95ad61657076395cbbce23e2121fc5542074"
+
+[[package]]
+name = "io-lifetimes"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfa919a82ea574332e2de6e74b4c36e74d41982b335080fa59d4ef31be20fdf3"
@@ -1127,7 +1122,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
 dependencies = [
  "hermit-abi 0.3.1",
- "io-lifetimes",
+ "io-lifetimes 1.0.6",
  "rustix 0.36.9",
  "windows-sys 0.45.0",
 ]
@@ -1235,15 +1230,15 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.4"
+version = "0.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.1"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "lock_api"
@@ -1585,8 +1580,8 @@ dependencies = [
  "async-trait",
  "cached",
  "dirs",
- "fd-lock",
  "flate2",
+ "fs4",
  "human-sort",
  "lenient_semver",
  "miette",
@@ -1793,29 +1788,29 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
+version = "0.35.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727a1a6d65f786ec22df8a81ca3121107f235970dc1705ed681d3e6e8b9cd5f9"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes 0.7.5",
+ "libc",
+ "linux-raw-sys 0.0.46",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "rustix"
 version = "0.36.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
 dependencies = [
  "bitflags",
- "errno 0.2.8",
- "io-lifetimes",
+ "errno",
+ "io-lifetimes 1.0.6",
  "libc",
  "linux-raw-sys 0.1.4",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "rustix"
-version = "0.37.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aae838e49b3d63e9274e1c01833cc8139d3fec468c3b84688c628f44b1ae11d"
-dependencies = [
- "bitflags",
- "errno 0.3.1",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.3.1",
  "windows-sys 0.45.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ reqwest = { version = "0.11.16", default-features = false, features = ["rustls-t
 rustc-hash = "1.1.0"
 serde = { version = "1.0.159", features = ["derive"] }
 serde_json = "1.0.95"
-starbase_utils = { version = "0.2.2", default-features = false, features = ["json", "toml"] }
+starbase_utils = { version = "0.2.3", default-features = false, features = ["json", "toml"] }
 thiserror = "1.0.40"
 tokio = { version = "1.27.0", features = ["full", "tracing"] }
 tracing = "0.1.37"

--- a/crates/cli/src/commands/clean.rs
+++ b/crates/cli/src/commands/clean.rs
@@ -105,7 +105,7 @@ pub async fn clean(days: Option<u8>) -> SystemResult {
                 count,
                 versions_to_clean
                     .iter()
-                    .map(|v| color::id(v))
+                    .map(color::id)
                     .collect::<Vec<_>>()
                     .join(", ")
             ))

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/moonrepo/proto"
 async-trait = "0.1.68"
 cached = { workspace = true }
 dirs = "5.0.0"
+fd-lock = "3.0.12"
 flate2 = "1.0.25"
 human-sort = "0.2.2"
 lenient_semver = { version = "0.4.2", default-features = false, features = ["version_lite"] }
@@ -21,7 +22,7 @@ semver = "1.0.17"
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.10.6"
-starbase_styles = "0.1.3"
+starbase_styles = "0.1.4"
 starbase_utils = { workspace = true }
 tar = "0.4.38"
 tinytemplate = "1.2.1"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -11,8 +11,9 @@ repository = "https://github.com/moonrepo/proto"
 async-trait = "0.1.68"
 cached = { workspace = true }
 dirs = "5.0.0"
-fd-lock = "3.0.12"
+# fd-lock = "3.0.12"
 flate2 = "1.0.25"
+fs4 = { version = "0.6.3", features = ["sync"] }
 human-sort = "0.2.2"
 lenient_semver = { version = "0.4.2", default-features = false, features = ["version_lite"] }
 miette = { workspace = true }


### PR DESCRIPTION
Have noticed some race conditions, especially when multiple processes are running in parallel. Let's try locking.