### PR TITLE
fix: Don't create shim if it already exists.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+#### 🐞 Fixes
+
+- Temporary fix for "text file busy" error when creating shims.
+
 ## 0.7.1
 
 #### 🐞 Fixes

--- a/crates/core/src/shimmer.rs
+++ b/crates/core/src/shimmer.rs
@@ -180,6 +180,11 @@ impl ShimBuilder {
     fn do_create(&self, shim_path: PathBuf, contents: &str) -> Result<PathBuf, ProtoError> {
         let shim_exists = shim_path.exists();
 
+        // Temporary until we can version shims!
+        if shim_exists {
+            return Ok(shim_path);
+        }
+
         if let Some(parent) = shim_path.parent() {
             fs::create_dir_all(parent)?;
         }


### PR DESCRIPTION
I think this is currently causing a "text file busy" error.