### PR TITLE
Build and upload in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,11 +109,11 @@ jobs:
       - uses: moonrepo/setup-rust@v1
         with:
           targets: ${{ matrix.target }}
+          cache-target: release
       - run:
           cargo install --root artifacts --path ./crates/cli
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.target }}
           path: artifacts
-          retention-days: 14
-          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - if: ${{matrix.target == 'aarch64-unknown-linux-gnu'}}
-        run: apt install gcc-aarch64-linux-gnu
+        run: sudo apt-get install gcc-aarch64-linux-gnu
       - uses: moonrepo/setup-rust@v1
         with:
           targets: ${{ matrix.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
           targets: ${{ matrix.target }}
           cache-target: release
       - run:
-          cargo install --root artifacts --path ./crates/cli
+          cargo install --root artifacts --path ./crates/cli --target ${{ matrix.target }}
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,9 @@ jobs:
         with:
           targets: ${{ matrix.target }}
           cache-target: release
+      - run: rustup target list --installed
+      - run: rustup target add ${{ matrix.target }}
+      - run: rustup target list --installed
       - run:
           cargo install --root artifacts --path ./crates/cli --target ${{ matrix.target }}
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,8 +87,8 @@ jobs:
       - run: cargo run -- --help
       - run: cargo run -- list-remote node
       - run: cargo run -- list-remote wasm-test
-  install:
-    name: Install binaries
+  build:
+    name: Upload build
     runs-on: ${{ matrix.host }}
     strategy:
       matrix:
@@ -106,7 +106,6 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
-      - uses: moonrepo/setup-toolchain@v0
       - uses: moonrepo/setup-rust@v1
         with:
           targets: ${{ matrix.target }}
@@ -118,4 +117,3 @@ jobs:
           path: artifacts
           retention-days: 14
           if-no-files-found: error
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,3 +87,32 @@ jobs:
       - run: cargo run -- --help
       - run: cargo run -- list-remote node
       - run: cargo run -- list-remote wasm-test
+  install:
+    name: Install binaries
+    runs-on: ${{ matrix.host }}
+    strategy:
+      matrix:
+        include:
+        - target: aarch64-unknown-linux-gnu
+          host: ubuntu-latest
+        - target: x86_64-unknown-linux-gnu
+          host: ubuntu-20.04
+        - target: x86_64-apple-darwin
+          host: macos-12
+        - target: aarch64-apple-darwin
+          host: macos-latest
+        - target: x86_64-pc-windows-msvc
+          host: windows-2022
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+      - uses: moonrepo/setup-toolchain@v0
+      - uses: moonrepo/setup-rust@v1
+        with:
+          targets: ${{ matrix.target }}
+      - run:
+          cargo install --root artifacts --path ./crates/cli
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.target }}
+          path: artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,8 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
+      - if: ${{matrix.target == 'aarch64-unknown-linux-gnu'}}
+        run: apt install gcc-aarch64-linux-gnu
       - uses: moonrepo/setup-rust@v1
         with:
           targets: ${{ matrix.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,13 +96,13 @@ jobs:
         - target: aarch64-unknown-linux-gnu
           host: ubuntu-latest
         - target: x86_64-unknown-linux-gnu
-          host: ubuntu-20.04
+          host: ubuntu-latest
         - target: x86_64-apple-darwin
-          host: macos-12
+          host: macos-latest
         - target: aarch64-apple-darwin
           host: macos-latest
         - target: x86_64-pc-windows-msvc
-          host: windows-2022
+          host: windows-latest
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -116,3 +116,6 @@ jobs:
         with:
           name: ${{ matrix.target }}
           path: artifacts
+          retention-days: 14
+          if-no-files-found: error
+


### PR DESCRIPTION
This is a simpler workflow to publish binaries for release testing.
Associating the binaries with the CI workflow rather than a separate GitHub release has pros and cons.

Pro Artifacts:
- It's obvious which PR/commit the artifacts are associated with. When there are multiple commits, each one gets its own CI run and set of artifacts.
- Cluttered release page makes it hard to find a release you want.
- The CI results are available on the artifacts page, not so with releases.

Pro Release:
- Predictable URL better for linking
- Control over archives: can choose non-zip format, can specify file permissions (so no need to `chmod +x`)