### PR TITLE
new: use .zshenv by default

### DIFF
--- a/crates/cli/src/shell.rs
+++ b/crates/cli/src/shell.rs
@@ -81,7 +81,11 @@ pub fn find_profiles(shell: &Shell) -> miette::Result<Vec<PathBuf>> {
         Shell::Zsh => {
             let zdot_dir = env::var("ZDOTDIR").map(PathBuf::from).unwrap_or(home_dir);
 
-            profiles.extend([zdot_dir.join(".zprofile"), zdot_dir.join(".zshrc")]);
+            profiles.extend([
+                zdot_dir.join(".zshenv"),
+                zdot_dir.join(".zprofile"),
+                zdot_dir.join(".zshrc"),
+            ]);
         }
         _ => {}
     };


### PR DESCRIPTION
**References:**
https://zsh.sourceforge.io/Intro/intro_3.html
> `.zshenv' is sourced on all invocations of the shell, unless the -f option is set. It should contain commands to set the command search path, plus other important environment variables.

**Implementation in rustup:**
https://github.com/rust-lang/rustup/blob/f26d16b3b940bfb7b5e5aad7ee8f7121569f1d60/src/cli/self_update/shell.rs#L186-L191
