### PR TITLE
fix: Ignore version detection in node modules.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 - [Rust](https://github.com/moonrepo/rust-plugin/blob/master/CHANGELOG.md)
 - [TOML schema](https://github.com/moonrepo/schema-plugin/blob/master/CHANGELOG.md)
 
+## Unreleased
+
+#### 🐞 Fixes
+
+- Fixed an issue where version detection would read files found in `node_modules` (which you usually don't want).
+
 ## 0.22.1
 
 #### 🐞 Fixes

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -199,8 +199,9 @@ pub async fn run(args: ArgsRef<RunArgs>) -> SystemResult {
 
     // Determine the binary path to execute
     let exe_config = get_executable(&tool, args)?;
+    let exe_path = exe_config.exe_path.as_ref().unwrap();
 
-    debug!(bin = ?exe_config.exe_path, args = ?args.passthrough, "Running {}", tool.get_name());
+    debug!(bin = ?exe_path, args = ?args.passthrough, "Running {}", tool.get_name());
 
     // Run before hook
     tool.run_hook("pre_run", || RunHook {
@@ -216,7 +217,7 @@ pub async fn run(args: ArgsRef<RunArgs>) -> SystemResult {
         )
         .env(
             format!("{}_BIN", tool.get_env_var_prefix()),
-            exe_config.exe_path.unwrap().to_string_lossy().to_string(),
+            exe_path.to_string_lossy().to_string(),
         )
         .spawn()
         .into_diagnostic()?

--- a/crates/core/src/tool.rs
+++ b/crates/core/src/tool.rs
@@ -546,6 +546,11 @@ impl Tool {
             return Ok(None);
         }
 
+        // TODO move this into plugins
+        if current_dir.to_string_lossy().contains("node_modules") {
+            return Ok(None);
+        }
+
         let has_parser = self.plugin.has_func("parse_version_file");
         let result: DetectVersionOutput = self.plugin.cache_func("detect_version_files")?;
 

--- a/crates/core/src/version_detector.rs
+++ b/crates/core/src/version_detector.rs
@@ -60,7 +60,7 @@ pub async fn detect_version(
             if let Some(local_version) = config.tools.get(&tool.id) {
                 debug!(
                     tool = tool.id.as_str(),
-                    version = ?local_version,
+                    version = local_version.to_string(),
                     file = ?config.path,
                     "Detected version from .prototools file",
                 );

--- a/crates/pdk-api/src/api.rs
+++ b/crates/pdk-api/src/api.rs
@@ -366,6 +366,7 @@ json_struct!(
         pub no_shim: bool,
 
         /// The parent executable name required to execute the local executable path.
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub parent_exe_name: Option<String>,
 
         /// Custom args to prepend to user-provided args within the generated shim.


### PR DESCRIPTION
Users don't control these versions (like `engines`), so ignore them completely.