### PR TITLE
fix: Preload schema plugin for `proto use`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@
 - [Rust](https://github.com/moonrepo/rust-plugin/blob/master/CHANGELOG.md)
 - [TOML schema](https://github.com/moonrepo/schema-plugin/blob/master/CHANGELOG.md)
 
+## Unreleased
+
+#### 🐞 Fixes
+
+- Fixed an issue where `proto use` (or parallel processes) would run into file system
+  collisions when attempting to download and install multiple TOML schema based tools.
+
 ## 0.23.5
 
 #### 🚀 Updates

--- a/crates/cli/src/commands/install_all.rs
+++ b/crates/cli/src/commands/install_all.rs
@@ -6,6 +6,7 @@ use crate::{
     commands::install::{internal_install, InstallArgs},
 };
 use miette::IntoDiagnostic;
+use proto_core::load_schema_plugin;
 use starbase::system;
 use starbase_styles::color;
 use std::{env, process};
@@ -53,6 +54,13 @@ pub async fn install_all() {
 
     disable_progress_bars();
 
+    // Download the schema plugin before installing tools.
+    // We must do this here, otherwise when multiple schema
+    // based tools are installed in parallel, they will
+    // collide when attempting to download the schema plugin!
+    load_schema_plugin(&loader.proto, &loader.user_config).await?;
+
+    // Then install each tool in parallel!
     let mut futures = vec![];
 
     for tool in tools {


### PR DESCRIPTION
Should alleviate this error:

```
Error: fs::rename

  × Failed to rename ~/.proto/temp/internal-schema-
  │ e4bcf2a719dfcf6c7b7c768cb76bf31bfa2318e54e5cb72029b4c6616d463491.wasm
  │ to ~/.proto/plugins/internal-schema-
  │ e4bcf2a719dfcf6c7b7c768cb76bf31bfa2318e54e5cb72029b4c6616d463491.wasm.
  ╰─▶ No such file or directory (os error 2)
  help: Does the source file exist?
```