### PR TITLE
new: Update `proto use` to detect from the ecosystem.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 #### 🚀 Updates
 
+- Updated `proto use` to also install tools based on environment/ecosystem config in the current working directory.
+  - For example, will install a `packageManager` from `package.json`.
 - Updated shims to only be created on initial install, or when the internal API changes, instead of always.
 
 #### 🐞 Fixes

--- a/crates/cli/src/bin.rs
+++ b/crates/cli/src/bin.rs
@@ -65,7 +65,7 @@ async fn run(
         Commands::Unalias { tool, alias } => commands::unalias(tool, alias).await?,
         Commands::Uninstall { tool, semver } => commands::uninstall(tool, semver).await?,
         Commands::Upgrade => commands::upgrade().await?,
-        Commands::Use => commands::install_all(tools_config).await?,
+        Commands::Use => commands::install_all(tools_config, user_config).await?,
     };
 }
 

--- a/crates/cli/src/commands/install_all.rs
+++ b/crates/cli/src/commands/install_all.rs
@@ -1,30 +1,61 @@
 use crate::helpers::{disable_progress_bars, enable_progress_bars};
-use crate::states::ToolsConfig;
-use crate::tools::ToolType;
+use crate::states::{ToolsConfig, UserConfig};
+use crate::tools::{create_plugin_from_locator, create_tool, ToolType};
 use crate::{commands::clean::clean, commands::install::install, helpers::create_progress_bar};
 use futures::future::try_join_all;
-use proto::{create_plugin_from_locator, Proto, UserConfig};
-use proto_core::{ProtoError, TOOLS_CONFIG_NAME};
+use proto_core::Proto;
+use rustc_hash::FxHashMap;
 use starbase::SystemResult;
+use std::env;
+use std::path::PathBuf;
 use std::str::FromStr;
-use tracing::info;
+use strum::IntoEnumIterator;
+use tracing::{debug, info};
 
-pub async fn install_all(tools_config: &ToolsConfig) -> SystemResult {
-    let Some(config) = &tools_config.0 else {
-        return Err(ProtoError::MissingConfig(TOOLS_CONFIG_NAME.to_owned()))?;
-    };
+pub async fn install_all(tools_config: &ToolsConfig, user_config: &UserConfig) -> SystemResult {
+    let mut tools = FxHashMap::default();
+    let mut plugins = FxHashMap::default();
+    let mut config_dir = PathBuf::new();
+    let working_dir = env::current_dir().expect("Missing current directory.");
 
-    if !config.tools.is_empty() {
+    // Inherit from .prototools
+    if let Some(config) = &tools_config.0 {
+        debug!(config = %config.path.display(), "Detecting tools and plugins from .prototools");
+
+        if !config.tools.is_empty() {
+            tools.extend(config.tools.clone());
+        }
+
+        if !config.plugins.is_empty() {
+            plugins.extend(config.plugins.clone());
+            config_dir = config.path.parent().unwrap().to_path_buf();
+        }
+    }
+
+    // Detect from working dir
+    debug!("Detecting tools from environment");
+
+    for tool_type in ToolType::iter() {
+        let tool = create_tool(&tool_type).await?;
+
+        if let Some(version) = tool.detect_version_from(&working_dir).await? {
+            debug!(version, "Detected version for {}", tool.get_name());
+
+            tools.insert(tool.get_bin_name().to_owned(), version);
+        }
+    }
+
+    if !tools.is_empty() {
         let mut futures = vec![];
         let pb = create_progress_bar(format!(
             "Installing {} tools: {}",
-            config.tools.len(),
-            config.tools.keys().cloned().collect::<Vec<_>>().join(", ")
+            tools.len(),
+            tools.keys().cloned().collect::<Vec<_>>().join(", ")
         ));
 
         disable_progress_bars();
 
-        for (tool, version) in &config.tools {
+        for (tool, version) in &tools {
             futures.push(install(
                 ToolType::from_str(tool)?,
                 Some(version.to_owned()),
@@ -34,30 +65,27 @@ pub async fn install_all(tools_config: &ToolsConfig) -> SystemResult {
         }
 
         try_join_all(futures).await?;
+
         enable_progress_bars();
 
         pb.finish_and_clear();
     }
 
-    if !config.plugins.is_empty() {
+    if !plugins.is_empty() {
+        let proto = Proto::new()?;
         let mut futures = vec![];
         let pb = create_progress_bar(format!(
             "Installing {} plugins: {}",
-            config.plugins.len(),
-            config
-                .plugins
-                .keys()
-                .cloned()
-                .collect::<Vec<_>>()
-                .join(", ")
+            plugins.len(),
+            plugins.keys().cloned().collect::<Vec<_>>().join(", ")
         ));
 
-        for (name, locator) in &config.plugins {
+        for (name, locator) in &plugins {
             futures.push(create_plugin_from_locator(
                 name,
-                Proto::new()?,
+                &proto,
                 locator,
-                config.path.parent().unwrap(),
+                &config_dir,
             ));
         }
 
@@ -66,7 +94,7 @@ pub async fn install_all(tools_config: &ToolsConfig) -> SystemResult {
         pb.finish_and_clear();
     }
 
-    if UserConfig::load()?.auto_clean {
+    if user_config.0.auto_clean {
         info!("Auto-clean enabled");
         clean(None, true).await?;
     }

--- a/crates/cli/src/commands/install_all.rs
+++ b/crates/cli/src/commands/install_all.rs
@@ -36,6 +36,10 @@ pub async fn install_all(tools_config: &ToolsConfig, user_config: &UserConfig) -
     debug!("Detecting tools from environment");
 
     for tool_type in ToolType::iter() {
+        if matches!(tool_type, ToolType::Plugin(_)) {
+            continue;
+        }
+
         let tool = create_tool(&tool_type).await?;
 
         if let Some(version) = tool.detect_version_from(&working_dir).await? {
@@ -94,8 +98,14 @@ pub async fn install_all(tools_config: &ToolsConfig, user_config: &UserConfig) -
         pb.finish_and_clear();
     }
 
+    if tools.is_empty() && plugins.is_empty() {
+        info!("Nothing to install!")
+    } else {
+        info!("Successfully installed tools and plugins");
+    }
+
     if user_config.0.auto_clean {
-        info!("Auto-clean enabled");
+        debug!("Auto-clean enabled, starting clean");
         clean(None, true).await?;
     }
 

--- a/crates/cli/tests/use_test.rs
+++ b/crates/cli/tests/use_test.rs
@@ -56,3 +56,18 @@ fn installs_all_plugins() {
 
     assert!(moon_path.exists());
 }
+
+#[test]
+fn installs_tool_via_detection() {
+    let temp = create_temp_dir();
+    let node_path = temp.join("tools/node/19.0.0");
+
+    fs::write(temp.path().join(".nvmrc"), "19.0.0").unwrap();
+
+    assert!(!node_path.exists());
+
+    let mut cmd = create_proto_command(temp.path());
+    cmd.arg("use").assert().success();
+
+    assert!(node_path.exists());
+}

--- a/crates/cli/tests/use_test.rs
+++ b/crates/cli/tests/use_test.rs
@@ -5,18 +5,6 @@ use std::fs;
 use utils::*;
 
 #[test]
-fn errors_if_no_config() {
-    let temp = create_temp_dir();
-
-    let mut cmd = create_proto_command(temp.path());
-    let assert = cmd.arg("use").assert();
-
-    assert.stderr(predicate::str::contains(
-        "Could not locate a .prototools configuration file.",
-    ));
-}
-
-#[test]
 fn installs_all_tools() {
     let temp = create_temp_dir();
     let node_path = temp.join("tools/node/19.0.0");

--- a/crates/schema-plugin/Cargo.toml
+++ b/crates/schema-plugin/Cargo.toml
@@ -3,7 +3,7 @@ name = "proto_schema_plugin"
 version = "0.2.2"
 edition = "2021"
 license = "MIT"
-description = "A TOML schema plugin for proto."
+description = "A schema plugin for proto, with TOML support."
 homepage = "https://moonrepo.dev/proto"
 repository = "https://github.com/moonrepo/proto"
 

--- a/crates/schema-plugin/README.md
+++ b/crates/schema-plugin/README.md
@@ -2,4 +2,4 @@
 
 ![Crates.io](https://img.shields.io/crates/v/proto_schema_plugin) ![Crates.io](https://img.shields.io/crates/d/proto_schema_plugin)
 
-A plugin for [proto](https://moonrepo.dev/proto) that utilizes a TOML schema.
+A plugin for [proto](https://moonrepo.dev/proto) that is powered by a configuration schema, with initial TOML support.


### PR DESCRIPTION
Alongside installing `.prototools`, the `use` command will also detect versions based on cwd.