### PR TITLE
new: Automatically configure Windows system PATH

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2439,6 +2439,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+ "winreg 0.52.0",
 ]
 
 [[package]]
@@ -2737,7 +2738,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "winreg",
+ "winreg 0.50.0",
 ]
 
 [[package]]
@@ -4847,6 +4848,16 @@ name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -70,3 +70,6 @@ sigpipe = "0.1.3"
 [dev-dependencies]
 starbase_sandbox = { workspace = true }
 shared_child = "1.0.0"
+
+[target."cfg(windows)".dependencies]
+winreg = { version = "0.52.0", default-features = false }

--- a/crates/cli/src/commands/setup.rs
+++ b/crates/cli/src/commands/setup.rs
@@ -135,6 +135,27 @@ fn already_setup_message(installed_bin_path: PathBuf) {
     help_message();
 }
 
+fn manual_system_path_message(proto: &ProtoResource) {
+    println!(
+        "Add the following to your {} to get started:",
+        color::property("PATH")
+    );
+    println!();
+    println!(
+        "{}",
+        if cfg!(windows) {
+            // we avoid %USERPROFILE% as it only works in the user path and not system path
+            color::muted_light(format!(
+                "{};{}",
+                proto.env.store.shims_dir.as_os_str().to_string_lossy(),
+                proto.env.store.bin_dir.as_os_str().to_string_lossy()
+            ))
+        } else {
+            color::muted_light("$HOME/.proto/shims;$HOME/.proto/bin")
+        },
+    );
+}
+
 fn finished_message(
     proto: &ProtoResource,
     exported_content: Option<String>,
@@ -149,29 +170,18 @@ fn finished_message(
 
     if path_was_updated {
         println!("Launch a new terminal window to start using proto!");
-    } else if exported_content.is_some() && cfg!(not(windows)) {
-        println!("Add the following to your shell profile to get started:");
+    } else if exported_content.is_some() {
+        if cfg!(windows) {
+            manual_system_path_message(proto);
+            println!();
+            println!("Or alternatively add the following to your shell profile:");
+        } else {
+            println!("Add the following to your shell profile to get started:");
+        }
         println!();
         println!("{}", color::muted_light(exported_content.unwrap().trim()));
     } else {
-        println!(
-            "Add the following to your {} to get started:",
-            color::property("PATH")
-        );
-        println!();
-        println!(
-            "{}",
-            if cfg!(windows) {
-                // we avoid %USERPROFILE% as it only works in the user path and not system path
-                color::muted_light(format!(
-                    "{};{}",
-                    proto.env.store.shims_dir.as_os_str().to_string_lossy(),
-                    proto.env.store.bin_dir.as_os_str().to_string_lossy()
-                ))
-            } else {
-                color::muted_light("$HOME/.proto/shims;$HOME/.proto/bin")
-            },
-        );
+        manual_system_path_message(&proto);
     }
 
     println!();

--- a/crates/cli/src/commands/setup.rs
+++ b/crates/cli/src/commands/setup.rs
@@ -1,11 +1,10 @@
-use crate::helpers::{create_theme, ProtoResource};
+use crate::helpers::ProtoResource;
 use crate::shell::{
-    detect_shell, find_profiles, format_exports, write_profile, write_profile_if_not_setup, Export,
+    detect_shell, format_exports, prompt_for_shell_profile, write_profile,
+    write_profile_if_not_setup, Export,
 };
 use clap::Args;
 use clap_complete::Shell;
-use dialoguer::{Input, Select};
-use miette::IntoDiagnostic;
 use proto_shim::get_exe_file_name;
 use starbase::system;
 use starbase_styles::color;
@@ -15,6 +14,9 @@ use std::io::IsTerminal;
 use std::path::PathBuf;
 use tracing::debug;
 
+#[cfg(windows)]
+mod windows;
+
 #[derive(Args, Clone, Debug)]
 pub struct SetupArgs {
     #[arg(long, help = "Shell to setup for")]
@@ -22,6 +24,9 @@ pub struct SetupArgs {
 
     #[arg(long, help = "Don't update a shell profile")]
     no_profile: bool,
+
+    #[arg(long, help = "Don't update the system path")]
+    no_modify_path: bool,
 
     // deprecated
     #[arg(long, hide = true, help = "Return the shell profile path if setup")]
@@ -35,87 +40,63 @@ pub struct SetupArgs {
 pub async fn setup(args: ArgsRef<SetupArgs>, proto: ResourceRef<ProtoResource>) {
     let shell = detect_shell(args.shell);
     let paths = env::split_paths(&env::var("PATH").unwrap()).collect::<Vec<_>>();
-    let installed_bin_path = proto.env.store.bin_dir.join(get_exe_file_name("proto"));
 
     if paths.contains(&proto.env.store.shims_dir) && paths.contains(&proto.env.store.bin_dir) {
         debug!("Skipping setup, proto already exists in PATH");
 
+        let installed_bin_path = proto.env.store.bin_dir.join(get_exe_file_name("proto"));
         already_setup_message(installed_bin_path);
 
         return Ok(());
     }
 
-    let Some(content) = format_exports(
+    println!("Finishing proto installation...");
+
+    let mut path_was_updated = false;
+
+    #[cfg(windows)]
+    if !args.no_modify_path {
+        path_was_updated |= windows::do_add_to_path(vec![
+            proto.env.store.shims_dir.clone(),
+            proto.env.store.bin_dir.clone(),
+        ])?;
+    }
+
+    let content = format_exports(
         &shell,
         "proto",
         vec![
             Export::Var("PROTO_HOME".into(), "$HOME/.proto".into()),
             Export::Path(vec!["$PROTO_HOME/shims".into(), "$PROTO_HOME/bin".into()]),
         ],
-    ) else {
-        finished_message(installed_bin_path, None, None);
+    );
 
-        return Ok(());
-    };
-
-    // Avoid updating the shell profile
-    if args.no_profile {
-        finished_message(installed_bin_path, None, Some(content));
-
-        return Ok(());
+    if !args.no_profile {
+        if let Some(ref content) = content {
+            let interactive = !args.yes && env::var("CI").is_err() && stdout().is_terminal();
+            path_was_updated |=
+                update_shell_profile(&shell, &proto, &content, interactive)?.is_some();
+        }
     }
 
-    // Otherwise attempt to update the shell profile
+    finished_message(&proto, content, path_was_updated);
+}
+
+fn update_shell_profile(
+    shell: &Shell,
+    proto: &ProtoResource,
+    content: &String,
+    interactive: bool,
+) -> miette::Result<Option<PathBuf>> {
     debug!("Updating PATH in {} shell", shell);
 
     let profile_path;
-    let interactive = !args.yes && env::var("CI").is_err() && stdout().is_terminal();
-
-    println!("Finishing proto installation...");
 
     // If interactive, let the user pick a profile
     if interactive {
         debug!("Prompting the user to select a shell profile");
 
-        let theme = create_theme();
-
-        let mut profiles = find_profiles(&shell)?;
-        profiles.reverse();
-
-        let mut items = profiles.iter().map(color::path).collect::<Vec<_>>();
-        items.push("Other".to_owned());
-        items.push("None".to_owned());
-
-        let default_index = 0;
-        let other_index = profiles.len();
-        let none_index = other_index + 1;
-
-        let selected_index = Select::with_theme(&theme)
-            .with_prompt("Which profile to update?")
-            .items(&items)
-            .default(default_index)
-            .interact_opt()
-            .into_diagnostic()?
-            .unwrap_or(default_index);
-
-        if selected_index == none_index {
-            profile_path = None;
-        } else if selected_index == other_index {
-            let custom_path = PathBuf::from(
-                Input::<String>::with_theme(&theme)
-                    .with_prompt("Custom profile path?")
-                    .interact_text()
-                    .into_diagnostic()?,
-            );
-
-            profile_path = Some(if custom_path.is_absolute() {
-                custom_path
-            } else {
-                proto.env.cwd.join(custom_path)
-            });
-        } else {
-            profile_path = Some(profiles[selected_index].clone());
-        }
+        profile_path = prompt_for_shell_profile(shell, &proto.env.cwd)?;
 
         if let Some(profile) = &profile_path {
             debug!("Selected profile {}, updating", color::path(profile));
@@ -132,10 +113,11 @@ pub async fn setup(args: ArgsRef<SetupArgs>, proto: ResourceRef<ProtoResource>) 
 
     // If we found a profile, update the global config so we can reference it
     if let Some(profile) = &profile_path {
+        println!("Updated profile {}", color::path(profile));
         proto.env.store.save_preferred_profile(profile)?;
     }
 
-    finished_message(installed_bin_path, profile_path, Some(content));
+    Ok(profile_path)
 }
 
 fn help_message() {
@@ -154,38 +136,42 @@ fn already_setup_message(installed_bin_path: PathBuf) {
 }
 
 fn finished_message(
-    installed_bin_path: PathBuf,
-    updated_profile_path: Option<PathBuf>,
+    proto: &ProtoResource,
     exported_content: Option<String>,
+    path_was_updated: bool,
 ) {
-    if let Some(profile_path) = updated_profile_path {
-        println!(
-            "Successfully installed proto to {} and updated profile {}!",
-            color::path(installed_bin_path),
-            color::path(profile_path),
-        );
+    let installed_bin_path = proto.env.store.bin_dir.join(get_exe_file_name("proto"));
+
+    println!(
+        "Successfully installed proto to {}!",
+        color::path(installed_bin_path),
+    );
+
+    if path_was_updated {
         println!("Launch a new terminal window to start using proto!");
+    } else if exported_content.is_some() && cfg!(not(windows)) {
+        println!("Add the following to your shell profile to get started:");
+        println!();
+        println!("{}", color::muted_light(exported_content.unwrap().trim()));
     } else {
         println!(
-            "Successfully installed proto to {}!",
-            color::path(installed_bin_path),
+            "Add the following to your {} to get started:",
+            color::property("PATH")
         );
-
-        if let Some(content) = exported_content {
-            println!("Add the following to your shell profile to get started:");
-            println!();
-            println!("{}", color::muted_light(content.trim()));
-        } else {
-            println!(
-                "Add the following to your {} to get started:",
-                color::property("PATH")
-            );
-            println!();
-            println!(
-                "{}",
+        println!();
+        println!(
+            "{}",
+            if cfg!(windows) {
+                // we avoid %USERPROFILE% as it only works in the user path and not system path
+                color::muted_light(format!(
+                    "{};{}",
+                    proto.env.store.shims_dir.as_os_str().to_string_lossy(),
+                    proto.env.store.bin_dir.as_os_str().to_string_lossy()
+                ))
+            } else {
                 color::muted_light("$HOME/.proto/shims;$HOME/.proto/bin")
-            );
-        }
+            },
+        );
     }
 
     println!();

--- a/crates/cli/src/commands/setup/windows.rs
+++ b/crates/cli/src/commands/setup/windows.rs
@@ -1,0 +1,154 @@
+use std::ffi::OsString;
+use std::os::windows::ffi::OsStrExt;
+use std::path::PathBuf;
+
+use miette::{IntoDiagnostic, Result};
+
+use tracing::debug;
+use winreg::enums::{RegType, HKEY_CURRENT_USER, KEY_READ, KEY_WRITE};
+use winreg::{RegKey, RegValue};
+
+pub(crate) fn do_add_to_path(dirs: Vec<PathBuf>) -> Result<bool> {
+    let current_path = get_path_var()?;
+
+    let dirs: Vec<Vec<u16>> = dirs
+        .iter()
+        .map(|dir| OsString::from(dir).encode_wide().collect::<Vec<u16>>())
+        .filter(|dir| !path_contains(&current_path, &dir))
+        .collect();
+
+    let new_path = dirs
+        .iter()
+        .chain([&current_path])
+        .fold(vec![], |acc, path| path_join(&acc, &path));
+
+    if current_path == new_path {
+        debug!("System PATH already contains the new entries, leaving it untouched");
+        Ok(false)
+    } else {
+        debug!("Updating system PATH");
+        set_path_var(&new_path)?;
+        Ok(true)
+    }
+}
+
+fn get_path_var() -> Result<Vec<u16>> {
+    use std::io::{Error, ErrorKind};
+
+    RegKey::predef(HKEY_CURRENT_USER)
+        .open_subkey_with_flags("Environment", KEY_READ)
+        .and_then(|env| env.get_raw_value("PATH"))
+        .and_then(|value| {
+            winreg_ext::from_winreg_value(&value).ok_or(Error::new(
+                ErrorKind::InvalidData,
+                "The registry key HKEY_CURRENT_USER\\Environment\\PATH is not a string",
+            ))
+        })
+        .or_else(|err| {
+            if err.kind() == ErrorKind::NotFound {
+                Ok(vec![])
+            } else {
+                Err(err)
+            }
+        })
+        .into_diagnostic()
+}
+
+fn set_path_var(new_path: &[u16]) -> Result<()> {
+    RegKey::predef(HKEY_CURRENT_USER)
+        .open_subkey_with_flags("Environment", KEY_READ | KEY_WRITE)
+        .and_then(|environment| {
+            if new_path.is_empty() {
+                environment.delete_value("PATH")
+            } else {
+                let reg_value = RegValue {
+                    bytes: winreg_ext::to_winreg_bytes(new_path),
+                    vtype: RegType::REG_EXPAND_SZ,
+                };
+                environment.set_raw_value("PATH", &reg_value)
+            }
+        })
+        .into_diagnostic()
+}
+
+/// Checks whether the windows path contains the given entry.
+/// Note this does not guarantee any match isn't just a substring of a longer entry,
+/// i.e. the entry "/proto" will match "/proto/bin".
+fn path_contains(path: &[u16], entry: &[u16]) -> bool {
+    path.windows(entry.len()).any(|path| path == entry)
+}
+
+fn path_join(left: &[u16], right: &[u16]) -> Vec<u16> {
+    if left.is_empty() {
+        right.to_owned()
+    } else if right.is_empty() {
+        left.to_owned()
+    } else {
+        let sep = b';' as u16;
+        [left, right].join(&sep)
+    }
+}
+
+// This is copied from:
+// https://github.com/rust-lang/rustup/blob/a49059082a7b5cd2a59c1d8adf1b9a5a64402203/src/cli/self_update/windows.rs
+//
+// License:
+//
+// Copyright (c) 2016 The Rust Project Developers
+//
+// Permission is hereby granted, free of charge, to any
+// person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the
+// Software without restriction, including without
+// limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software
+// is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice
+// shall be included in all copies or substantial portions
+// of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+// ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+// SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+// IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+mod winreg_ext {
+    use winreg::enums::RegType;
+
+    /// Convert a slice of UCS-2 chars to a null-terminated UCS-2 string in bytes
+    pub fn to_winreg_bytes(val: &[u16]) -> Vec<u8> {
+        let mut v = val.to_owned();
+        v.push(0);
+        unsafe { std::slice::from_raw_parts(v.as_ptr().cast::<u8>(), v.len() * 2).to_vec() }
+    }
+
+    /// This is used to decode the value of HKCU\Environment\PATH. If that key is
+    /// not REG_SZ | REG_EXPAND_SZ then this returns None. The winreg library itself
+    /// does a lossy unicode conversion.
+    pub fn from_winreg_value(val: &winreg::RegValue) -> Option<Vec<u16>> {
+        use std::slice;
+
+        match val.vtype {
+            RegType::REG_SZ | RegType::REG_EXPAND_SZ => {
+                // Copied from winreg
+                let mut words = unsafe {
+                    #[allow(clippy::cast_ptr_alignment)]
+                    slice::from_raw_parts(val.bytes.as_ptr().cast::<u16>(), val.bytes.len() / 2)
+                        .to_owned()
+                };
+                while words.last() == Some(&0) {
+                    words.pop();
+                }
+                Some(words)
+            }
+            _ => None,
+        }
+    }
+}


### PR DESCRIPTION
Very much inspired by rustup's implementation and in fact the low-level byte handling was copied verbatim, hence I added their MIT license. I hope this is fine with you, as I don't really know another way to achieve that part.

I added a --no-modify-path parameter to the setup command, but it's only really relevant for Windows. Should I conditionally compile it in, or is it better to keep the API identical?

I also had to restructure the setup flow quite a bit. I think I kept the same spirit of it, but let me know if you're unhappy with any of it. 

Note in the finished_message I opted for not suggesting Windows users to configure their PowerShell profile manually, and instead just tell them what to add to the system PATH if they didn't let us do it for them.

---

A final thing that just hit me, is something I encountered personally when I started using proto. I prepended my path (the user one) manually, just like this would do and for the most part it worked fine. Down the line I had an issue with a binary (dotnet maybe?) that was installed and added by its own installer to the system path (if I didn't just forget about doing it myself that is). This will always take precedence over the user one, as the user path is append to the system path. I ended up having to remove that binary from the system path. 

I don't see a way around this though... Maybe just something for the upcoming `proto doctor` command to check for and warn about?