### PR TITLE
fix: Temporarily fix Windows shims.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 #### 🐞 Fixes
 
 - Fixed the `bun_plugin` being set to an incorrect version.
+- Temporarily fixed "Access is denied" errors on Windows when creating shims.
+- More improvements for the Elvish shell.
 
 ## 0.26.1
 

--- a/crates/shim/src/windows.rs
+++ b/crates/shim/src/windows.rs
@@ -30,6 +30,22 @@ pub fn get_shim_file_name(name: &str) -> String {
     get_exe_file_name(name)
 }
 
+macro_rules! handle_io_error {
+    ($expr:expr) => {
+         if let Err(error) = $expr {
+            // If we receive an "Access is denied" error, we should 
+            // exit early as there's no way around this, as this exe
+            // may be currently in use by another process. This happens
+            // consistently when ran through task runners (like moon).
+            if error.raw_os_error().is_some_and(|code| code == 5) {
+                return Ok(());
+            } else {
+                return Err(error);
+            }
+        }
+    };
+}
+
 // We can't remove or overwrite an executable that is currently running,
 // but we can rename it and create the new shim alongside it.
 // @see https://stackoverflow.com/a/7198760
@@ -43,11 +59,11 @@ pub fn create_shim(source_code: &[u8], shim_path: &Path, find_only: bool) -> io:
 
     // Rename the current exe
     if shim_path.exists() {
-        fs::rename(shim_path, &renamed_shim_path)?;
+        handle_io_error!(fs::rename(shim_path, &renamed_shim_path));
     }
 
     // Create the new exe
-    fs::write(shim_path, source_code)?;
+    handle_io_error!(fs::write(shim_path, source_code));
 
     // Attempt to remove the old exe (but don't fail)
     if renamed_shim_path.exists() {

--- a/crates/shim/src/windows.rs
+++ b/crates/shim/src/windows.rs
@@ -32,8 +32,8 @@ pub fn get_shim_file_name(name: &str) -> String {
 
 macro_rules! handle_io_error {
     ($expr:expr) => {
-         if let Err(error) = $expr {
-            // If we receive an "Access is denied" error, we should 
+        if let Err(error) = $expr {
+            // If we receive an "Access is denied" error, we should
             // exit early as there's no way around this, as this exe
             // may be currently in use by another process. This happens
             // consistently when ran through task runners (like moon).

--- a/justfile
+++ b/justfile
@@ -13,6 +13,9 @@ build-shim:
 build-wasm:
 	cd plugins && cargo wasi build
 
+check:
+	cargo check --workspace
+
 format:
 	cargo fmt --all
 


### PR DESCRIPTION
Windows shims seems to fail in moon consistently with "Access is denied"errors: https://github.com/moonrepo/moon/actions/runs/7333162316/job/19969691809?pr=1244

I'm not entirely sure why. I'm assuming that the exe is in use by another process and renaming fails.

If we hit this error, we just return early, because it's still safe because the shim already exists anyways.