### PR TITLE
fix: Remove space after gt lt gte lte in detector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2413,6 +2413,7 @@ dependencies = [
  "lenient_semver",
  "miette",
  "pathdiff",
+ "regex",
  "reqwest",
  "rustc-hash",
  "semver",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -19,6 +19,7 @@ human-sort = { workspace = true }
 lenient_semver = { version = "0.4.2", default-features = false, features = ["version_lite"] }
 miette = { workspace = true }
 pathdiff = "0.2.1"
+regex = { workspace = true }
 reqwest = { workspace = true }
 rustc-hash = { workspace = true }
 semver = { workspace = true }

--- a/crates/core/src/detector.rs
+++ b/crates/core/src/detector.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::borrowed_box)]
 
 use crate::errors::ProtoError;
-use crate::helpers::{is_alias_name, remove_v_prefix, remove_space_after_gtlt};
+use crate::helpers::{is_alias_name, remove_space_after_gtlt, remove_v_prefix};
 use crate::manifest::Manifest;
 use crate::tool::Tool;
 use crate::tools_config::ToolsConfig;

--- a/crates/core/src/detector.rs
+++ b/crates/core/src/detector.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::borrowed_box)]
 
 use crate::errors::ProtoError;
-use crate::helpers::{is_alias_name, remove_v_prefix};
+use crate::helpers::{is_alias_name, remove_v_prefix, remove_space_after_gtlt};
 use crate::manifest::Manifest;
 use crate::tool::Tool;
 use crate::tools_config::ToolsConfig;
@@ -144,7 +144,7 @@ pub fn expand_detected_version(
         return Ok(Some(version.to_owned()));
     }
 
-    let version = remove_v_prefix(&version.replace(".*", ""));
+    let version = remove_space_after_gtlt(&remove_v_prefix(&version.replace(".*", "")));
     let mut fully_qualified = false;
     let mut maybe_version = String::new();
 

--- a/crates/core/src/helpers.rs
+++ b/crates/core/src/helpers.rs
@@ -59,6 +59,11 @@ pub fn remove_v_prefix(value: &str) -> String {
     value.to_owned()
 }
 
+pub fn remove_space_after_gtlt(value: &str) -> String {
+    let pattern = regex::Regex::new(r"([><]=?)\s+(\d)").unwrap();
+    pattern.replace_all(value, "$1$2").to_string()
+}
+
 #[cached(time = 300)]
 #[tracing::instrument]
 pub fn is_offline() -> bool {

--- a/crates/core/tests/detector_test.rs
+++ b/crates/core/tests/detector_test.rs
@@ -467,6 +467,69 @@ mod expanded_version {
     }
 
     #[test]
+    fn handles_gt_gte_with_space() {
+        let temp = create_empty_sandbox();
+        let manifest_path = create_manifest(
+            temp.path(),
+            Manifest {
+                installed_versions: FxHashSet::from_iter(["1.5.9".into()]),
+                ..Manifest::default()
+            },
+        );
+
+        assert_eq!(
+            expand_detected_version(">= 1.5.9", &Manifest::load(&manifest_path).unwrap())
+                .unwrap()
+                .unwrap(),
+            "1.5.9"
+        );
+        assert_eq!(
+            expand_detected_version("> 1.5.0", &Manifest::load(&manifest_path).unwrap())
+                .unwrap()
+                .unwrap(),
+            "1.5.9"
+        );
+        assert_eq!(
+            expand_detected_version(">= 1.2", &Manifest::load(&manifest_path).unwrap())
+                .unwrap()
+                .unwrap(),
+            "1.5.9"
+        );
+        assert_eq!(
+            expand_detected_version("> 1.2", &Manifest::load(&manifest_path).unwrap())
+                .unwrap()
+                .unwrap(),
+            "1.5.9"
+        );
+        assert_eq!(
+            expand_detected_version(">= 0", &Manifest::load(&manifest_path).unwrap())
+                .unwrap()
+                .unwrap(),
+            "1.5.9"
+        );
+        assert_eq!(
+            expand_detected_version("> 0", &Manifest::load(&manifest_path).unwrap())
+                .unwrap()
+                .unwrap(),
+            "1.5.9"
+        );
+
+        // Failures
+        assert_eq!(
+            expand_detected_version("> 1.6", &Manifest::load(&manifest_path).unwrap()).unwrap(),
+            None
+        );
+        assert_eq!(
+            expand_detected_version(">= 2", &Manifest::load(&manifest_path).unwrap()).unwrap(),
+            None
+        );
+        assert_eq!(
+            expand_detected_version("> 1.5.9", &Manifest::load(&manifest_path).unwrap()).unwrap(),
+            None
+        );
+    }
+
+    #[test]
     fn handles_multi() {
         let temp = create_empty_sandbox();
         let manifest_path = create_manifest(


### PR DESCRIPTION
Replace whitespace after `>`, `>=`, `<` and `<=` in `detector`.

It's how `node-semver` handles it: https://github.com/npm/node-semver/blob/cce61804ba6f997225a1267135c06676fe0524d2/internal/re.js#L188-L192