### PR TITLE
internal: Remove tracing crate.

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -42,8 +42,13 @@ async fn main() -> MainResult {
         ..TracingOptions::default()
     });
 
+    let mut args = env::args_os().collect::<Vec<_>>();
+
     debug!(
-        args = ?env::args().collect::<Vec<_>>(),
+        bin = ?args.remove(0),
+        args = ?args,
+        shim = env::var("PROTO_SHIM_NAME").ok(),
+        shim_bin = env::var("PROTO_SHIM_PATH").ok(),
         pid = std::process::id(),
         "Running proto v{}",
         env!("CARGO_PKG_VERSION")

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -44,6 +44,7 @@ async fn main() -> MainResult {
 
     debug!(
         args = ?env::args().collect::<Vec<_>>(),
+        pid = std::process::id(),
         "Running proto v{}",
         env!("CARGO_PKG_VERSION")
     );

--- a/crates/cli/src/main_shim.rs
+++ b/crates/cli/src/main_shim.rs
@@ -1,6 +1,5 @@
 // NOTE: We want to keep the shim binary as lean as possible,
-// so these imports use std as much as possible, and should
-// not pull in large libraries (tracing is already enough)!
+// so these imports primarily use std, and avoid fat crates.
 
 use anyhow::{anyhow, Result};
 use proto_shim::{exec_command_and_replace, locate_proto_exe};

--- a/crates/core/src/tool.rs
+++ b/crates/core/src/tool.rs
@@ -1203,20 +1203,19 @@ impl Tool {
         let mut locations = vec![];
 
         let mut add = |name: &str, config: ExecutableConfig, primary: bool| {
-            if !config.no_bin {
-                if config
+            if !config.no_bin
+                && config
                     .exe_link_path
                     .as_ref()
                     .or(config.exe_path.as_ref())
                     .is_some()
-                {
-                    locations.push(ExecutableLocation {
-                        path: self.proto.bin_dir.join(get_exe_file_name(name)),
-                        name: name.to_owned(),
-                        config,
-                        primary,
-                    });
-                }
+            {
+                locations.push(ExecutableLocation {
+                    path: self.proto.bin_dir.join(get_exe_file_name(name)),
+                    name: name.to_owned(),
+                    config,
+                    primary,
+                });
             }
         };
 


### PR DESCRIPTION
The shim release filesize was around 2.5mb, which is way too much. Removing `tracing` dropped it down to about 500kb... That's more like it.

To make up for the lost information, I moved some of the values around.