### PR TITLE
fix: Copy bins instead of symlinking on Windows.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 #### 🚀 Updates
 
 - Updated `proto install-global` and `proto uninstall-global` to detect/resolve a version first, as some package managers require it.
+- Updated Windows to _not_ use symlinks for binaries, and instead copy the `.exe` file. This is required to solve "A required privilege is not held by the client" errors, because symlinks require admin privileges.
 
 #### 🐞 Fixes
 

--- a/crates/cli/src/commands/clean.rs
+++ b/crates/cli/src/commands/clean.rs
@@ -1,7 +1,9 @@
 use crate::helpers::ToolsLoader;
 use clap::Args;
 use dialoguer::Confirm;
-use proto_core::{get_plugins_dir, get_temp_dir, load_tool, Id, ProtoError, Tool, VersionSpec};
+use proto_core::{
+    get_plugins_dir, get_temp_dir, load_tool, remove_bin_file, Id, ProtoError, Tool, VersionSpec,
+};
 use starbase::diagnostics::IntoDiagnostic;
 use starbase::{system, SystemResult};
 use starbase_styles::color;
@@ -206,7 +208,7 @@ pub async fn purge_tool(id: &Id, yes: bool) -> SystemResult {
 
         // Delete binaries
         for bin in tool.get_bin_locations()? {
-            fs::remove_link(bin.path)?;
+            remove_bin_file(bin.path)?;
         }
 
         // Delete shims

--- a/crates/cli/src/commands/migrate/v0_20.rs
+++ b/crates/cli/src/commands/migrate/v0_20.rs
@@ -1,5 +1,5 @@
 use crate::helpers::load_configured_tools;
-use crate::shell::{self, format_env_var};
+use crate::shell;
 use proto_core::get_bin_dir;
 use starbase::SystemResult;
 use starbase_utils::fs;
@@ -63,6 +63,8 @@ pub async fn migrate() -> SystemResult {
 
 #[cfg(not(windows))]
 fn update_shell() -> SystemResult {
+    use crate::shell::{self, format_env_var};
+
     info!("Updating shell profile...");
 
     let shell = shell::detect_shell(None);

--- a/crates/cli/src/commands/migrate/v0_20.rs
+++ b/crates/cli/src/commands/migrate/v0_20.rs
@@ -63,7 +63,7 @@ pub async fn migrate() -> SystemResult {
 
 #[cfg(not(windows))]
 fn update_shell() -> SystemResult {
-    use crate::shell::{self, format_env_var};
+    use crate::shell::format_env_var;
 
     info!("Updating shell profile...");
 

--- a/crates/cli/tests/clean_test.rs
+++ b/crates/cli/tests/clean_test.rs
@@ -31,6 +31,7 @@ mod clean {
         assert!(!sandbox.path().join("tools/node/4.5.6/index.js").exists());
     }
 
+    #[cfg(not(windows))]
     #[test]
     fn purges_tool_bin() {
         let sandbox = create_empty_sandbox();

--- a/crates/cli/tests/install_uninstall_test.rs
+++ b/crates/cli/tests/install_uninstall_test.rs
@@ -333,6 +333,7 @@ mod install_uninstall {
         assert!(tools.tools.get("node").is_none());
     }
 
+    #[cfg(not(windows))]
     #[test]
     fn symlinks_bin_when_pinning() {
         let temp = create_empty_sandbox();
@@ -346,25 +347,17 @@ mod install_uninstall {
             .arg("--no-bundled-npm")
             .assert();
 
-        let link = temp
-            .path()
-            .join("bin")
-            .join(if cfg!(windows) { "node.exe" } else { "node" });
+        let link = temp.path().join("bin").join("node");
 
         assert!(link.exists());
 
         assert_eq!(
             std::fs::read_link(link).unwrap(),
-            temp.path()
-                .join("tools/node/19.0.0")
-                .join(if cfg!(windows) {
-                    "node.exe"
-                } else {
-                    "bin/node"
-                })
+            temp.path().join("tools/node/19.0.0").join("bin/node")
         );
     }
 
+    #[cfg(not(windows))]
     #[test]
     fn symlinks_bin_on_first_install_without_pinning() {
         let temp = create_empty_sandbox();
@@ -377,10 +370,44 @@ mod install_uninstall {
             .arg("--no-bundled-npm")
             .assert();
 
-        let link = temp
-            .path()
-            .join("bin")
-            .join(if cfg!(windows) { "node.exe" } else { "node" });
+        let link = temp.path().join("bin").join("node");
+
+        assert!(link.exists());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn creates_bin_when_pinning() {
+        let temp = create_empty_sandbox();
+
+        let mut cmd = create_proto_command(temp.path());
+        cmd.arg("install")
+            .arg("node")
+            .arg("19.0.0")
+            .arg("--pin")
+            .arg("--")
+            .arg("--no-bundled-npm")
+            .assert();
+
+        let link = temp.path().join("bin").join("node.exe");
+
+        assert!(link.exists());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn creates_bin_on_first_install_without_pinning() {
+        let temp = create_empty_sandbox();
+
+        let mut cmd = create_proto_command(temp.path());
+        cmd.arg("install")
+            .arg("node")
+            .arg("19.0.0")
+            .arg("--")
+            .arg("--no-bundled-npm")
+            .assert();
+
+        let link = temp.path().join("bin").join("node.exe");
 
         assert!(link.exists());
     }

--- a/crates/core/src/helpers.rs
+++ b/crates/core/src/helpers.rs
@@ -5,7 +5,6 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use sha2::digest::typenum::Len;
 use sha2::{Digest, Sha256};
 use starbase_archive::is_supported_archive_extension;
 use starbase_utils::dirs::home_dir;

--- a/crates/core/src/helpers.rs
+++ b/crates/core/src/helpers.rs
@@ -236,16 +236,18 @@ pub fn write_json_file_with_lock<T: Serialize>(
     Ok(())
 }
 
+// Windows copies the file for bins
+#[cfg(windows)]
 pub fn remove_bin_file(path: impl AsRef<Path>) -> miette::Result<()> {
-    let path = path.as_ref();
-    let metadata = std::fs::symlink_metadata(path).into_diagnostic()?;
+    fs::remove_file(path)?;
 
-    // Unix uses symlinks for bins, while Windows copies the file
-    if metadata.is_symlink() {
-        fs::remove_link(path)?;
-    } else {
-        fs::remove_file(path)?;
-    }
+    Ok(())
+}
+
+// Unix uses symlinks for bins
+#[cfg(not(windows))]
+pub fn remove_bin_file(path: impl AsRef<Path>) -> miette::Result<()> {
+    fs::remove_link(path)?;
 
     Ok(())
 }

--- a/crates/core/src/tool.rs
+++ b/crates/core/src/tool.rs
@@ -1,5 +1,4 @@
 use crate::error::ProtoError;
-use crate::events::*;
 use crate::helpers::{
     extract_filename_from_url, hash_file_contents, is_archive_file, is_cache_enabled, is_offline,
     ENV_VAR,
@@ -9,6 +8,7 @@ use crate::proto::ProtoEnvironment;
 use crate::shimmer::{get_shim_file_names, ShimContext, SHIM_VERSION};
 use crate::tool_manifest::ToolManifest;
 use crate::version_resolver::VersionResolver;
+use crate::{events::*, remove_bin_file};
 use extism::{manifest::Wasm, Manifest as PluginManifest};
 use miette::IntoDiagnostic;
 use proto_pdk_api::*;
@@ -1459,11 +1459,14 @@ impl Tool {
                 "Creating binary symlink"
             );
 
-            fs::remove_link(&output_path)?;
+            remove_bin_file(&output_path)?;
 
+            // Windows requires admin privileges to create soft/hard links,
+            // so just copy the binary... Annoying...
             #[cfg(windows)]
             {
-                std::os::windows::fs::symlink_file(input_path, &output_path).into_diagnostic()?;
+                // std::os::windows::fs::symlink_file(input_path, &output_path).into_diagnostic()?;
+                fs::copy_file(input_path, &output_path)?;
             }
 
             #[cfg(not(windows))]
@@ -1561,7 +1564,7 @@ impl Tool {
         // otherwise the OS will throw errors for missing sources
         if self.manifest.default_version.is_none() || self.manifest.installed_versions.is_empty() {
             for bin in self.get_bin_locations()? {
-                fs::remove_link(bin.path)?;
+                remove_bin_file(bin.path)?;
             }
         }
 

--- a/crates/core/src/tool.rs
+++ b/crates/core/src/tool.rs
@@ -1,14 +1,14 @@
 use crate::error::ProtoError;
+use crate::events::*;
 use crate::helpers::{
     extract_filename_from_url, hash_file_contents, is_archive_file, is_cache_enabled, is_offline,
-    ENV_VAR,
+    remove_bin_file, ENV_VAR,
 };
 use crate::host_funcs::{create_host_functions, HostData};
 use crate::proto::ProtoEnvironment;
 use crate::shimmer::{get_shim_file_names, ShimContext, SHIM_VERSION};
 use crate::tool_manifest::ToolManifest;
 use crate::version_resolver::VersionResolver;
-use crate::{events::*, remove_bin_file};
 use extism::{manifest::Wasm, Manifest as PluginManifest};
 use miette::IntoDiagnostic;
 use proto_pdk_api::*;


### PR DESCRIPTION
Symlinks require admin privs, and we simply can't force all users to have to enable those settings.