### PR TITLE
fix: Fix `proto upgrade` on Windows.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+#### 🐞 Fixes
+
+- Fixed an issue where `proto upgrade` would fail on Windows.
+
 ## 0.10.2
 
 #### 🐞 Fixes


### PR DESCRIPTION
The unzip creates `temp/proto.exe` instead of `temp/<target>/proto.exe`, which tar uses. This updates upgrade to check both patterns.