### PR TITLE
fix: Include detection source in error messages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Added a `proto debug env` command, for debugging basic env/store information.
 - Updated version resolve errors to include the tool that failed.
+- Updated missing install errors to include the file that a version was detected from.
 
 #### ⚙️ Internal
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,13 +173,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.74"
+version = "0.1.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
+checksum = "fdf6721fb0140e4f897002dd086c06f6c27775df19cfe1fccb21181a48fd2c98"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -497,7 +497,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -841,7 +841,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.39",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -863,7 +863,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core 0.20.3",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -1101,7 +1101,7 @@ checksum = "d2be216330f7304de051e0faf1578880e9e0dc1ecbd2c0fea5765c63a079d0ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -1284,7 +1284,7 @@ checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -1361,7 +1361,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.39",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -2011,7 +2011,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -2299,9 +2299,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "75cb1540fadbd5b8fbccc4dddad2734eba435053f725621c070711a14bb5f4b8"
 dependencies = [
  "unicode-ident",
 ]
@@ -2825,7 +2825,7 @@ dependencies = [
  "darling 0.20.3",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -2913,7 +2913,7 @@ checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -3106,9 +3106,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "starbase"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7fbfce6b8c392aeda6a5acdb6b4e90c7bb6658f0dc957032471672cf5538001"
+checksum = "735a1804ac4b6051e61bd947abede6bf6ad3131fa819476031604678dec26163"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3159,14 +3159,14 @@ dependencies = [
 
 [[package]]
 name = "starbase_macros"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed281d2657820727914b0ef0bac484a822e66cc783e0b614a4703492f5381da"
+checksum = "988e67c7a4f2afb4c19a431f0a45226538441e12641daaf66a60da031fb44f7d"
 dependencies = [
  "darling 0.20.3",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -3273,9 +3273,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "ee659fb5f3d355364e1f3e5bc10fb82068efbf824a1e9d1c9504244a6469ad53"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3414,22 +3414,22 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f11c217e1416d6f036b870f14e0413d480dbf28edbee1f877abaf0206af43bb7"
+checksum = "83a48fd946b02c0a526b2e9481c8e2a17755e47039164a86c4070446e3a4614d"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01742297787513b79cf8e29d1056ede1313e2420b7b3b15d0a768b4921f549df"
+checksum = "e7fbe9b594d6568a6a1443250a7e67d80b74e1e96f6d1715e1e21cc1888291d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -3524,7 +3524,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -3657,7 +3657,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -3988,7 +3988,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.43",
  "wasm-bindgen-shared",
 ]
 
@@ -4022,7 +4022,7 @@ checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.43",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4885,7 +4885,7 @@ checksum = "86cd5ca076997b97ef09d3ad65efe811fa68c9e874cb636ccb211223a813b0c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.43",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ clap = "4.4.11"
 clap_complete = "4.4.4"
 convert_case = "0.6.0"
 dirs = "5.0.1"
-extism = { version = "0.5.5" }
+extism = "0.5.5"
 extism-pdk = "0.3.4"
 human-sort = "0.2.2"
 miette = "5.10.0"
@@ -24,7 +24,7 @@ serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0.108"
 sha2 = "0.10.8"
 shell-words = "1.1.0"
-starbase = "0.2.10"
+starbase = "0.2.11"
 starbase_archive = { version = "0.2.5", features = [
 	"tar-gz",
 	"tar-xz",
@@ -39,7 +39,7 @@ starbase_utils = { version = "0.3.11", default-features = false, features = [
 	"json",
 	"toml",
 ] }
-thiserror = "1.0.51"
+thiserror = "1.0.52"
 tokio = { version = "1.35.1", features = ["full", "tracing"] }
 tracing = "0.1.40"
 

--- a/crates/cli/src/commands/install_all.rs
+++ b/crates/cli/src/commands/install_all.rs
@@ -30,7 +30,7 @@ pub async fn install_all(proto: ResourceRef<ProtoResource>) {
             continue;
         }
 
-        if let Some(candidate) = tool.detect_version_from(&proto.env.cwd).await? {
+        if let Some((candidate, _)) = tool.detect_version_from(&proto.env.cwd).await? {
             debug!("Detected version {} for {}", candidate, tool.get_name());
 
             versions.insert(tool.id.clone(), candidate);

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -153,12 +153,24 @@ pub async fn run(args: ArgsRef<RunArgs>, proto: ResourceRef<ProtoResource>) -> S
         let config = tool.proto.load_config()?;
 
         if !config.settings.auto_install {
-            return Err(ProtoError::MissingToolForRun {
-                tool: tool.get_name().to_owned(),
-                version: version.to_string(),
-                command: format!("proto install {} {}", tool.id, tool.get_resolved_version()),
+            let command = format!("proto install {} {}", tool.id, tool.get_resolved_version());
+
+            if let Ok(source) = env::var("PROTO_DETECTED_FROM") {
+                return Err(ProtoError::MissingToolForRunWithSource {
+                    tool: tool.get_name().to_owned(),
+                    version: version.to_string(),
+                    command,
+                    path: source.into(),
+                }
+                .into());
+            } else {
+                return Err(ProtoError::MissingToolForRun {
+                    tool: tool.get_name().to_owned(),
+                    version: version.to_string(),
+                    command,
+                }
+                .into());
             }
-            .into());
         }
 
         // Install the tool

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -81,6 +81,20 @@ pub enum ProtoError {
         command: String,
     },
 
+    #[diagnostic(code(proto::tool::required))]
+    #[error(
+        "This project requires {tool} {} (detected from {}), but this version has not been installed. Install it with {}!",
+        .version.style(Style::Hash),
+        .path.style(Style::Path),
+        .command.style(Style::Shell),
+    )]
+    MissingToolForRunWithSource {
+        tool: String,
+        version: String,
+        command: String,
+        path: PathBuf,
+    },
+
     #[diagnostic(code(proto::tool::uninstall_failed))]
     #[error("Failed to uninstall {tool}. {error}")]
     UninstallFailed { tool: String, error: String },

--- a/crates/core/src/tool.rs
+++ b/crates/core/src/tool.rs
@@ -555,7 +555,7 @@ impl Tool {
     pub async fn detect_version_from(
         &self,
         current_dir: &Path,
-    ) -> miette::Result<Option<UnresolvedVersionSpec>> {
+    ) -> miette::Result<Option<(UnresolvedVersionSpec, PathBuf)>> {
         if !self.plugin.has_func("detect_version_files") {
             return Ok(None);
         }
@@ -614,7 +614,7 @@ impl Tool {
                 "Detected a version"
             );
 
-            return Ok(Some(version));
+            return Ok(Some((version, file_path)));
         }
 
         Ok(None)


### PR DESCRIPTION
This will help users who don't know why a certain version is being used.

<img width="1492" alt="Screenshot 2023-12-26 at 10 53 42 AM" src="https://github.com/moonrepo/proto/assets/143744/645d72d2-874e-48b4-9f80-727ded574bdd">
