### PR TITLE
fix: Disable caching for install flows.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 
 - Updated `proto install --pin` to also pin even if the tool has already been installed.
 
+#### 🐞 Fixes
+
+- Fixed an issue where `proto install` and `proto list-remote` would read from the cache and be unaware of newly released versions upstream.
+
 ## 0.17.0
 
 #### 💥 Breaking

--- a/crates/cli/src/commands/install.rs
+++ b/crates/cli/src/commands/install.rs
@@ -23,7 +23,7 @@ pub struct InstallArgs {
 
     #[arg(
         long,
-        help = "Install a canary (next, nightly, etc) version",
+        help = "Install a canary (nightly, etc) version",
         group = "version-type"
     )]
     pub canary: bool,
@@ -50,6 +50,9 @@ pub async fn internal_install(args: InstallArgs) -> SystemResult {
     } else {
         args.spec.clone().unwrap_or_default()
     };
+
+    // Disable version caching and always use the latest when installing
+    tool.disable_caching();
 
     if !version.is_canary() && tool.is_setup(&version).await? {
         if args.pin {

--- a/crates/cli/src/commands/install_all.rs
+++ b/crates/cli/src/commands/install_all.rs
@@ -76,7 +76,7 @@ pub async fn install_all() {
         info!("Successfully installed tools");
     }
 
-    if UserConfig::load()?.auto_clean {
+    if user_config.auto_clean {
         debug!("Auto-clean enabled, starting clean");
 
         internal_clean(&CleanArgs {

--- a/crates/cli/src/commands/install_all.rs
+++ b/crates/cli/src/commands/install_all.rs
@@ -33,12 +33,9 @@ pub async fn install_all() {
         let tool = load_tool_from_locator(&name, &proto, &locator, &user_config).await?;
 
         if let Some(candidate) = tool.detect_version_from(&working_dir).await? {
-            let resolver = tool.load_version_resolver(&candidate).await?;
-            let version = resolver.resolve(&candidate)?;
+            debug!("Detected version {} for {}", candidate, tool.get_name());
 
-            debug!("Detected version {} for {}", version, tool.get_name());
-
-            config.tools.insert(name, version.to_unresolved_spec());
+            config.tools.insert(name, candidate);
         }
     }
 

--- a/crates/cli/src/commands/list_remote.rs
+++ b/crates/cli/src/commands/list_remote.rs
@@ -12,7 +12,8 @@ pub struct ListRemoteArgs {
 
 #[system]
 pub async fn list_remote(args: ArgsRef<ListRemoteArgs>) {
-    let tool = load_tool(&args.id).await?;
+    let mut tool = load_tool(&args.id).await?;
+    tool.disable_caching();
 
     debug!("Loading versions");
 


### PR DESCRIPTION
Have seen a few reports where install fails for new versions, and it's because they hit the cache.