### PR TITLE
new: Add `sync_manifest` function.

### DIFF
--- a/crates/core/src/tool.rs
+++ b/crates/core/src/tool.rs
@@ -263,14 +263,14 @@ impl Tool {
             let mut entries = BTreeMap::new();
 
             for version in &versions {
-                let entry = self
-                    .manifest
-                    .versions
-                    .get(version)
-                    .cloned()
-                    .unwrap_or_default();
-
-                entries.insert(version.to_owned(), entry);
+                entries.insert(
+                    version.to_owned(),
+                    self.manifest
+                        .versions
+                        .get(version)
+                        .cloned()
+                        .unwrap_or_default(),
+                );
             }
 
             self.manifest.versions = entries;

--- a/crates/core/src/tool.rs
+++ b/crates/core/src/tool.rs
@@ -14,6 +14,7 @@ use proto_pdk_api::*;
 use proto_wasm_plugin::{create_host_functions, HostData};
 use starbase_archive::Archiver;
 use starbase_utils::{fs, json};
+use std::collections::{BTreeMap, HashSet};
 use std::env::{self, consts};
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
@@ -229,6 +230,55 @@ impl Tool {
         }
 
         self.metadata = metadata;
+
+        Ok(())
+    }
+
+    /// Sync the local tool manifest with changes from the plugin.
+    pub fn sync_manifest(&mut self) -> miette::Result<()> {
+        if !self.plugin.has_func("sync_manifest") {
+            return Ok(());
+        }
+
+        debug!(tool = self.id.as_str(), "Syncing manifest with changes");
+
+        let sync_changes: SyncManifestOutput = self.plugin.call_func_with(
+            "sync_manifest",
+            SyncManifestInput {
+                env: self.create_environment()?,
+                tool_dir: self.plugin.to_virtual_path(&self.get_tool_dir()),
+            },
+        )?;
+        let mut modified = false;
+
+        if let Some(default) = sync_changes.default_version {
+            modified = true;
+            self.manifest.default_version = Some(AliasOrVersion::parse(&default)?);
+        }
+
+        if let Some(versions) = sync_changes.versions {
+            modified = true;
+
+            let mut entries = BTreeMap::new();
+
+            for version in &versions {
+                let entry = self
+                    .manifest
+                    .versions
+                    .get(version)
+                    .cloned()
+                    .unwrap_or_default();
+
+                entries.insert(version.to_owned(), entry);
+            }
+
+            self.manifest.versions = entries;
+            self.manifest.installed_versions = HashSet::from_iter(versions);
+        }
+
+        if modified {
+            self.manifest.save()?;
+        }
 
         Ok(())
     }
@@ -912,6 +962,9 @@ impl Tool {
 
                 self.manifest.insert_version(&version, default)?;
             }
+
+            // Allow plugins to override manifest
+            self.sync_manifest()?;
 
             return Ok(true);
         }

--- a/crates/core/src/tool.rs
+++ b/crates/core/src/tool.rs
@@ -80,7 +80,7 @@ impl Tool {
         Ok(tool)
     }
 
-    pub fn create_plugin_manifest<'l, P: AsRef<ProtoEnvironment>>(
+    pub fn create_plugin_manifest<P: AsRef<ProtoEnvironment>>(
         proto: P,
         wasm: Wasm,
     ) -> miette::Result<PluginManifest> {

--- a/crates/core/src/tool.rs
+++ b/crates/core/src/tool.rs
@@ -246,6 +246,7 @@ impl Tool {
             "sync_manifest",
             SyncManifestInput {
                 env: self.create_environment()?,
+                home_dir: self.plugin.to_virtual_path(&self.proto.home),
                 tool_dir: self.plugin.to_virtual_path(&self.get_tool_dir()),
             },
         )?;

--- a/crates/core/src/tool_manifest.rs
+++ b/crates/core/src/tool_manifest.rs
@@ -22,12 +22,22 @@ fn now() -> u128 {
 
 pub const MANIFEST_NAME: &str = "manifest.json";
 
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(default)]
 pub struct ToolManifestVersion {
     pub no_clean: bool,
     pub installed_at: u128,
     pub last_used_at: Option<u128>,
+}
+
+impl Default for ToolManifestVersion {
+    fn default() -> Self {
+        Self {
+            no_clean: env::var("PROTO_NO_CLEAN").is_ok(),
+            installed_at: now(),
+            last_used_at: None,
+        }
+    }
 }
 
 #[derive(Debug, Default, Deserialize, Serialize)]
@@ -140,14 +150,8 @@ impl ToolManifest {
 
         self.installed_versions.insert(version.to_owned());
 
-        self.versions.insert(
-            version.to_owned(),
-            ToolManifestVersion {
-                installed_at: now(),
-                no_clean: env::var("PROTO_NO_CLEAN").is_ok(),
-                ..ToolManifestVersion::default()
-            },
-        );
+        self.versions
+            .insert(version.to_owned(), ToolManifestVersion::default());
 
         self.save()?;
 

--- a/crates/core/src/version_detector.rs
+++ b/crates/core/src/version_detector.rs
@@ -73,7 +73,7 @@ pub async fn detect_version(
             if let Some(detected_version) = tool.detect_version_from(dir).await? {
                 debug!(
                     tool = tool.id.as_str(),
-                    version = ?detected_version,
+                    version = detected_version.to_string(),
                     "Detected version from tool's ecosystem"
                 );
 

--- a/crates/pdk-api/src/api.rs
+++ b/crates/pdk-api/src/api.rs
@@ -472,6 +472,9 @@ json_struct!(
         /// Current environment.
         pub env: Environment,
 
+        /// Virtual path to the user's home directory.
+        pub home_dir: PathBuf,
+
         /// Virtual path to the tool's installation directory.
         pub tool_dir: PathBuf,
     }

--- a/crates/pdk-api/src/api.rs
+++ b/crates/pdk-api/src/api.rs
@@ -465,3 +465,26 @@ json_struct!(
         pub local_shims: HashMap<String, ShimConfig>,
     }
 );
+
+json_struct!(
+    /// Input passed to the `sync_manifest` function.
+    pub struct SyncManifestInput {
+        /// Current environment.
+        pub env: Environment,
+
+        /// Virtual path to the tool's installation directory.
+        pub tool_dir: PathBuf,
+    }
+);
+
+json_struct!(
+    /// Output returned by the `sync_manifest` function.
+    pub struct SyncManifestOutput {
+        /// Override the default version with a new alias or version.
+        pub default_version: Option<String>,
+
+        /// List of versions that are currently installed. Will replace
+        /// what is currently in the manifest.
+        pub versions: Option<Vec<Version>>,
+    }
+);

--- a/crates/schema-plugin/src/schema.rs
+++ b/crates/schema-plugin/src/schema.rs
@@ -16,7 +16,7 @@ pub struct DetectSchema {
     pub version_files: Option<Vec<String>>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct InstallSchema {
     pub arch: HashMap<String, String>,
@@ -24,32 +24,12 @@ pub struct InstallSchema {
     pub download_url: String,
 }
 
-impl Default for InstallSchema {
-    fn default() -> Self {
-        InstallSchema {
-            arch: HashMap::default(),
-            checksum_url: None,
-            download_url: String::new(),
-        }
-    }
-}
-
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct GlobalsSchema {
     pub install_args: Option<Vec<String>>,
     pub lookup_dirs: Vec<String>,
     pub package_prefix: Option<String>,
-}
-
-impl Default for GlobalsSchema {
-    fn default() -> Self {
-        GlobalsSchema {
-            install_args: None,
-            lookup_dirs: vec![],
-            package_prefix: None,
-        }
-    }
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
This allows tools (like Rust) to sync their manifest when needed.