### PR TITLE
new: Add dir locks during installation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
 
 - Fixed some commands where their shorthand alias was not being registered correctly.
 
+#### ⚙️ Internal
+
+- Added folder locking during tool installation to avoid colliding processes.
+
 ## 0.15.1
 
 #### ⚙️ Internal

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3095,9 +3095,9 @@ dependencies = [
 
 [[package]]
 name = "starbase_utils"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465ca58c4b63cd1b36ac839c4e09d36e7979bda4d005f40adfcc14e50c2aeec8"
+checksum = "09593b70b1d477cd8f6e84c5934e13da13bc788ec9d626822f3edeaaaaaddec5"
 dependencies = [
  "dirs 5.0.1",
  "fs4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ starbase_archive = { version = "0.2.0", features = [
 ] }
 starbase_sandbox = { version = "0.1.8" }
 starbase_styles = "0.1.13"
-starbase_utils = { version = "0.2.20", default-features = false, features = [
+starbase_utils = { version = "0.2.21", default-features = false, features = [
 	"json",
 	"toml",
 ] }

--- a/crates/cli/tests/run_test.rs
+++ b/crates/cli/tests/run_test.rs
@@ -105,25 +105,10 @@ mod run {
 
         fs::remove_file(temp.path().join(".prototools")).unwrap();
 
-        // Ecosystem
-        temp.create_file("package.json", r#"{ "engines": { "node": "19.0.0" }}"#);
-
-        let mut cmd = create_proto_command(temp.path());
-        let assert = cmd
-            .arg("run")
-            .arg("node")
-            .arg("--")
-            .arg("--version")
-            .assert();
-
-        assert.stdout(predicate::str::contains("19.0.0"));
-
-        fs::remove_file(temp.path().join("package.json")).unwrap();
-
         // Global version
         temp.create_file(
             "tools/node/manifest.json",
-            r#"{ "default_version": "19.0.0" }"#,
+            r#"{ "default_version": "19.0.0", "installed_versions": ["19.0.0"] }"#,
         );
 
         let mut cmd = create_proto_command(temp.path());

--- a/crates/core/src/shimmer.rs
+++ b/crates/core/src/shimmer.rs
@@ -136,7 +136,7 @@ fn create_shim(
         return Ok(shim_path);
     }
 
-    fs::write_file(&shim_path, build_shim_file(context, &shim_path, global)?)?;
+    fs::write_file_with_lock(&shim_path, build_shim_file(context, &shim_path, global)?)?;
     fs::update_perms(&shim_path, None)?;
 
     Ok(shim_path)

--- a/crates/core/src/shimmer.rs
+++ b/crates/core/src/shimmer.rs
@@ -136,7 +136,7 @@ fn create_shim(
         return Ok(shim_path);
     }
 
-    fs::write_file_with_lock(&shim_path, build_shim_file(context, &shim_path, global)?)?;
+    fs::write_file(&shim_path, build_shim_file(context, &shim_path, global)?)?;
     fs::update_perms(&shim_path, None)?;
 
     Ok(shim_path)

--- a/crates/pdk-test-utils/src/lib.rs
+++ b/crates/pdk-test-utils/src/lib.rs
@@ -75,7 +75,7 @@ pub fn create_schema_plugin(id: &str, sandbox: &Path, schema: PathBuf) -> WasmTe
 fn internal_create_plugin(
     id: &str,
     sandbox: &Path,
-    mut config: HashMap<String, String>,
+    config: HashMap<String, String>,
 ) -> WasmTestWrapper {
     let id = Id::new(id).unwrap();
     let proto = ProtoEnvironment::new_testing(sandbox);
@@ -84,7 +84,7 @@ fn internal_create_plugin(
     let mut manifest =
         Tool::create_plugin_manifest(&proto, Wasm::file(find_wasm_file(sandbox))).unwrap();
 
-    inject_default_manifest_config(&id, &proto, &user_config, &manifest, &mut config).unwrap();
+    inject_default_manifest_config(&id, &proto, &user_config, &mut manifest).unwrap();
 
     manifest.config.extend(config);
 


### PR DESCRIPTION
This primarily will help for tests and task runners where multiple proto processes are running.