### PR TITLE
fix: Fix some certificate issues.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 - [Rust](https://github.com/moonrepo/rust-plugin/blob/master/CHANGELOG.md)
 - [TOML schema](https://github.com/moonrepo/schema-plugin/blob/master/CHANGELOG.md)
 
+## Unreleased
+
+#### 🐞 Fixes
+
+- Attempted fix for some certificate issues when making requests.
+
 ## 0.38.3
 
 #### 🧩 Plugins

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1500,7 +1500,7 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
- "rustls 0.23.10",
+ "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
@@ -2465,7 +2465,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 1.1.0",
- "rustls 0.23.10",
+ "rustls",
  "thiserror",
  "tokio",
  "tracing",
@@ -2481,7 +2481,7 @@ dependencies = [
  "rand",
  "ring",
  "rustc-hash 1.1.0",
- "rustls 0.23.10",
+ "rustls",
  "slab",
  "thiserror",
  "tinyvec",
@@ -2672,7 +2672,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.10",
+ "rustls",
  "rustls-native-certs",
  "rustls-pemfile",
  "rustls-pki-types",
@@ -2771,24 +2771,11 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
-dependencies = [
- "log",
- "ring",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -3557,7 +3544,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.10",
+ "rustls",
  "rustls-pki-types",
  "tokio",
 ]
@@ -3800,17 +3787,17 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.9.7"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d11a831e3c0b56e438a28308e7c810799e3c118417f342d30ecec080105395cd"
+checksum = "72139d247e5f97a3eff96229a7ae85ead5328a39efe76f8bf5a06313d505b6ea"
 dependencies = [
  "base64 0.22.1",
  "flate2",
  "log",
  "once_cell",
- "rustls 0.22.4",
+ "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
- "rustls-webpki",
  "url",
  "webpki-roots",
 ]
@@ -3916,6 +3903,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "ureq",
  "warpgate_api",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ async-trait = "0.1.81"
 clap = "4.5.9"
 clap_complete = "4.5.8"
 dirs = "5.0.1"
-extism = "1.0.0" # Lower for consumers
+extism = { version = "1.0.0", default-features = false }
 extism-pdk = "1.2.0"
 human-sort = "0.2.2"
 indexmap = "2.2.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ async-trait = "0.1.81"
 clap = "4.5.9"
 clap_complete = "4.5.8"
 dirs = "5.0.1"
-extism = { version = "1.0.0", default-features = false }
+extism = "1.0.0" # Lower for consumers
 extism-pdk = "1.2.0"
 human-sort = "0.2.2"
 indexmap = "2.2.6"

--- a/crates/warpgate/Cargo.toml
+++ b/crates/warpgate/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/moonrepo/proto"
 [dependencies]
 system_env = { version = "0.5.0", path = "../system-env" }
 warpgate_api = { version = "0.8.2", path = "../warpgate-api" }
-extism = { workspace = true }
+extism = { workspace = true, features = ["http"] }
 miette = { workspace = true }
 once_cell = { workspace = true }
 once_map = { workspace = true }
@@ -24,6 +24,9 @@ starbase_utils = { workspace = true, features = ["glob", "net"] }
 starbase_styles = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+
+# Enabling certs for extism!
+ureq = { version = "2.10.0", features = ["native-certs"] }
 
 [dev-dependencies]
 starbase_sandbox = { workspace = true }


### PR DESCRIPTION
proto uses reqwest for HTTP, while WASM uses ureq. The former had certs setup but the latter did not. Hopefully this helps.