### PR TITLE
new: Use temporary, backported trivial caching implemention in extism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,11 +1104,10 @@ dependencies = [
 [[package]]
 name = "extism"
 version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67e81d3e7d1592412579984e773bd553703a664bbfb1ddded742bf6dfae63847"
+source = "git+https://github.com/extism/extism.git?branch=backport-cache#66c3c78c56be262e9bdf38a32272a2b43b9a69b8"
 dependencies = [
  "anyhow",
- "extism-manifest",
+ "extism-manifest 0.5.0 (git+https://github.com/extism/extism.git?branch=backport-cache)",
  "extism-runtime",
  "log",
  "serde_json",
@@ -1126,6 +1125,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "extism-manifest"
+version = "0.5.0"
+source = "git+https://github.com/extism/extism.git?branch=backport-cache#66c3c78c56be262e9bdf38a32272a2b43b9a69b8"
+dependencies = [
+ "base64 0.21.0",
+ "serde",
+]
+
+[[package]]
 name = "extism-pdk"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1133,7 +1141,7 @@ checksum = "09c20fe9cafa572607e22192bf2040849e7456664895bdc589c89387876e2067"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
- "extism-manifest",
+ "extism-manifest 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "extism-pdk-derive",
  "rmp-serde",
  "serde",
@@ -1154,12 +1162,11 @@ dependencies = [
 [[package]]
 name = "extism-runtime"
 version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126b884cfa74fc386eedff1095bac8ef6c2ae5efdb656e508f12a41434d0bf0c"
+source = "git+https://github.com/extism/extism.git?branch=backport-cache#66c3c78c56be262e9bdf38a32272a2b43b9a69b8"
 dependencies = [
  "anyhow",
  "cbindgen",
- "extism-manifest",
+ "extism-manifest 0.5.0 (git+https://github.com/extism/extism.git?branch=backport-cache)",
  "glob",
  "libc",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ cached = "0.46.1"
 clap = "4.4.8"
 clap_complete = "4.4.4"
 convert_case = "0.6.0"
-extism = { version = "0.5.4" }
+extism = { git = "https://github.com/extism/extism.git", branch = "backport-cache"}
 extism-pdk = "0.3.4"
 human-sort = "0.2.2"
 miette = "5.10.0"


### PR DESCRIPTION
This pr resolves extism from a temporarily-created branch [backport-cache](https://github.com/extism/extism/tree/backport-cache) off of v0.5.x. More holistic caching improvements are already merged on extism main, which is for the upcoming 1.0 release.

The 1-line change to prompt wasmtime to use caching by default results in significant tool resolution performance gains.

In my testing, trivial calling of `node` goes from ~100ms to ~18.5ms.

No config change is needed, wasmtime will do the caching transparently in the background. The behavior can also be optionally disabled by editing the user-global wasmtime config, if issues arise.

Tested on linux, not sure how or if it'll work on Windows.

---

hyperfine tests:

```
# Latest proto
hyperfine --warmup 10 -- 'proto run node -- --version'
Benchmark 1: proto run node -- --version
  Time (mean ± σ):      99.2 ms ±   6.3 ms    [User: 662.5 ms, System: 79.4 ms]
  Range (min … max):    91.3 ms … 119.7 ms    29 runs


# With the change on main
hyperfine --warmup 10 -- './target/release/proto run node -- --version'
Benchmark 1: ./target/release/proto run node -- --version
  Time (mean ± σ):      18.5 ms ±   1.0 ms    [User: 7.9 ms, System: 12.7 ms]
  Range (min … max):    17.1 ms …  23.8 ms    146 runs
```
