### PR TITLE
Remove vestigial variables

### DIFF
--- a/crates/core/templates/windows/cmd.tpl
+++ b/crates/core/templates/windows/cmd.tpl
@@ -3,10 +3,7 @@
 @echo off
 setlocal
 
-set "ErrorActionPreference=Stop"
-
 if defined PROTO_DEBUG (
-    set "DebugPreference=Continue"
     echo "Running with {{ bin }}.cmd shim"
 )
 


### PR DESCRIPTION
The `ErrorActionPreference` and `DebugPreference` variables have no effect in batch scripts.