### PR TITLE
new: Add `install.unpack` schema setting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+#### 🚀 Updates
+
+- Added `install.unpack` setting to TOML plugin.
+
 ## 0.8.3
 
 #### 🐞 Fixes

--- a/crates/cli/tests/fixtures/moon-schema.toml
+++ b/crates/cli/tests/fixtures/moon-schema.toml
@@ -13,6 +13,7 @@ download-file = "moon-{arch}-pc-windows-msvc.exe"
 
 [install]
 download-url = "https://github.com/moonrepo/moon/releases/download/v{version}/{download_file}"
+unpack = false
 
 [resolve]
 git-url = "https://github.com/moonrepo/moon"

--- a/crates/core/src/installer.rs
+++ b/crates/core/src/installer.rs
@@ -41,7 +41,7 @@ pub trait Installable<'tool>: Send + Sync + Describable<'tool> {
             "Attempting to install tool",
         );
 
-        if unpack(download_path, install_dir, prefix)? {
+        if self.should_unpack() && unpack(download_path, install_dir, prefix)? {
             // Unpacked archive
         } else {
             let install_path = install_dir.join(if cfg!(windows) {
@@ -58,6 +58,11 @@ pub trait Installable<'tool>: Send + Sync + Describable<'tool> {
         debug!("Successfully installed tool");
 
         Ok(true)
+    }
+
+    /// Whether or not the downloaded file should be unpacked before installing.
+    fn should_unpack(&self) -> bool {
+        true
     }
 
     /// Uninstall the tool by deleting the install directory.

--- a/crates/schema-plugin/src/install.rs
+++ b/crates/schema-plugin/src/install.rs
@@ -15,4 +15,8 @@ impl Installable<'_> for SchemaPlugin {
     fn get_install_dir(&self) -> Result<PathBuf, ProtoError> {
         Ok(self.base_dir.join(self.get_resolved_version()))
     }
+
+    fn should_unpack(&self) -> bool {
+        self.schema.install.unpack
+    }
 }

--- a/crates/schema-plugin/src/schema.rs
+++ b/crates/schema-plugin/src/schema.rs
@@ -17,15 +17,29 @@ pub struct DetectSchema {
     pub version_files: Option<Vec<String>>,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct InstallSchema {
     pub arch: FxHashMap<String, String>,
     pub checksum_url: Option<String>,
     pub download_url: String,
+    pub unpack: bool,
     // Global bins
     pub global_args: Option<Vec<String>>,
     pub globals_dir: Vec<String>,
+}
+
+impl Default for InstallSchema {
+    fn default() -> Self {
+        InstallSchema {
+            arch: FxHashMap::default(),
+            checksum_url: None,
+            download_url: String::new(),
+            unpack: true,
+            global_args: None,
+            globals_dir: vec![],
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
Some tools aren't archived, so we need to avoid unpacking.