### PR TITLE
internal: Clean up bin name/ID confusion.

### DIFF
--- a/crates/bun/src/execute.rs
+++ b/crates/bun/src/execute.rs
@@ -1,23 +1,13 @@
 use crate::BunLanguage;
-use proto_core::{async_trait, get_home_dir, Describable, Executable, Installable, ProtoError};
+use proto_core::{
+    async_trait, get_bin_name, get_home_dir, Describable, Executable, Installable, ProtoError,
+};
 use std::path::{Path, PathBuf};
-
-#[cfg(target_os = "windows")]
-pub fn get_bin_name<T: AsRef<str>>(name: T) -> String {
-    format!("{}.exe", name.as_ref())
-}
-
-#[cfg(not(target_os = "windows"))]
-pub fn get_bin_name<T: AsRef<str>>(name: T) -> String {
-    name.as_ref().to_string()
-}
 
 #[async_trait]
 impl Executable<'_> for BunLanguage {
     async fn find_bin_path(&mut self) -> Result<(), ProtoError> {
-        let bin_path = self
-            .get_install_dir()?
-            .join(get_bin_name(self.get_bin_name()));
+        let bin_path = self.get_install_dir()?.join(get_bin_name("bun"));
 
         if bin_path.exists() {
             self.bin_path = Some(bin_path);

--- a/crates/bun/src/lib.rs
+++ b/crates/bun/src/lib.rs
@@ -39,7 +39,7 @@ impl BunLanguage {
 }
 
 impl Describable<'_> for BunLanguage {
-    fn get_bin_name(&self) -> &str {
+    fn get_id(&self) -> &str {
         "bun"
     }
 

--- a/crates/bun/src/shim.rs
+++ b/crates/bun/src/shim.rs
@@ -7,7 +7,7 @@ use proto_core::{
 #[async_trait]
 impl Shimable<'_> for BunLanguage {
     async fn create_shims(&mut self, _find_only: bool) -> Result<(), ProtoError> {
-        let mut shimmer = ShimBuilder::new(self.get_bin_name(), self.get_bin_path()?);
+        let mut shimmer = ShimBuilder::new(self.get_id(), self.get_bin_path()?);
 
         shimmer
             .dir(self.get_install_dir()?)

--- a/crates/cli/src/commands/install_all.rs
+++ b/crates/cli/src/commands/install_all.rs
@@ -50,7 +50,7 @@ pub async fn install_all(
             if let Some(version) = expand_detected_version(&version, tool.get_manifest()?)? {
                 debug!(version, "Detected version for {}", tool.get_name());
 
-                tools.insert(tool.get_bin_name().to_owned(), version);
+                tools.insert(tool.get_id().to_owned(), version);
             }
         }
     }

--- a/crates/cli/src/commands/install_global.rs
+++ b/crates/cli/src/commands/install_global.rs
@@ -11,7 +11,7 @@ use tracing::{debug, info};
 async fn get_bin_or_fallback(tool: &mut Box<dyn Tool<'_>>) -> Result<PathBuf, ProtoError> {
     Ok(match tool.find_bin_path().await {
         Ok(_) => tool.get_bin_path()?.to_path_buf(),
-        Err(_) => PathBuf::from(tool.get_bin_name()),
+        Err(_) => PathBuf::from(tool.get_id()),
     })
 }
 

--- a/crates/cli/src/commands/local.rs
+++ b/crates/cli/src/commands/local.rs
@@ -12,7 +12,7 @@ pub async fn local(tool_type: ToolType, version: String) -> SystemResult {
 
     config
         .tools
-        .insert(tool.get_bin_name().to_owned(), version.clone());
+        .insert(tool.get_id().to_owned(), version.clone());
 
     config.save()?;
 

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -22,7 +22,7 @@ pub async fn run(
             return Err(ProtoError::MissingToolForRun(
                 tool.get_name(),
                 version.to_owned(),
-                color::shell(format!("proto install {} {}", tool.get_bin_name(), version)),
+                color::shell(format!("proto install {} {}", tool.get_id(), version)),
             ))?;
         }
 
@@ -57,11 +57,11 @@ pub async fn run(
     let status = Command::new(tool.get_bin_path()?)
         .args(&args)
         .env(
-            format!("PROTO_{}_VERSION", tool.get_bin_name().to_uppercase()),
+            format!("PROTO_{}_VERSION", tool.get_id().to_uppercase()),
             tool.get_resolved_version(),
         )
         .env(
-            format!("PROTO_{}_BIN", tool.get_bin_name().to_uppercase()),
+            format!("PROTO_{}_BIN", tool.get_id().to_uppercase()),
             tool.get_bin_path()?.to_string_lossy().to_string(),
         )
         .spawn()

--- a/crates/core/src/describer.rs
+++ b/crates/core/src/describer.rs
@@ -1,7 +1,8 @@
 #[async_trait::async_trait]
 pub trait Describable<'tool>: Send + Sync {
-    /// Return the tool's binary name. Will also be used in variables and file names.
-    fn get_bin_name(&self) -> &str;
+    /// Return an identifier for the tool. Will also be used in variables,
+    /// file names, and more.
+    fn get_id(&self) -> &str;
 
     /// Return a human readable name of the tool.
     fn get_name(&self) -> String;

--- a/crates/core/src/detector.rs
+++ b/crates/core/src/detector.rs
@@ -29,7 +29,7 @@ pub async fn detect_version<'l, T: Tool<'l> + ?Sized>(
     forced_version: Option<String>,
 ) -> Result<String, ProtoError> {
     let mut version = forced_version;
-    let env_var = format!("PROTO_{}_VERSION", tool.get_bin_name().to_uppercase());
+    let env_var = format!("PROTO_{}_VERSION", tool.get_id().to_uppercase());
 
     // Env var takes highest priority
     if version.is_none() {
@@ -68,7 +68,7 @@ pub async fn detect_version<'l, T: Tool<'l> + ?Sized>(
 
             let config = ToolsConfig::load_from(dir)?;
 
-            if let Some(local_version) = config.tools.get(tool.get_bin_name()) {
+            if let Some(local_version) = config.tools.get(tool.get_id()) {
                 debug!(
                     version = local_version,
                     file = %config.path.display(),
@@ -123,9 +123,7 @@ pub async fn detect_version<'l, T: Tool<'l> + ?Sized>(
     // We didn't find anything!
     match version {
         Some(ver) => Ok(ver),
-        None => Err(ProtoError::VersionDetectFailed(
-            tool.get_bin_name().to_owned(),
-        )),
+        None => Err(ProtoError::VersionDetectFailed(tool.get_id().to_owned())),
     }
 }
 

--- a/crates/core/src/executor.rs
+++ b/crates/core/src/executor.rs
@@ -16,3 +16,13 @@ pub trait Executable<'tool>: Send + Sync {
     /// globally installed packages.
     fn get_globals_bin_dir(&self) -> Result<PathBuf, ProtoError>;
 }
+
+#[cfg(target_os = "windows")]
+pub fn get_bin_name(name: &str) -> String {
+    format!("{}.exe", name)
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn get_bin_name(name: &str) -> String {
+    name.to_string()
+}

--- a/crates/core/src/installer.rs
+++ b/crates/core/src/installer.rs
@@ -45,9 +45,9 @@ pub trait Installable<'tool>: Send + Sync + Describable<'tool> {
             // Unpacked archive
         } else {
             let install_path = install_dir.join(if cfg!(windows) {
-                format!("{}.exe", self.get_bin_name())
+                format!("{}.exe", self.get_id())
             } else {
-                self.get_bin_name().to_string()
+                self.get_id().to_string()
             });
 
             // Not an archive, assume a binary and copy

--- a/crates/deno/src/execute.rs
+++ b/crates/deno/src/execute.rs
@@ -1,26 +1,16 @@
 use crate::DenoLanguage;
-use proto_core::{async_trait, get_home_dir, Describable, Executable, Installable, ProtoError};
+use proto_core::{
+    async_trait, get_bin_name, get_home_dir, Describable, Executable, Installable, ProtoError,
+};
 use std::{
     env,
     path::{Path, PathBuf},
 };
 
-#[cfg(target_os = "windows")]
-pub fn get_bin_name<T: AsRef<str>>(name: T) -> String {
-    format!("{}.exe", name.as_ref())
-}
-
-#[cfg(not(target_os = "windows"))]
-pub fn get_bin_name<T: AsRef<str>>(name: T) -> String {
-    name.as_ref().to_string()
-}
-
 #[async_trait]
 impl Executable<'_> for DenoLanguage {
     async fn find_bin_path(&mut self) -> Result<(), ProtoError> {
-        let bin_path = self
-            .get_install_dir()?
-            .join(get_bin_name(self.get_bin_name()));
+        let bin_path = self.get_install_dir()?.join(get_bin_name("deno"));
 
         if bin_path.exists() {
             self.bin_path = Some(bin_path);

--- a/crates/deno/src/lib.rs
+++ b/crates/deno/src/lib.rs
@@ -39,7 +39,7 @@ impl DenoLanguage {
 }
 
 impl Describable<'_> for DenoLanguage {
-    fn get_bin_name(&self) -> &str {
+    fn get_id(&self) -> &str {
         "deno"
     }
 

--- a/crates/deno/src/shim.rs
+++ b/crates/deno/src/shim.rs
@@ -7,7 +7,7 @@ use proto_core::{
 #[async_trait]
 impl Shimable<'_> for DenoLanguage {
     async fn create_shims(&mut self, _find_only: bool) -> Result<(), ProtoError> {
-        let mut shimmer = ShimBuilder::new(self.get_bin_name(), self.get_bin_path()?);
+        let mut shimmer = ShimBuilder::new(self.get_id(), self.get_bin_path()?);
 
         shimmer
             .dir(self.get_install_dir()?)

--- a/crates/go/src/execute.rs
+++ b/crates/go/src/execute.rs
@@ -1,26 +1,16 @@
 use crate::GoLanguage;
-use proto_core::{async_trait, get_home_dir, Describable, Executable, Installable, ProtoError};
+use proto_core::{
+    async_trait, get_bin_name, get_home_dir, Describable, Executable, Installable, ProtoError,
+};
 use std::{
     env,
     path::{Path, PathBuf},
 };
 
-#[cfg(target_os = "windows")]
-pub fn get_bin_name<T: AsRef<str>>(name: T) -> String {
-    format!("bin/{}.exe", name.as_ref())
-}
-
-#[cfg(not(target_os = "windows"))]
-pub fn get_bin_name<T: AsRef<str>>(name: T) -> String {
-    format!("bin/{}", name.as_ref())
-}
-
 #[async_trait]
 impl Executable<'_> for GoLanguage {
     async fn find_bin_path(&mut self) -> Result<(), ProtoError> {
-        let bin_path = self
-            .get_install_dir()?
-            .join(get_bin_name(self.get_bin_name()));
+        let bin_path = self.get_install_dir()?.join("bin").join(get_bin_name("go"));
 
         if bin_path.exists() {
             self.bin_path = Some(bin_path);

--- a/crates/go/src/lib.rs
+++ b/crates/go/src/lib.rs
@@ -39,7 +39,7 @@ impl GoLanguage {
 }
 
 impl Describable<'_> for GoLanguage {
-    fn get_bin_name(&self) -> &str {
+    fn get_id(&self) -> &str {
         "go"
     }
 

--- a/crates/go/src/shim.rs
+++ b/crates/go/src/shim.rs
@@ -7,7 +7,7 @@ use proto_core::{
 #[async_trait]
 impl Shimable<'_> for GoLanguage {
     async fn create_shims(&mut self, _find_only: bool) -> Result<(), ProtoError> {
-        let mut shimmer = ShimBuilder::new(self.get_bin_name(), self.get_bin_path()?);
+        let mut shimmer = ShimBuilder::new(self.get_id(), self.get_bin_path()?);
 
         shimmer
             .dir(self.get_install_dir()?)

--- a/crates/node/src/depman/mod.rs
+++ b/crates/node/src/depman/mod.rs
@@ -71,7 +71,7 @@ impl NodeDependencyManager {
 }
 
 impl Describable<'_> for NodeDependencyManager {
-    fn get_bin_name(&self) -> &str {
+    fn get_id(&self) -> &str {
         &self.package_name
     }
 

--- a/crates/node/src/execute.rs
+++ b/crates/node/src/execute.rs
@@ -15,9 +15,7 @@ pub fn get_bin_name<T: AsRef<str>>(name: T) -> String {
 #[async_trait]
 impl Executable<'_> for NodeLanguage {
     async fn find_bin_path(&mut self) -> Result<(), ProtoError> {
-        let bin_path = self
-            .get_install_dir()?
-            .join(get_bin_name(self.get_bin_name()));
+        let bin_path = self.get_install_dir()?.join(get_bin_name(self.get_id()));
 
         if bin_path.exists() {
             self.bin_path = Some(bin_path);

--- a/crates/node/src/execute.rs
+++ b/crates/node/src/execute.rs
@@ -15,7 +15,7 @@ pub fn get_bin_name<T: AsRef<str>>(name: T) -> String {
 #[async_trait]
 impl Executable<'_> for NodeLanguage {
     async fn find_bin_path(&mut self) -> Result<(), ProtoError> {
-        let bin_path = self.get_install_dir()?.join(get_bin_name(self.get_id()));
+        let bin_path = self.get_install_dir()?.join(get_bin_name("node"));
 
         if bin_path.exists() {
             self.bin_path = Some(bin_path);

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -44,7 +44,7 @@ impl NodeLanguage {
 }
 
 impl Describable<'_> for NodeLanguage {
-    fn get_bin_name(&self) -> &str {
+    fn get_id(&self) -> &str {
         "node"
     }
 

--- a/crates/node/src/shim.rs
+++ b/crates/node/src/shim.rs
@@ -31,7 +31,7 @@ $NpxBin = $NodeBin.replace("node.exe", "npx.cmd")
 #[async_trait]
 impl Shimable<'_> for NodeLanguage {
     async fn create_shims(&mut self, _find_only: bool) -> Result<(), ProtoError> {
-        let mut shimmer = ShimBuilder::new(self.get_bin_name(), self.get_bin_path()?);
+        let mut shimmer = ShimBuilder::new(self.get_id(), self.get_bin_path()?);
 
         shimmer
             .dir(self.get_install_dir()?)

--- a/crates/rust/src/install.rs
+++ b/crates/rust/src/install.rs
@@ -1,6 +1,5 @@
-use crate::RustLanguage;
-use proto_core::{async_trait, color, is_musl, Installable, ProtoError, Resolvable};
-use std::env::consts;
+use crate::{get_triple_target, RustLanguage};
+use proto_core::{async_trait, color, Installable, ProtoError, Resolvable};
 use std::path::{Path, PathBuf};
 use tokio::process::Command;
 use tracing::debug;
@@ -49,16 +48,7 @@ impl Installable<'_> for RustLanguage {
     }
 
     fn get_install_dir(&self) -> Result<PathBuf, ProtoError> {
-        let target = match consts::OS {
-            "linux" => format!(
-                "{}-unknown-linux-{}",
-                consts::ARCH,
-                if is_musl() { "musl" } else { "gnu" }
-            ),
-            "macos" => format!("{}-apple-darwin", consts::ARCH),
-            "windows" => format!("{}-pc-windows-msvc", consts::ARCH),
-            other => return Err(ProtoError::UnsupportedPlatform("Rust".into(), other.into())),
-        };
+        let target = get_triple_target()?;
 
         // ~/.rustup/toolchains/1.68.0-aarch64-apple-darwin
         Ok(self

--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -41,7 +41,7 @@ impl RustLanguage {
 
 impl Describable<'_> for RustLanguage {
     // This is actually an ID, not the actual bin name... revisit!
-    fn get_bin_name(&self) -> &str {
+    fn get_id(&self) -> &str {
         "rust"
     }
 

--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -7,9 +7,10 @@ mod shim;
 mod verify;
 
 use once_cell::sync::OnceCell;
-use proto_core::{impl_tool, Describable, Manifest, Proto, ProtoError, Tool};
+use proto_core::{impl_tool, is_musl, Describable, Manifest, Proto, ProtoError, Tool};
 use std::{
     any::Any,
+    env::consts,
     path::{Path, PathBuf},
 };
 
@@ -51,3 +52,16 @@ impl Describable<'_> for RustLanguage {
 }
 
 impl_tool!(RustLanguage);
+
+pub fn get_triple_target() -> Result<String, ProtoError> {
+    Ok(match consts::OS {
+        "linux" => format!(
+            "{}-unknown-linux-{}",
+            consts::ARCH,
+            if is_musl() { "musl" } else { "gnu" }
+        ),
+        "macos" => format!("{}-apple-darwin", consts::ARCH),
+        "windows" => format!("{}-pc-windows-msvc", consts::ARCH),
+        other => return Err(ProtoError::UnsupportedPlatform("Rust".into(), other.into())),
+    })
+}

--- a/crates/schema-plugin/src/execute.rs
+++ b/crates/schema-plugin/src/execute.rs
@@ -1,5 +1,7 @@
 use crate::SchemaPlugin;
-use proto_core::{async_trait, get_home_dir, Describable, Executable, Installable, ProtoError};
+use proto_core::{
+    async_trait, get_bin_name, get_home_dir, Describable, Executable, Installable, ProtoError,
+};
 use std::{
     env,
     path::{Path, PathBuf},
@@ -17,11 +19,7 @@ impl Executable<'_> for SchemaPlugin {
         }
 
         if bin.is_none() {
-            bin = Some(if cfg!(windows) {
-                format!("{}.exe", self.get_bin_name())
-            } else {
-                self.get_bin_name().to_owned()
-            });
+            bin = Some(get_bin_name(self.get_id()));
         }
 
         let bin_path = self.get_install_dir()?.join(bin.unwrap());
@@ -62,8 +60,6 @@ impl Executable<'_> for SchemaPlugin {
             }
         }
 
-        Ok(home_dir
-            .join(format!(".{}", self.get_bin_name()))
-            .join("bin"))
+        Ok(home_dir.join(format!(".{}", self.get_id())).join("bin"))
     }
 }

--- a/crates/schema-plugin/src/lib.rs
+++ b/crates/schema-plugin/src/lib.rs
@@ -84,7 +84,7 @@ impl SchemaPlugin {
 }
 
 impl Describable<'_> for SchemaPlugin {
-    fn get_bin_name(&self) -> &str {
+    fn get_id(&self) -> &str {
         &self.id
     }
 

--- a/crates/schema-plugin/src/schema.rs
+++ b/crates/schema-plugin/src/schema.rs
@@ -94,7 +94,6 @@ pub enum SchemaToolType {
 #[derive(Debug, Default, Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct Schema {
-    pub bin: String,
     pub name: String,
     #[serde(rename = "type")]
     pub type_of: SchemaToolType,

--- a/crates/schema-plugin/src/shim.rs
+++ b/crates/schema-plugin/src/shim.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 #[async_trait]
 impl Shimable<'_> for SchemaPlugin {
     async fn create_shims(&mut self, find_only: bool) -> Result<(), ProtoError> {
-        let mut shimmer = ShimBuilder::new(self.get_bin_name(), self.get_bin_path()?);
+        let mut shimmer = ShimBuilder::new(self.get_id(), self.get_bin_path()?);
         let schema = &self.schema.shim;
 
         shimmer

--- a/crates/schema-plugin/tests/schema_test.rs
+++ b/crates/schema-plugin/tests/schema_test.rs
@@ -14,7 +14,6 @@ use std::path::Path;
 
 fn create_plugin(dir: &Path, mut schema: Schema) -> SchemaPlugin {
     schema.name = "moon".into();
-    schema.bin = "moon".into();
 
     let mut tool = SchemaPlugin::new(Proto::from(dir), "moon".into(), schema);
     tool.version = Some("1.0.0".into());


### PR DESCRIPTION
Our API called it bin name, but that's not really what it was. It was the general tool ID used as a reference.