### PR TITLE
fix: Support `.x` in versions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@
 - [Rust](https://github.com/moonrepo/rust-plugin/blob/master/CHANGELOG.md)
 - [TOML schema](https://github.com/moonrepo/schema-plugin/blob/master/CHANGELOG.md)
 
+## Unreleased
+
+#### 🚀 Updates
+
+- Support `.x` when parsing versions. Will be treated as `*`.
+
+#### 🐞 Fixes
+
+- Fixed and removed some "unreachable" branches when parsing versions.
+
 ## 0.38.0
 
 #### 💥 Breaking

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -22,7 +22,7 @@ use tracing::debug;
 fn get_tracing_modules() -> Vec<String> {
     let mut modules = string_vec!["proto", "schematic", "starbase", "warpgate"];
 
-    if bool_var("PROTO_WASM_LOG") {
+    if bool_var("PROTO_DEBUG_WASM") || bool_var("PROTO_WASM_LOG") {
         modules.push("extism".into());
     } else {
         modules.push("extism::pdk".into());

--- a/crates/cli/tests/outdated_test.rs
+++ b/crates/cli/tests/outdated_test.rs
@@ -113,7 +113,7 @@ mod outdated {
     fn updates_each_file_respectively() {
         let sandbox = create_empty_sandbox();
         sandbox.create_file(".proto/.prototools", r#"go = "1.19""#);
-        sandbox.create_file("a/.prototools", r#"node = "20.0.0""#);
+        sandbox.create_file("a/.prototools", r#"node = "19.0.0""#);
         sandbox.create_file("a/b/.prototools", r#"npm = "9.0.0""#);
 
         let mut cmd = create_proto_command(sandbox.path());

--- a/crates/cli/tests/snapshots/outdated_test__outdated__updates_each_file_respectively.snap
+++ b/crates/cli/tests/snapshots/outdated_test__outdated__updates_each_file_respectively.snap
@@ -4,6 +4,6 @@ expression: "vec![fs::read_to_string(sandbox.path().join(\".proto/.prototools\")
 ---
 [
     "go = \"1.19.13\"\n",
-    "node = \"20.15.0\"\n",
+    "node = \"19.9.0\"\n",
     "npm = \"9.9.3\"\n",
 ]

--- a/crates/version-spec/src/lib.rs
+++ b/crates/version-spec/src/lib.rs
@@ -67,6 +67,8 @@ pub fn clean_version_req_string<T: AsRef<str>>(value: T) -> String {
         .as_ref()
         .trim()
         .replace(".*", "")
+        .replace(".x", "")
+        .replace(".X", "")
         .replace("-*", "")
         .replace("&&", ",")
 }

--- a/crates/version-spec/src/unresolved_parser.rs
+++ b/crates/version-spec/src/unresolved_parser.rs
@@ -100,7 +100,7 @@ impl UnresolvedParser {
                         if ch == 'v' || ch == 'V' {
                             continue;
                         } else {
-                            unreachable!()
+                            return Err(SpecError::ParseUnknownChar(ch));
                         }
                     }
                 },
@@ -130,7 +130,7 @@ impl UnresolvedParser {
                                 ParsePart::BuildSuffix => {
                                     self.build_id.push('-');
                                 }
-                                _ => unreachable!(),
+                                _ => continue,
                             };
                         } else if self.kind == ParseKind::Cal {
                             match self.in_part {
@@ -146,7 +146,7 @@ impl UnresolvedParser {
                                 ParsePart::PreId => {
                                     self.pre_id.push('-');
                                 }
-                                _ => unreachable!(),
+                                _ => continue,
                             };
                         }
                     } else if ch == '.' {
@@ -167,7 +167,7 @@ impl UnresolvedParser {
                                 ParsePart::BuildSuffix => {
                                     self.build_id.push('.');
                                 }
-                                _ => unreachable!(),
+                                _ => continue,
                             };
                         } else if self.kind == ParseKind::Cal {
                             match self.in_part {
@@ -182,7 +182,7 @@ impl UnresolvedParser {
                                 ParsePart::BuildSuffix => {
                                     self.build_id.push('.');
                                 }
-                                _ => unreachable!(),
+                                _ => continue,
                             };
                         }
                     }
@@ -193,12 +193,12 @@ impl UnresolvedParser {
                         if self.kind == ParseKind::Sem {
                             self.in_part = ParsePart::BuildSuffix;
                         } else {
-                            unreachable!();
+                            continue;
                         }
                     } else if self.kind == ParseKind::Cal {
                         self.in_part = ParsePart::BuildSuffix;
                     } else {
-                        unreachable!();
+                        continue;
                     }
                 }
                 // AND separator

--- a/crates/version-spec/src/unresolved_spec.rs
+++ b/crates/version-spec/src/unresolved_spec.rs
@@ -73,15 +73,15 @@ impl UnresolvedVersionSpec {
     /// Note that this *does not* actually resolve or validate against a manifest,
     /// and instead simply constructs the [`VersionSpec`].
     ///
-    /// Furthermore, the `Req` and `ReqAny` variants will panic, as they are not
-    /// resolved or valid versions.
+    /// Furthermore, the `Req` and `ReqAny` variants will return a "latest" alias,
+    ///  as they are not resolved or valid versions.
     pub fn to_resolved_spec(&self) -> VersionSpec {
         match self {
             Self::Canary => VersionSpec::Canary,
             Self::Alias(alias) => VersionSpec::Alias(alias.to_owned()),
             Self::Calendar(version) => VersionSpec::Calendar(version.to_owned()),
             Self::Semantic(version) => VersionSpec::Semantic(version.to_owned()),
-            _ => unreachable!(),
+            _ => VersionSpec::default(),
         }
     }
 }

--- a/crates/version-spec/tests/unresolved_spec_test.rs
+++ b/crates/version-spec/tests/unresolved_spec_test.rs
@@ -89,6 +89,22 @@ mod unresolved_spec {
             UnresolvedVersionSpec::Req(VersionReq::parse("~2000").unwrap())
         );
         assert_eq!(
+            UnresolvedVersionSpec::parse("1.x").unwrap(),
+            UnresolvedVersionSpec::Req(VersionReq::parse("~1").unwrap())
+        );
+        assert_eq!(
+            UnresolvedVersionSpec::parse("2000.x").unwrap(),
+            UnresolvedVersionSpec::Req(VersionReq::parse("~2000").unwrap())
+        );
+        assert_eq!(
+            UnresolvedVersionSpec::parse("1.2.X").unwrap(),
+            UnresolvedVersionSpec::Req(VersionReq::parse("~1.2").unwrap())
+        );
+        assert_eq!(
+            UnresolvedVersionSpec::parse("2000.02.X").unwrap(),
+            UnresolvedVersionSpec::Req(VersionReq::parse("~2000.2").unwrap())
+        );
+        assert_eq!(
             UnresolvedVersionSpec::parse(">1").unwrap(),
             UnresolvedVersionSpec::Req(VersionReq::parse(">1").unwrap())
         );

--- a/crates/version-spec/tests/unresolved_spec_test.rs
+++ b/crates/version-spec/tests/unresolved_spec_test.rs
@@ -97,6 +97,14 @@ mod unresolved_spec {
             UnresolvedVersionSpec::Req(VersionReq::parse("~2000").unwrap())
         );
         assert_eq!(
+            UnresolvedVersionSpec::parse("1.x.x").unwrap(),
+            UnresolvedVersionSpec::Req(VersionReq::parse("~1").unwrap())
+        );
+        assert_eq!(
+            UnresolvedVersionSpec::parse("2000.x.x").unwrap(),
+            UnresolvedVersionSpec::Req(VersionReq::parse("~2000").unwrap())
+        );
+        assert_eq!(
             UnresolvedVersionSpec::parse("1.2.X").unwrap(),
             UnresolvedVersionSpec::Req(VersionReq::parse("~1.2").unwrap())
         );


### PR DESCRIPTION
Fixes https://github.com/moonrepo/proto/issues/537