### PR TITLE
new: Use explicit version types in WASM API.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,26 @@
 
 ## Unreleased
 
+#### 💥 Breaking
+
+- WASM API
+  - Removed `input.context` from `LoadVersionsInput` and `ResolveVersionInput`.
+
 #### 🚀 Updates
 
 - Added Linux x64 musl support (`x86_64-unknown-linux-musl`).
+- Updated WASM functions to use explicit Rust enum types for versions to properly handle all variations (version, alias, requirement, range).
+- WASM API
+  - Uses `VersionSpec` enum:
+    - `ResolveVersionOutput.version`
+    - `ToolContext.version`
+  - Uses `UnresolvedVersionSpec` enum:
+    - `LoadVersionsInput.initial`
+    - `ParseVersionFileOutput.version`
+    - `ResolveVersionInput.initial`
+    - `ResolveVersionOutput.candidate`
+    - `SyncManifestOutput.default_version`
+    - `ToolMetadataOutput.default_version`
 
 ## 0.20.4
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2382,6 +2382,7 @@ dependencies = [
  "serde_json",
  "system_env",
  "thiserror",
+ "version_spec",
  "warpgate_api",
 ]
 

--- a/crates/core/src/tool.rs
+++ b/crates/core/src/tool.rs
@@ -1424,10 +1424,7 @@ impl Tool {
             // Add version to manifest
             self.manifest.insert_version(
                 self.get_resolved_version(),
-                self.metadata
-                    .default_version
-                    .as_ref()
-                    .map(|v| v.to_unresolved_spec()),
+                self.metadata.default_version.clone(),
             )?;
 
             // Allow plugins to override manifest

--- a/crates/core/src/tool.rs
+++ b/crates/core/src/tool.rs
@@ -27,7 +27,6 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{Duration, SystemTime};
 use tracing::{debug, trace};
-use version_spec::*;
 use warpgate::{download_from_url_to_file, Id, PluginContainer, PluginLocator, VirtualPath};
 
 pub struct Tool {

--- a/crates/core/src/tool.rs
+++ b/crates/core/src/tool.rs
@@ -276,7 +276,7 @@ impl Tool {
     pub fn create_context(&self) -> ToolContext {
         ToolContext {
             tool_dir: self.to_virtual_path(&self.get_tool_dir()),
-            version: self.get_resolved_version().to_string(),
+            version: self.get_resolved_version(),
         }
     }
 
@@ -342,14 +342,7 @@ impl Tool {
 
         if let Some(default) = sync_changes.default_version {
             modified = true;
-
-            self.manifest.default_version =
-                Some(UnresolvedVersionSpec::parse(&default).map_err(|error| {
-                    ProtoError::Semver {
-                        version: default,
-                        error,
-                    }
-                })?);
+            self.manifest.default_version = Some(default);
         }
 
         if let Some(versions) = sync_changes.versions {
@@ -436,8 +429,7 @@ impl Tool {
             versions = self.plugin.cache_func_with(
                 "load_versions",
                 LoadVersionsInput {
-                    initial: initial_version.to_string(),
-                    context: self.create_context(),
+                    initial: initial_version.to_owned(),
                 },
             )?;
 
@@ -510,39 +502,30 @@ impl Tool {
             let result: ResolveVersionOutput = self.plugin.call_func_with(
                 "resolve_version",
                 ResolveVersionInput {
-                    initial: initial_version.to_string(),
-                    context: self.create_context(),
+                    initial: initial_version.to_owned(),
                 },
             )?;
 
             if let Some(candidate) = result.candidate {
                 debug!(
                     tool = self.id.as_str(),
-                    candidate = &candidate,
+                    candidate = candidate.to_string(),
                     "Received a possible version or alias to use",
                 );
 
                 resolved = true;
-                version = resolver.resolve(&UnresolvedVersionSpec::parse(&candidate).map_err(
-                    |error| ProtoError::Semver {
-                        version: candidate,
-                        error,
-                    },
-                )?)?;
+                version = resolver.resolve(&candidate)?;
             }
 
             if let Some(candidate) = result.version {
                 debug!(
                     tool = self.id.as_str(),
-                    version = &candidate,
+                    version = candidate.to_string(),
                     "Received an explicit version or alias to use",
                 );
 
                 resolved = true;
-                version = VersionSpec::parse(&candidate).map_err(|error| ProtoError::Semver {
-                    version: candidate,
-                    error,
-                })?;
+                version = candidate;
             }
         }
 
@@ -615,7 +598,10 @@ impl Tool {
 
                 result.version.unwrap()
             } else {
-                content
+                UnresolvedVersionSpec::parse(&content).map_err(|error| ProtoError::Semver {
+                    version: content,
+                    error,
+                })?
             };
 
             debug!(
@@ -624,10 +610,7 @@ impl Tool {
                 "Detected a version"
             );
 
-            return Ok(Some(
-                UnresolvedVersionSpec::parse(&version)
-                    .map_err(|error| ProtoError::Semver { version, error })?,
-            ));
+            return Ok(Some(version));
         }
 
         Ok(None)
@@ -1439,21 +1422,13 @@ impl Tool {
             self.setup_bin_link(false)?;
 
             // Add version to manifest
-            let mut default = None;
-
-            if let Some(default_version) = &self.metadata.default_version {
-                default = Some(
-                    UnresolvedVersionSpec::parse(default_version).map_err(|error| {
-                        ProtoError::Semver {
-                            version: default_version.to_owned(),
-                            error,
-                        }
-                    })?,
-                );
-            }
-
-            self.manifest
-                .insert_version(self.get_resolved_version(), default)?;
+            self.manifest.insert_version(
+                self.get_resolved_version(),
+                self.metadata
+                    .default_version
+                    .as_ref()
+                    .map(|v| v.to_unresolved_spec()),
+            )?;
 
             // Allow plugins to override manifest
             self.sync_manifest()?;

--- a/crates/pdk-api/Cargo.toml
+++ b/crates/pdk-api/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/moonrepo/proto"
 
 [dependencies]
 system_env = { version = "0.1.1", path = "../system-env" }
+version_spec = { version = "0.1.1", path = "../version-spec" }
 warpgate_api = { version = "0.1.4", path = "../warpgate-api" }
 anyhow = "1.0.75"
 semver = { workspace = true, features = ["serde"] }

--- a/crates/pdk-api/src/api.rs
+++ b/crates/pdk-api/src/api.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::path::PathBuf;
 use system_env::SystemDependency;
+use version_spec::{UnresolvedVersionSpec, VersionSpec};
 use warpgate_api::VirtualPath;
 
 pub use semver::{Version, VersionReq};
@@ -36,8 +37,8 @@ json_struct!(
         /// Virtual path to the tool's installation directory.
         pub tool_dir: VirtualPath,
 
-        /// Current version. Will be empty if not resolved.
-        pub version: String,
+        /// Current version. Will be "latest" if not resolved.
+        pub version: VersionSpec,
     }
 );
 
@@ -82,7 +83,7 @@ json_struct!(
     pub struct ToolMetadataOutput {
         /// Default alias or version to use as a fallback.
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub default_version: Option<String>,
+        pub default_version: Option<VersionSpec>,
 
         /// Controls aspects of the tool inventory.
         pub inventory: ToolInventoryMetadata,
@@ -131,7 +132,7 @@ json_struct!(
         /// The version that was extracted from the file.
         /// Can be a semantic version or a version requirement/range.
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub version: Option<String>,
+        pub version: Option<UnresolvedVersionSpec>,
     }
 );
 
@@ -441,11 +442,8 @@ impl UninstallGlobalOutput {
 json_struct!(
     /// Input passed to the `load_versions` function.
     pub struct LoadVersionsInput {
-        /// Current tool context.
-        pub context: ToolContext,
-
         /// The alias or version currently being resolved.
-        pub initial: String,
+        pub initial: UnresolvedVersionSpec,
     }
 );
 
@@ -510,11 +508,8 @@ impl LoadVersionsOutput {
 json_struct!(
     /// Input passed to the `resolve_version` function.
     pub struct ResolveVersionInput {
-        /// Current tool context.
-        pub context: ToolContext,
-
         /// The alias or version currently being resolved.
-        pub initial: String,
+        pub initial: UnresolvedVersionSpec,
     }
 );
 
@@ -523,12 +518,12 @@ json_struct!(
     pub struct ResolveVersionOutput {
         /// New alias or version candidate to resolve.
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub candidate: Option<String>,
+        pub candidate: Option<UnresolvedVersionSpec>,
 
         /// An explicitly resolved version to be used as-is.
         /// Note: Only use this field if you know what you're doing!
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub version: Option<String>,
+        pub version: Option<VersionSpec>,
     }
 );
 
@@ -651,7 +646,7 @@ json_struct!(
     pub struct SyncManifestOutput {
         /// Override the default version with a new alias or version.
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub default_version: Option<String>,
+        pub default_version: Option<UnresolvedVersionSpec>,
 
         /// List of versions that are currently installed. Will replace
         /// what is currently in the manifest.

--- a/crates/pdk-api/src/api.rs
+++ b/crates/pdk-api/src/api.rs
@@ -83,7 +83,7 @@ json_struct!(
     pub struct ToolMetadataOutput {
         /// Default alias or version to use as a fallback.
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub default_version: Option<VersionSpec>,
+        pub default_version: Option<UnresolvedVersionSpec>,
 
         /// Controls aspects of the tool inventory.
         pub inventory: ToolInventoryMetadata,

--- a/crates/pdk-api/src/lib.rs
+++ b/crates/pdk-api/src/lib.rs
@@ -10,4 +10,5 @@ pub use hooks::*;
 pub use host::*;
 pub use host_funcs::*;
 pub use system_env::{DependencyConfig, DependencyName, SystemDependency, SystemPackageManager};
+pub use version_spec::*;
 pub use warpgate_api::*;

--- a/crates/pdk-test-utils/src/wrapper.rs
+++ b/crates/pdk-test-utils/src/wrapper.rs
@@ -55,9 +55,7 @@ impl WasmTestWrapper {
             .unwrap()
     }
 
-    pub fn load_versions(&self, mut input: LoadVersionsInput) -> LoadVersionsOutput {
-        input.context = self.prepare_context(input.context);
-
+    pub fn load_versions(&self, input: LoadVersionsInput) -> LoadVersionsOutput {
         self.tool
             .plugin
             .call_func_with("load_versions", input)
@@ -148,9 +146,7 @@ impl WasmTestWrapper {
             .unwrap()
     }
 
-    pub fn resolve_version(&self, mut input: ResolveVersionInput) -> ResolveVersionOutput {
-        input.context = self.prepare_context(input.context);
-
+    pub fn resolve_version(&self, input: ResolveVersionInput) -> ResolveVersionOutput {
         self.tool
             .plugin
             .call_func_with("resolve_version", input)

--- a/crates/version-spec/src/lib.rs
+++ b/crates/version-spec/src/lib.rs
@@ -25,7 +25,7 @@ pub fn is_alias_name<T: AsRef<str>>(value: T) -> bool {
     })
 }
 
-pub static CLEAN_VERSION: Lazy<Regex> = Lazy::new(|| Regex::new(r"([><]=?)\s+(\d)").unwrap());
+static CLEAN_VERSION: Lazy<Regex> = Lazy::new(|| Regex::new(r"([><]=?)\s+(\d)").unwrap());
 
 pub fn clean_version_string<T: AsRef<str>>(value: T) -> String {
     let value = value.as_ref().trim().replace(".*", "");

--- a/plugins/Cargo.lock
+++ b/plugins/Cargo.lock
@@ -896,11 +896,12 @@ dependencies = [
 
 [[package]]
 name = "extism"
-version = "0.5.2"
-source = "git+https://github.com/extism/extism.git?branch=stable#1452b9fb42cf7e63ee133b7311eec1f3e39fee52"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67e81d3e7d1592412579984e773bd553703a664bbfb1ddded742bf6dfae63847"
 dependencies = [
  "anyhow",
- "extism-manifest 0.5.0 (git+https://github.com/extism/extism.git?branch=stable)",
+ "extism-manifest",
  "extism-runtime",
  "log",
  "serde_json",
@@ -918,15 +919,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "extism-manifest"
-version = "0.5.0"
-source = "git+https://github.com/extism/extism.git?branch=stable#1452b9fb42cf7e63ee133b7311eec1f3e39fee52"
-dependencies = [
- "base64",
- "serde",
-]
-
-[[package]]
 name = "extism-pdk"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -934,7 +926,7 @@ checksum = "09c20fe9cafa572607e22192bf2040849e7456664895bdc589c89387876e2067"
 dependencies = [
  "anyhow",
  "base64",
- "extism-manifest 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "extism-manifest",
  "extism-pdk-derive",
  "rmp-serde",
  "serde",
@@ -954,12 +946,13 @@ dependencies = [
 
 [[package]]
 name = "extism-runtime"
-version = "0.5.2"
-source = "git+https://github.com/extism/extism.git?branch=stable#1452b9fb42cf7e63ee133b7311eec1f3e39fee52"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126b884cfa74fc386eedff1095bac8ef6c2ae5efdb656e508f12a41434d0bf0c"
 dependencies = [
  "anyhow",
  "cbindgen",
- "extism-manifest 0.5.0 (git+https://github.com/extism/extism.git?branch=stable)",
+ "extism-manifest",
  "glob",
  "libc",
  "log",
@@ -2023,7 +2016,7 @@ dependencies = [
 
 [[package]]
 name = "proto_core"
-version = "0.20.2"
+version = "0.20.4"
 dependencies = [
  "cached",
  "extism",
@@ -2053,7 +2046,7 @@ dependencies = [
 
 [[package]]
 name = "proto_pdk"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "extism-pdk",
@@ -2063,7 +2056,7 @@ dependencies = [
 
 [[package]]
 name = "proto_pdk_api"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "semver",
@@ -2071,12 +2064,13 @@ dependencies = [
  "serde_json",
  "system_env",
  "thiserror",
+ "version_spec",
  "warpgate_api",
 ]
 
 [[package]]
 name = "proto_pdk_test_utils"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "extism",
  "proto_core",
@@ -2087,7 +2081,7 @@ dependencies = [
 
 [[package]]
 name = "proto_wasm_plugin"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "extism",
  "proto_pdk_api",
@@ -3314,7 +3308,7 @@ dependencies = [
 
 [[package]]
 name = "warpgate"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "extism",
  "miette",

--- a/plugins/wasm-test/src/lib.rs
+++ b/plugins/wasm-test/src/lib.rs
@@ -44,10 +44,10 @@ pub fn parse_version_file(
 
     if input.file == ".proto-wasm-version" {
         if input.content.starts_with("version=") {
-            version = Some(input.content[8..].into());
+            version = Some(UnresolvedVersionSpec::parse(&input.content[8..])?);
         }
     } else {
-        version = Some(input.content);
+        version = Some(UnresolvedVersionSpec::parse(input.content)?);
     }
 
     Ok(Json(ParseVersionFileOutput { version }))
@@ -148,8 +148,10 @@ pub fn resolve_version(
 ) -> FnResult<Json<ResolveVersionOutput>> {
     let mut output = ResolveVersionOutput::default();
 
-    if input.initial == "node" {
-        output.candidate = Some("latest".into());
+    if let UnresolvedVersionSpec::Alias(alias) = &input.initial {
+        if alias == "node" {
+            output.candidate = Some(UnresolvedVersionSpec::Alias("latest".into()));
+        }
     }
 
     Ok(Json(output))


### PR DESCRIPTION
This allows plugins to more accurately handle all the variations.