### PR TITLE
new: Add a `--log` option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### 🚀 Updates
 
 - Added shim support for `bunx` (bun), `pnpx` (pnpm), and `yarnpkg` (yarn).
+- Added a global `--log` option to all commands.
 - Improved tracing log messages.
 
 #### ⚙️ Internal

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -5,7 +5,7 @@ name = "proto_cli"
 version = "0.10.6"
 edition = "2021"
 license = "MIT"
-description = "A language agnostic version manager."
+description = "A multi-language toolchain and version manager."
 homepage = "https://moonrepo.dev/proto"
 repository = "https://github.com/moonrepo/proto"
 keywords = ["language", "installer", "version-manager", "dependency-manager", "package-manager"]
@@ -35,7 +35,7 @@ proto_node = { version = "0.9.3", path = "../node" }
 proto_rust = { version = "0.7.2", path = "../rust" }
 proto_schema_plugin = { version = "0.5.2", path = "../schema-plugin" }
 async-recursion = "1.0.4"
-clap = { workspace = true, features = ["derive"] }
+clap = { workspace = true, features = ["derive", "env"] }
 clap_complete = { workspace = true }
 convert_case = { workspace = true }
 dialoguer = "0.10.4"

--- a/crates/cli/src/app.rs
+++ b/crates/cli/src/app.rs
@@ -1,6 +1,17 @@
 use crate::tools::ToolType;
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use clap_complete::Shell;
+
+#[derive(ValueEnum, Clone, Debug, Default)]
+pub enum LogLevel {
+    Off,
+    Error,
+    Warn,
+    #[default]
+    Info,
+    Debug,
+    Trace,
+}
 
 #[derive(Debug, Parser)]
 #[command(
@@ -11,9 +22,19 @@ use clap_complete::Shell;
     disable_colored_help = true,
     disable_help_subcommand = true,
     propagate_version = true,
-    next_line_help = false
+    next_line_help = false,
+    rename_all = "camelCase"
 )]
 pub struct App {
+    #[arg(
+        value_enum,
+        long,
+        global = true,
+        env = "PROTO_LOG",
+        help = "Lowest log level to output"
+    )]
+    pub log: Option<LogLevel>,
+
     #[command(subcommand)]
     pub command: Commands,
 }

--- a/crates/cli/src/bin.rs
+++ b/crates/cli/src/bin.rs
@@ -8,6 +8,7 @@ pub mod tools;
 
 use app::{App as CLI, Commands};
 use clap::Parser;
+use miette::IntoDiagnostic;
 use proto_core::{ToolsConfig as InnerToolsConfig, UserConfig as InnerUserConfig};
 use starbase::{system, tracing::TracingOptions, App, MainResult, State};
 use starbase_utils::string_vec;
@@ -94,7 +95,7 @@ async fn main() -> MainResult {
 
     App::setup_tracing_with_options(TracingOptions {
         default_level: if let Some(level) = cli.log {
-            LevelFilter::from_str(&format!("{:?}", level)).unwrap()
+            LevelFilter::from_str(format!("{:?}", level).as_ref()).into_diagnostic()?
         } else if matches!(cli.command, Commands::Bin { .. } | Commands::Run { .. }) {
             LevelFilter::WARN
         } else if matches!(cli.command, Commands::Completions { .. }) {

--- a/crates/cli/src/bin.rs
+++ b/crates/cli/src/bin.rs
@@ -13,6 +13,7 @@ use starbase::{system, tracing::TracingOptions, App, MainResult, State};
 use starbase_utils::string_vec;
 use states::{PluginList, ToolsConfig, UserConfig};
 use std::env;
+use std::str::FromStr;
 use tracing::metadata::LevelFilter;
 
 #[derive(State)]
@@ -92,7 +93,9 @@ async fn main() -> MainResult {
     let cli = CLI::parse();
 
     App::setup_tracing_with_options(TracingOptions {
-        default_level: if matches!(cli.command, Commands::Bin { .. } | Commands::Run { .. }) {
+        default_level: if let Some(level) = cli.log {
+            LevelFilter::from_str(&format!("{:?}", level)).unwrap()
+        } else if matches!(cli.command, Commands::Bin { .. } | Commands::Run { .. }) {
             LevelFilter::WARN
         } else if matches!(cli.command, Commands::Completions { .. }) {
             LevelFilter::OFF

--- a/crates/core/src/shimmer.rs
+++ b/crates/core/src/shimmer.rs
@@ -161,7 +161,7 @@ pub fn create_global_shim<'tool, C: AsRef<ShimContext<'tool>>>(
     create_global_shim_with_name(context.as_ref(), context.as_ref().bin)
 }
 
-#[tracing::instrument(skip_all)]
+#[tracing::instrument(name = "create_global_shim", skip_all)]
 pub fn create_global_shim_with_name<'tool, C: AsRef<ShimContext<'tool>>>(
     context: C,
     name: &str,


### PR DESCRIPTION
We supported `PROTO_LOG`, but it wasn't very discoverable. So this adds an option.