### PR TITLE
fix: recognize version with start with v when leading inequality sign

### DIFF
--- a/crates/version-spec/src/lib.rs
+++ b/crates/version-spec/src/lib.rs
@@ -48,7 +48,7 @@ pub fn clean_version_string<T: AsRef<str>>(value: T) -> String {
     }
 
     // Remove invalid space after <, <=, >, >=.
-    let version = regex::Regex::new(r"([><]=?)[ ]+([0-9])")
+    let version = regex::Regex::new(r"([><]=?)[ ]*v?([0-9])")
         .unwrap()
         .replace_all(&version, "$1$2");
 
@@ -94,6 +94,11 @@ mod tests {
         assert_eq!(clean_version_string(">  1.2.3"), ">1.2.3");
         assert_eq!(clean_version_string("<1.2.3"), "<1.2.3");
         assert_eq!(clean_version_string("<=   1.2.3"), "<=1.2.3");
+
+        assert_eq!(clean_version_string(">= v1.2.3"), ">=1.2.3");
+        assert_eq!(clean_version_string(">  v1.2.3"), ">1.2.3");
+        assert_eq!(clean_version_string("<v1.2.3"), "<1.2.3");
+        assert_eq!(clean_version_string("<=   v1.2.3"), "<=1.2.3");
 
         assert_eq!(clean_version_string("1.2, 3"), "1.2,3");
         assert_eq!(clean_version_string("1,3, 4"), "1,3,4");


### PR DESCRIPTION

Refer to https://github.com/moonrepo/proto/issues/483 issue, some version using `v` version with inequality sign, So recognize that versions.


---


```
just test-ci

     Summary [ 259.601s] 233 tests run: 233 passed, 0 skipped
```