### PR TITLE
fix: Sort versions during detection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+#### 🐞 Fixes
+
+- Installed versions are now sorted during detection, so that latest versions are always used first.
+
 ## 0.8.0
 
 #### 🚀 Updates


### PR DESCRIPTION
We should always use the latest applicable version.