### PR TITLE
Remove `version` from local crates

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -27,9 +27,9 @@ name = "proto"
 path = "src/main.rs"
 
 [dependencies]
-proto_core = { version = "0.25.2", path = "../core" }
-proto_pdk_api = { version = "0.11.2", path = "../pdk-api" }
-system_env = { version = "0.1.8", path = "../system-env" }
+proto_core = { path = "../core" }
+proto_pdk_api = { path = "../pdk-api" }
+system_env = { path = "../system-env" }
 chrono = "0.4.31"
 clap = { workspace = true, features = ["derive", "env"] }
 clap_complete = { workspace = true }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -8,14 +8,14 @@ homepage = "https://moonrepo.dev/proto"
 repository = "https://github.com/moonrepo/proto"
 
 [dependencies]
-proto_pdk_api = { version = "0.11.2", path = "../pdk-api" }
-system_env = { version = "0.1.8", path = "../system-env", features = [
+proto_pdk_api = { path = "../pdk-api" }
+system_env = { path = "../system-env", features = [
 	"schematic",
 ] }
-version_spec = { version = "0.1.7", path = "../version-spec", features = [
+version_spec = { path = "../version-spec", features = [
 	"schematic",
 ] }
-warpgate = { version = "0.7.0", path = "../warpgate", features = ["schematic"] }
+warpgate = { path = "../warpgate", features = ["schematic"] }
 cached = { workspace = true }
 extism = { workspace = true }
 human-sort = { workspace = true }

--- a/crates/pdk-api/Cargo.toml
+++ b/crates/pdk-api/Cargo.toml
@@ -8,9 +8,9 @@ homepage = "https://moonrepo.dev/proto"
 repository = "https://github.com/moonrepo/proto"
 
 [dependencies]
-system_env = { version = "0.1.8", path = "../system-env" }
-version_spec = { version = "0.1.7", path = "../version-spec" }
-warpgate_api = { version = "0.1.6", path = "../warpgate-api" }
+system_env = { path = "../system-env" }
+version_spec = { path = "../version-spec" }
+warpgate_api = { path = "../warpgate-api" }
 anyhow = "1.0.75"
 semver = { workspace = true, features = ["serde"] }
 serde = { workspace = true }

--- a/crates/pdk-test-utils/Cargo.toml
+++ b/crates/pdk-test-utils/Cargo.toml
@@ -8,8 +8,8 @@ homepage = "https://moonrepo.dev/proto"
 repository = "https://github.com/moonrepo/proto"
 
 [dependencies]
-proto_core = { version = "0.25.2", path = "../core" }
-proto_pdk_api = { version = "0.11.2", path = "../pdk-api" }
+proto_core = { path = "../core" }
+proto_pdk_api = { path = "../pdk-api" }
 extism = { workspace = true }
 serde_json = { workspace = true }
 toml = { version = "0.8.8", optional = true }

--- a/crates/pdk/Cargo.toml
+++ b/crates/pdk/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://moonrepo.dev/proto"
 repository = "https://github.com/moonrepo/proto"
 
 [dependencies]
-proto_pdk_api = { version = "0.11.2", path = "../pdk-api" }
+proto_pdk_api = { path = "../pdk-api" }
 anyhow = "1.0.75"
 extism-pdk = { workspace = true }
 serde = { workspace = true }

--- a/crates/warpgate/Cargo.toml
+++ b/crates/warpgate/Cargo.toml
@@ -7,7 +7,7 @@ description = "Download, resolve, and manage Extism WASM plugins at runtime."
 repository = "https://github.com/moonrepo/proto"
 
 [dependencies]
-warpgate_api = { version = "0.1.6", path = "../warpgate-api" }
+warpgate_api = { path = "../warpgate-api" }
 extism = { workspace = true }
 miette = { workspace = true }
 once_cell = { workspace = true }

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -114,14 +114,14 @@ This will create a `<id>-debug.log` file in the current directory with all log o
 
 proto has a few crates that are used directly by plugins: `proto_pdk`, `proto_pdk_api`, and `proto_pdk_test_utils`.
 
-We can easily add debugging/logging to these crates, and test them within our plugins, by using the `path` setting in `Cargo.toml`. This will force Cargo to use our local crates, instead of the crates from crates.io.
+We can easily add debugging/logging to these crates, and test them within our plugins, by using the `path` setting instead of `version` in `Cargo.toml`. This will force Cargo to use our local crates, instead of the crates from crates.io.
 
 For example in the Node.js plugin's [`Cargo.toml`](https://github.com/moonrepo/node-plugin/blob/master/Cargo.toml), we can uncomment (or insert) the `path`s to point to crates in our local proto checkout:
 
 ```toml
-proto_pdk = { version = "0.8.0", path = "../../proto/crates/pdk" }
-proto_pdk_api = { version = "0.8.0", path = "../../proto/crates/pdk-api" }
-proto_pdk_test_utils = { version = "0.8.2", path = "../../proto/crates/pdk-test-utils" }
+proto_pdk = { path = "../../proto/crates/pdk" }
+proto_pdk_api = { path = "../../proto/crates/pdk-api" }
+proto_pdk_test_utils = { path = "../../proto/crates/pdk-test-utils" }
 ```
 
 From here, just re-build proto and the WASM plugin, and re-run the commands above.


### PR DESCRIPTION
Having both a `path` and a `version` causes Cargo to use a different package source when built locally versus from cargo.

https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#multiple-locations