### PR TITLE
new: Improve signal handling.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,6 +528,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "command-group"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a68fa787550392a9d58f44c21a3022cfb3ea3e2458b7f85d3b399d0ceeccf409"
+dependencies = [
+ "nix",
+ "winapi",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2043,6 +2053,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2293,6 +2314,7 @@ dependencies = [
  "chrono",
  "clap 4.4.11",
  "clap_complete",
+ "command-group",
  "convert_case",
  "dialoguer",
  "dirs 5.0.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2310,7 +2310,6 @@ dependencies = [
  "semver",
  "serde",
  "shared_child",
- "signal-child",
  "signal-hook",
  "sigpipe",
  "starbase",
@@ -2985,12 +2984,6 @@ checksum = "7ccc8076840c4da029af4f87e4e8daeb0fca6b87bbb02e10cb60b791450e11e4"
 dependencies = [
  "dirs 4.0.0",
 ]
-
-[[package]]
-name = "signal-child"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a4eed4c5ae38438470ab8e0108bb751012f786f44ff585cfd837c9a5fe426f"
 
 [[package]]
 name = "signal-hook"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,16 +787,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctrlc"
-version = "3.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e95fbd621905b854affdc67943b043a0fbb6ed7385fd5a25650d19a8a6cfdf"
-dependencies = [
- "nix",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "darling"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2053,17 +2043,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nix"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
-dependencies = [
- "bitflags 2.4.1",
- "cfg-if",
- "libc",
-]
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2315,7 +2294,6 @@ dependencies = [
  "clap 4.4.11",
  "clap_complete",
  "convert_case",
- "ctrlc",
  "dialoguer",
  "dirs 5.0.1",
  "human-sort",
@@ -2333,6 +2311,7 @@ dependencies = [
  "serde",
  "shared_child",
  "signal-child",
+ "signal-hook",
  "sigpipe",
  "starbase",
  "starbase_archive",
@@ -3012,6 +2991,16 @@ name = "signal-child"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a4eed4c5ae38438470ab8e0108bb751012f786f44ff585cfd837c9a5fe426f"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
 
 [[package]]
 name = "signal-hook-registry"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -74,4 +74,3 @@ winreg = "0.52.0"
 
 [dev-dependencies]
 starbase_sandbox = { workspace = true }
-signal-child = "1.0.5"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -59,6 +59,7 @@ tracing = { workspace = true }
 uuid = { version = "1.6.1", features = ["v4"] }
 
 # For the shim binary
+command-group = "5.0.1"
 rust_json = "0.1.5"
 shared_child = "1.0.0"
 signal-hook = "0.3.17"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -59,9 +59,9 @@ tracing = { workspace = true }
 uuid = { version = "1.6.1", features = ["v4"] }
 
 # For the shim binary
-ctrlc = "3.4.1"
 rust_json = "0.1.5"
 shared_child = "1.0.0"
+signal-hook = "0.3.17"
 sigpipe = "0.1.3"
 
 # Force latest rustls

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -180,6 +180,7 @@ pub async fn run(args: ArgsRef<RunArgs>, proto: ResourceRef<ProtoResource>) -> S
 
     // Run the command
     let mut command = create_command(&tool, &exe_config, &args.passthrough)?;
+
     command
         .env(
             format!("{}_VERSION", tool.get_env_var_prefix()),
@@ -191,10 +192,6 @@ pub async fn run(args: ArgsRef<RunArgs>, proto: ResourceRef<ProtoResource>) -> S
         );
 
     let child = spawn_command_with_signals(command).into_diagnostic()?;
-
-    // println!("proto parent id = {}", std::process::id());
-    // println!("proto child id = {}", child.id());
-
     let status = child.wait().into_diagnostic()?;
 
     // Run after hook

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -193,8 +193,8 @@ pub async fn run(args: ArgsRef<RunArgs>, proto: ResourceRef<ProtoResource>) -> S
 
     let status = spawn_command_with_signals(command, |child_id| {
         trace!(
-            pid = std::process::id(), 
-            child_pid = child_id, 
+            pid = std::process::id(),
+            child_pid = child_id,
             "Spawning child process",
         );
     })

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -120,8 +120,7 @@ fn create_command<I: IntoIterator<Item = A>, A: AsRef<OsStr>>(
         create_process_command(exe_path, args)
     };
 
-    // Convert std to tokio
-    Ok(Command::from(command))
+    Ok(command)
 }
 
 #[system]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -3,6 +3,7 @@ mod commands;
 mod error;
 mod helpers;
 mod printer;
+mod shared;
 mod shell;
 mod systems;
 mod telemetry;

--- a/crates/cli/src/main_shim.rs
+++ b/crates/cli/src/main_shim.rs
@@ -191,16 +191,15 @@ pub fn main() -> Result<()> {
     let mut command = create_command(args, &shim_name, &exe_path)?;
     command.env("PROTO_LOG", log_level);
 
-    let child = spawn_command_with_signals(command)?;
+    let status = spawn_command_with_signals(command, |child_id| {
+        trace!(
+            shim = &shim_name,
+            pid = std::process::id(),
+            child_pid = child_id,
+            "Spawning proto child process"
+        );
+    })?;
 
-    trace!(
-        shim = &shim_name,
-        pid = std::process::id(),
-        child_pid = child.id(),
-        "Spawning proto child process"
-    );
-
-    let status = child.wait()?;
     let code = status.code().unwrap_or(1);
 
     trace!(shim = &shim_name, code, "Received exit code");

--- a/crates/cli/src/main_shim.rs
+++ b/crates/cli/src/main_shim.rs
@@ -37,6 +37,18 @@ fn locate_proto_binary(proto_home_dir: &Path, shim_exe_path: &Path) -> Option<Pa
             lookup_dirs.push(PathBuf::from(dir).join("debug"));
         }
 
+        if let Ok(dir) = env::var("CARGO_MANIFEST_DIR") {
+            lookup_dirs.push(
+                PathBuf::from(if let Some(index) = dir.find("crates") {
+                    &dir[0..index]
+                } else {
+                    &dir
+                })
+                .join("target")
+                .join("debug"),
+            );
+        }
+
         if let Ok(dir) = env::var("GITHUB_WORKSPACE") {
             lookup_dirs.push(PathBuf::from(dir).join("target").join("debug"));
         }

--- a/crates/cli/src/shared.rs
+++ b/crates/cli/src/shared.rs
@@ -1,22 +1,28 @@
 // This code is shared between the shim and main binaries!
 
-use shared_child::SharedChild;
-use signal_hook::consts::*;
-use std::process::Command;
-use std::sync::Arc;
-use std::{io, thread};
+use std::io;
+use std::process::{Command, ExitStatus};
 
-// https://blog.logrocket.com/guide-signal-handling-rust/
-pub fn spawn_command_with_signals(mut command: Command) -> io::Result<Arc<SharedChild>> {
+// On Unix, use native signals.
+#[cfg(not(windows))]
+pub fn spawn_command_with_signals(
+    mut command: Command,
+    on_spawn: impl FnOnce(u32),
+) -> io::Result<ExitStatus> {
+    use shared_child::SharedChild;
+    use signal_hook::consts::*;
+    use std::sync::Arc;
+    use std::thread;
+
     let shared_child = SharedChild::spawn(&mut command)?;
     let child = Arc::new(shared_child);
     let child_clone = Arc::clone(&child);
 
-    #[cfg(not(windows))]
     thread::spawn(move || {
         use shared_child::unix::SharedChildExt;
         use signal_hook::iterator::Signals;
 
+        // https://blog.logrocket.com/guide-signal-handling-rust/
         let mut signals =
             Signals::new([SIGTERM, SIGQUIT, SIGINT, SIGHUP, SIGABRT, SIGUSR1, SIGUSR2]).unwrap();
 
@@ -38,21 +44,22 @@ pub fn spawn_command_with_signals(mut command: Command) -> io::Result<Arc<Shared
         }
     });
 
-    #[cfg(windows)]
-    thread::spawn(move || {
-        use signal_hook::low_level::register;
+    on_spawn(child.id());
+    child.wait()
+}
 
-        for signal in TERM_SIGNALS {
-            let child_clone = Arc::clone(&child_clone);
+// On Windows, use job objects.
+#[cfg(windows)]
+pub fn spawn_command_with_signals(
+    mut command: Command,
+    on_spawn: impl FnOnce(u32),
+) -> io::Result<ExitStatus> {
+    use command_group::CommandGroup;
 
-            unsafe {
-                register(*signal, move || {
-                    let _ = child_clone.kill();
-                })
-                .unwrap()
-            };
-        }
-    });
+    let mut group = command.group();
+    group.kill_on_drop(true);
 
-    Ok(child)
+    let mut child = group.spawn()?;
+    on_spawn(child.id());
+    child.wait()
 }

--- a/crates/cli/src/shared.rs
+++ b/crates/cli/src/shared.rs
@@ -1,0 +1,41 @@
+// This code is shared between the shim and main binaries!
+
+use shared_child::SharedChild;
+use signal_hook::{consts::TERM_SIGNALS, iterator::Signals};
+use std::process::Command;
+use std::sync::Arc;
+use std::{io, thread};
+
+pub fn spawn_command_with_signals(mut command: Command) -> io::Result<Arc<SharedChild>> {
+    let shared_child = SharedChild::spawn(&mut command)?;
+    let child = Arc::new(shared_child);
+    let child_clone = Arc::clone(&child);
+
+    thread::spawn(move || {
+        let mut signals = Signals::new(TERM_SIGNALS).unwrap();
+
+        for signal in signals.forever() {
+            #[cfg(not(windows))]
+            {
+                use shared_child::unix::SharedChildExt;
+
+                let a = child_clone.send_signal(signal);
+
+                dbg!(&a);
+
+                if a.is_err() {
+                    let _ = child_clone.kill();
+                }
+            }
+
+            #[cfg(windows)]
+            {
+                let _ = child_clone.kill();
+            }
+
+            break;
+        }
+    });
+
+    Ok(child)
+}

--- a/crates/cli/src/shared.rs
+++ b/crates/cli/src/shared.rs
@@ -1,41 +1,56 @@
 // This code is shared between the shim and main binaries!
 
 use shared_child::SharedChild;
-use signal_hook::{consts::TERM_SIGNALS, iterator::Signals};
+use signal_hook::consts::*;
 use std::process::Command;
 use std::sync::Arc;
 use std::{io, thread};
 
+// https://blog.logrocket.com/guide-signal-handling-rust/
 pub fn spawn_command_with_signals(mut command: Command) -> io::Result<Arc<SharedChild>> {
     let shared_child = SharedChild::spawn(&mut command)?;
     let child = Arc::new(shared_child);
     let child_clone = Arc::clone(&child);
 
+    #[cfg(not(windows))]
     thread::spawn(move || {
-        let mut signals = Signals::new(TERM_SIGNALS).unwrap();
+        use shared_child::unix::SharedChildExt;
+        use signal_hook::iterator::Signals;
 
-        #[allow(unused_assignments)]
-        let mut stop = false;
+        let mut signals =
+            Signals::new([SIGTERM, SIGQUIT, SIGINT, SIGHUP, SIGABRT, SIGUSR1, SIGUSR2]).unwrap();
 
         for signal in signals.forever() {
-            #[cfg(not(windows))]
-            {
-                use shared_child::unix::SharedChildExt;
+            let mut sent = child_clone.send_signal(signal).is_ok();
 
-                stop = child_clone
-                    .send_signal(signal)
-                    .or_else(|_| child_clone.kill())
-                    .is_ok();
-            }
+            match signal {
+                SIGTERM | SIGQUIT | SIGINT | SIGHUP | SIGABRT => {
+                    if !sent {
+                        sent = child_clone.kill().is_ok();
+                    }
 
-            #[cfg(windows)]
-            {
-                stop = child_clone.kill().is_ok();
+                    if sent {
+                        break;
+                    }
+                }
+                _ => {}
             }
+        }
+    });
 
-            if stop {
-                break;
-            }
+    #[cfg(windows)]
+    thread::spawn(move || {
+        use signal_hook::low_level::register;
+
+        for signal in TERM_SIGNALS {
+            let child_clone = Arc::clone(&child_clone);
+
+            unsafe {
+                register(*signal, move || {
+                    let _ = child_clone.kill();
+                })
+                .unwrap()
+            };
         }
     });
 

--- a/crates/cli/tests/fixtures/shim-signal.mjs
+++ b/crates/cli/tests/fixtures/shim-signal.mjs
@@ -1,8 +1,18 @@
 console.log("start");
 
 process.on("SIGINT", () => {
-  console.log("killed");
-  process.exit(1);
+  console.log("interrupted");
+  process.exit(2);
+});
+
+process.on("SIGTERM", () => {
+  console.log("terminated");
+  process.exit(3);
+});
+
+process.on("SIGHUP", () => {
+  console.log("hangup");
+  process.exit(4);
 });
 
 setTimeout(() => {

--- a/crates/core/src/proto.rs
+++ b/crates/core/src/proto.rs
@@ -74,6 +74,18 @@ impl ProtoEnvironment {
                 lookup_dirs.push(PathBuf::from(dir).join("debug"));
             }
 
+            if let Ok(dir) = env::var("CARGO_MANIFEST_DIR") {
+                lookup_dirs.push(
+                    PathBuf::from(if let Some(index) = dir.find("crates") {
+                        &dir[0..index]
+                    } else {
+                        &dir
+                    })
+                    .join("target")
+                    .join("debug"),
+                );
+            }
+
             if let Ok(dir) = env::var("GITHUB_WORKSPACE") {
                 lookup_dirs.push(PathBuf::from(dir).join("target").join("debug"));
             }

--- a/docs/shim-test.mjs
+++ b/docs/shim-test.mjs
@@ -1,6 +1,5 @@
 console.log("start");
 
-// Test CTRL+C handling
 process.on("SIGINT", () => {
   console.log("interrupted");
   process.exit(2);

--- a/docs/shim-test.mjs
+++ b/docs/shim-test.mjs
@@ -2,8 +2,18 @@ console.log("start");
 
 // Test CTRL+C handling
 process.on("SIGINT", () => {
-  console.log("killed");
-  process.exit(1);
+  console.log("interrupted");
+  process.exit(2);
+});
+
+process.on("SIGTERM", () => {
+  console.log("terminated");
+  process.exit(3);
+});
+
+process.on("SIGHUP", () => {
+  console.log("hangup");
+  process.exit(4);
 });
 
 // Test piping input
@@ -34,6 +44,6 @@ getStdinBuffer().then((buffer) => {
 // Start a timer so we can ensure "stop" is never logged
 setTimeout(() => {
   console.log("stop");
-}, 5000);
+}, 1000 * 60 * 1);
 
 console.log("running");

--- a/justfile
+++ b/justfile
@@ -26,7 +26,7 @@ lint-wasm:
 	cd plugins && cargo clippy --workspace --all-targets
 
 test name="":
-	just build-shim
+	just build
 	cargo nextest run --workspace {{name}}
 
 test-ci:


### PR DESCRIPTION
Uses `signal-hook` (which also has windows support) to handle signals correctly. I also wrapped the `proto run` in the same logic, since the flow is `shim -> proto run -> tool`.