### PR TITLE
new: Add more shim lookups.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@
 - [Rust](https://github.com/moonrepo/rust-plugin/blob/master/CHANGELOG.md)
 - [TOML schema](https://github.com/moonrepo/schema-plugin/blob/master/CHANGELOG.md)
 
+## Unreleased
+
+#### 🚀 Updates
+
+- Added more lookup directories when locating the `proto-shim` file.
+- Updated the CLI to set the `PROTO_VERSION` environment variable.
+
 ## 0.26.3
 
 #### 🐞 Fixes

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -19,12 +19,15 @@ async fn main() -> MainResult {
     App::setup_diagnostics();
 
     let cli = CLI::parse();
+    let version = env!("CARGO_PKG_VERSION");
 
     if let Some(level) = cli.log {
         env::set_var("STARBASE_LOG", level.to_string());
     } else if let Ok(level) = env::var("PROTO_LOG") {
         env::set_var("STARBASE_LOG", level);
     }
+
+    env::set_var("PROTO_VERSION", version);
 
     App::setup_tracing_with_options(TracingOptions {
         default_level: if matches!(cli.command, Commands::Bin { .. } | Commands::Run { .. }) {
@@ -51,7 +54,7 @@ async fn main() -> MainResult {
         shim_bin = env::var("PROTO_SHIM_PATH").ok(),
         pid = std::process::id(),
         "Running proto v{}",
-        env!("CARGO_PKG_VERSION")
+        version
     );
 
     let mut app = App::new();

--- a/crates/shim/src/lib.rs
+++ b/crates/shim/src/lib.rs
@@ -57,13 +57,23 @@ pub fn locate_proto_exe(bin: &str) -> Option<PathBuf> {
     }
 
     if let Ok(dir) = env::var("PROTO_HOME") {
-        lookup_dirs.push(PathBuf::from(dir).join("bin"));
+        let dir = PathBuf::from(dir);
+
+        if let Ok(version) = env::var("PROTO_VERSION") {
+            lookup_dirs.push(dir.join("tools").join("proto").join(version));
+        }
+
+        lookup_dirs.push(dir.join("bin"));
     }
 
     // Special case for unit tests and other isolations where
     // PROTO_HOME is set to something random, but the proto
     // binaries still exist in their original location.
     if let Some(dir) = dirs::home_dir() {
+        if let Ok(version) = env::var("PROTO_VERSION") {
+            lookup_dirs.push(dir.join(".proto").join("tools").join("proto").join(version));
+        }
+
         lookup_dirs.push(dir.join(".proto").join("bin"));
     }
 


### PR DESCRIPTION
moon installs proto to `~/.proto/tools/proto/<version>`, so the shim file cannot be found in a clean environment.