### PR TITLE
new: Add `send_request` host function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 
 - WASM API
   - Added `ToolMetadataOutput.config_schema`, which can be used to define a JSON schema for the plugins configuration.
+  - Added a new `send_request` host function, that uses the same HTTP client as proto does.
+  - Added `fetch_bytes`, `fetch_json`, and `fetch_text` functions that use this new host function.
 
 ## 0.39.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 
 ## Unreleased
 
+#### 💥 Breaking
+
+- WASM API
+  - Removed the `is_musl` function. Use the host environment instead.
+
 #### 🚀 Updates
 
 - WASM API

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -2061,18 +2060,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
-name = "once_map"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa7085055bbe9c8edbd982048dbcf8181794d4a81cb04a11931673e63cc18dc6"
-dependencies = [
- "ahash",
- "hashbrown 0.14.5",
- "parking_lot",
- "stable_deref_trait",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3873,7 +3860,6 @@ dependencies = [
  "extism",
  "miette",
  "once_cell",
- "once_map",
  "regex",
  "reqwest",
  "scc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2839,6 +2839,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ccfb12511cdb770157ace92d7dda771e498445b78f9886e8cdbc5140a4eced"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2912,6 +2921,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "177258b64c0faaa9ffd3c65cd3262c2bc7e2588dbbd9c1641d0346145c1bbda8"
 
 [[package]]
 name = "security-framework"
@@ -3861,6 +3876,7 @@ dependencies = [
  "once_map",
  "regex",
  "reqwest",
+ "scc",
  "schematic",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "anstyle-parse"
@@ -124,13 +124,14 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.14"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed72493ac66d5804837f480ab3766c72bdfab91a65e565fc54fa9e42db0073a8"
+checksum = "dc1835b7f27878de8525dc71410b5a31cdcc5f230aed5ba5df968e09c201b23d"
 dependencies = [
  "anstyle",
  "bstr",
  "doc-comment",
+ "libc",
  "predicates",
  "predicates-core",
  "predicates-tree",
@@ -139,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "assert_fs"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd762e110c8ed629b11b6cde59458cc1c71de78ebbcc30099fc8e0403a2a2ec"
+checksum = "7efdb1fdb47602827a342857666feb372712cbc64b414172bd6b167a02927674"
 dependencies = [
  "anstyle",
  "doc-comment",
@@ -403,9 +404,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.11"
+version = "4.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35723e6a11662c2afb578bcf0b88bf6ea8e21282a953428f240574fcc3a2b5b3"
+checksum = "11d8838454fda655dafd3accb2b6e2bea645b9e4078abe84a22ceb947235c5cc"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -413,9 +414,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.11"
+version = "4.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49eb96cbfa7cfa35017b7cd548c75b14c3118c98b423041d70562665e07fb0fa"
+checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -425,9 +426,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.11"
+version = "4.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6ae69fbb0833c6fcd5a8d4b8609f108c7ad95fc11e248d853ff2c42a90df26a"
+checksum = "9c677cd0126f3026d8b093fa29eae5d812fde5c05bc66dbb29d0374eea95113a"
 dependencies = [
  "clap",
 ]
@@ -444,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.11"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d029b67f89d30bbb547c89fd5161293c0aec155fc691d7924b64550662db93e"
+checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -998,7 +999,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "toml 0.8.16",
+ "toml 0.8.19",
  "tracing",
  "tracing-subscriber",
  "ureq",
@@ -1156,9 +1157,9 @@ dependencies = [
 
 [[package]]
 name = "fs4"
-version = "0.8.4"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7e180ac76c23b45e767bd7ae9579bc0bb458618c4bc71835926e098e61d15f8"
+checksum = "e8c6b3bd49c37d2aa3f3f2220233b29a7cd23f79d1fe70e5337d25fb390793de"
 dependencies = [
  "rustix",
  "windows-sys 0.52.0",
@@ -1328,7 +1329,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 dependencies = [
  "fallible-iterator",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "stable_deref_trait",
 ]
 
@@ -1374,7 +1375,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1538,7 +1539,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -1600,9 +1601,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
@@ -2049,7 +2050,7 @@ checksum = "d8dd6c0cdf9429bce006e1362bfce61fa1bfd8c898a643ed8d2b471934701d3d"
 dependencies = [
  "crc32fast",
  "hashbrown 0.14.5",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "memchr",
 ]
 
@@ -2190,9 +2191,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "predicates"
-version = "3.1.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
+checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
 dependencies = [
  "anstyle",
  "difflib",
@@ -2293,7 +2294,7 @@ dependencies = [
  "comfy-table",
  "dialoguer",
  "dirs 5.0.1",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "indicatif",
  "miette",
  "proto_core",
@@ -2334,7 +2335,7 @@ dependencies = [
 name = "proto_core"
 version = "0.39.3"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "miette",
  "minisign-verify",
  "once_cell",
@@ -2413,7 +2414,7 @@ dependencies = [
  "serde",
  "serde_json",
  "starbase_sandbox",
- "toml 0.8.16",
+ "toml 0.8.19",
  "warpgate",
 ]
 
@@ -2584,9 +2585,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2827,9 +2828,9 @@ dependencies = [
 
 [[package]]
 name = "scc"
-version = "2.1.6"
+version = "2.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ccfb12511cdb770157ace92d7dda771e498445b78f9886e8cdbc5140a4eced"
+checksum = "79da19444d9da7a9a82b80ecf059eceba6d3129d84a8610fd25ff2364f255466"
 dependencies = [
  "sdd",
 ]
@@ -2861,7 +2862,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4952b2fab03cea740a66c0ca502d16f31ad5d3cc0a803541778f20715ebd0088"
 dependencies = [
  "garde",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "markdown",
  "miette",
  "schemars",
@@ -2872,7 +2873,7 @@ dependencies = [
  "serde_path_to_error",
  "starbase_styles",
  "thiserror",
- "toml 0.8.16",
+ "toml 0.8.19",
  "tracing",
 ]
 
@@ -2895,11 +2896,11 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9939a1953cd54de031828aabb6b9e37191c45328c0620f7286ccc76a35a6ac05"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "semver",
  "serde",
  "serde_json",
- "toml 0.8.16",
+ "toml 0.8.19",
  "url",
 ]
 
@@ -2911,9 +2912,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sdd"
-version = "2.1.0"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "177258b64c0faaa9ffd3c65cd3262c2bc7e2588dbbd9c1641d0346145c1bbda8"
+checksum = "0495e4577c672de8254beb68d01a9b62d0e8a13c099edecdbedccce3223cd29f"
 
 [[package]]
 name = "security-framework"
@@ -2949,18 +2950,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.207"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "5665e14a49a4ea1b91029ba7d3bca9f299e1f7cfa194388ccc20f14743e784f2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.207"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "6aea2634c86b0e8ef2cfdc0c340baede54ec27b1e46febd7f80dffb2aa44a00e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2969,11 +2970,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.122"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
+checksum = "66ad62847a56b3dba58cc891acd13884b9c61138d330c0d7b6181713d4fce38d"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "itoa",
  "memchr",
  "ryu",
@@ -3146,9 +3147,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "starbase"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f7b4290f74bb6ed278d81007239cd97678460d66dbdc02b41f82cee1cf0af3"
+checksum = "abd8078afa10ac51ffafd83626e96f0ad34a187a5e97ff1d6df66fd9b75f839b"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3162,9 +3163,9 @@ dependencies = [
 
 [[package]]
 name = "starbase_archive"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f85072fb2748d4057bc32fea60b696fb669dcf808f88044da1dca8cb5582fe"
+checksum = "e6b412349652a360e5141521688d97c739fbe025e49ada64354550a1193e1edb"
 dependencies = [
  "binstall-tar",
  "flate2",
@@ -3181,9 +3182,9 @@ dependencies = [
 
 [[package]]
 name = "starbase_sandbox"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef8a1b40b7859260a4371b1dcebb24ebf27356de1514cca4beb6b10fc273c03a"
+checksum = "66fc04e95ede168033c1c1825d1cb266c706ca35e955b0e4b337fbf5cc5d5bbc"
 dependencies = [
  "assert_cmd",
  "assert_fs",
@@ -3196,9 +3197,9 @@ dependencies = [
 
 [[package]]
 name = "starbase_shell"
-version = "0.5.3"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5946c2d5c4eeeedf7685942f3c4d7f17659cf7d74c13c42c5b26417dc50104"
+checksum = "2a4afd24bccc65a94bef7b43acd2b2362e32bcad0eb5674b95aae81cec58c59b"
 dependencies = [
  "miette",
  "regex",
@@ -3221,22 +3222,21 @@ dependencies = [
 
 [[package]]
 name = "starbase_utils"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518f3e8a2987aa9341fc94712517aaaef88b9b8beae2434513bf2e6845d8338f"
+checksum = "d8353d4dd059139755ceafe835d95292e049b44d99e78de0f2718df0bfa33c4d"
 dependencies = [
  "dirs 5.0.1",
  "fs4",
  "json-strip-comments",
  "miette",
- "once_cell",
  "reqwest",
  "serde",
  "serde_json",
  "starbase_styles",
  "thiserror",
  "tokio",
- "toml 0.8.16",
+ "toml 0.8.19",
  "tracing",
  "url",
  "wax",
@@ -3330,15 +3330,14 @@ checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "sysinfo"
-version = "0.30.13"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
+checksum = "d4115055da5f572fff541dd0c4e61b0262977f453cc9fe04be83aba25a89bdab"
 dependencies = [
- "cfg-if",
  "core-foundation-sys",
  "libc",
+ "memchr",
  "ntapi",
- "once_cell",
  "windows",
 ]
 
@@ -3482,9 +3481,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.39.1"
+version = "1.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d040ac2b29ab03b09d4129c2f5bbd012a3ac2f79d38ff506a4bf8dd34b0eac8a"
+checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3545,21 +3544,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.16"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81967dd0dd2c1ab0bc3468bd7caecc32b8a4aa47d0c8c695d8c2b2108168d62c"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.17",
+ "toml_edit 0.22.20",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8fb9f64314842840f1d940ac544da178732128f1c78c21772e876579e0da1db"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 dependencies = [
  "serde",
 ]
@@ -3570,22 +3569,22 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "toml_datetime",
  "winnow 0.5.40",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.17"
+version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9f8729f5aea9562aac1cc0441f5d6de3cff1ee0c5d67293eeca5eb36ee7c16"
+checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.9",
+ "winnow 0.6.18",
 ]
 
 [[package]]
@@ -4039,7 +4038,7 @@ dependencies = [
  "ahash",
  "bitflags 2.5.0",
  "hashbrown 0.14.5",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "semver",
 ]
 
@@ -4069,7 +4068,7 @@ dependencies = [
  "fxprof-processed-profile",
  "gimli",
  "hashbrown 0.14.5",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "ittapi",
  "libc",
  "libm",
@@ -4133,7 +4132,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "sha2",
- "toml 0.8.16",
+ "toml 0.8.19",
  "windows-sys 0.52.0",
  "zstd",
 ]
@@ -4193,7 +4192,7 @@ dependencies = [
  "cpp_demangle",
  "cranelift-entity",
  "gimli",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "log",
  "object 0.33.0",
  "postcard",
@@ -4302,7 +4301,7 @@ checksum = "c936a52ce69c28de2aa3b5fb4f2dbbb2966df304f04cccb7aca4ba56d915fda0"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "wit-parser",
 ]
 
@@ -4463,11 +4462,11 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.52.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
- "windows-core",
+ "windows-core 0.57.0",
  "windows-targets 0.52.5",
 ]
 
@@ -4476,6 +4475,49 @@ name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
  "windows-targets 0.52.5",
 ]
@@ -4630,9 +4672,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.9"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86c949fede1d13936a99f14fafd3e76fd642b556dd2ce96287fbe2e0151bfac6"
+checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
 dependencies = [
  "memchr",
 ]
@@ -4665,7 +4707,7 @@ checksum = "78c83dab33a9618d86cfe3563cc864deffd08c17efc5db31a3b7cd1edeffe6e1"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "log",
  "semver",
  "serde",
@@ -4741,16 +4783,16 @@ checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zip"
-version = "2.1.5"
+version = "2.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b895748a3ebcb69b9d38dcfdf21760859a4b0d0b0015277640c2ef4c69640e6f"
+checksum = "40dd8c92efc296286ce1fbd16657c5dbefff44f1b4ca01cc5f517d8b7b3d3e2e"
 dependencies = [
  "arbitrary",
  "crc32fast",
  "crossbeam-utils",
  "displaydoc",
  "flate2",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "memchr",
  "thiserror",
  "zopfli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ human-sort = "0.2.2"
 indexmap = "2.2.6"
 miette = "7.2.0"
 once_cell = "1.19.0"
-once_map = "0.4.18"
 regex = { version = "1.10.5", default-features = false, features = ["std"] }
 reqwest = { version = "0.12.5", default-features = false, features = [
     "charset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ reqwest = { version = "0.12.5", default-features = false, features = [
     "macos-system-configuration",
 ] }
 rustc-hash = "2.0.0"
+scc = "2.1.6"
 schematic = { version = "0.17.1", default-features = false }
 semver = { version = "1.0.23", features = ["serde"] }
 serde = { version = "1.0.204", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,31 +6,31 @@ default-members = ["crates/cli"]
 [workspace.dependencies]
 anyhow = "1.0.86"
 async-trait = "0.1.81"
-clap = "4.5.11"
-clap_complete = "4.5.11"
+clap = "4.5.15"
+clap_complete = "4.5.16"
 dirs = "5.0.1"
 extism = "1.0.0" # Lower for consumers
 extism-pdk = "1.2.0"
 human-sort = "0.2.2"
-indexmap = "2.2.6"
+indexmap = "2.4.0"
 miette = "7.2.0"
 once_cell = "1.19.0"
-regex = { version = "1.10.5", default-features = false, features = ["std"] }
+regex = { version = "1.10.6", default-features = false, features = ["std"] }
 reqwest = { version = "0.12.5", default-features = false, features = [
     "charset",
     "http2",
     "macos-system-configuration",
 ] }
 rustc-hash = "2.0.0"
-scc = "2.1.6"
+scc = "2.1.14"
 schematic = { version = "0.17.1", default-features = false }
 semver = { version = "1.0.23", features = ["serde"] }
-serde = { version = "1.0.204", features = ["derive"] }
-serde_json = "1.0.120"
+serde = { version = "1.0.207", features = ["derive"] }
+serde_json = "1.0.124"
 sha2 = "0.10.8"
 shell-words = "1.1.0"
-starbase = { version = "0.8.1" }
-starbase_archive = { version = "0.8.2", features = [
+starbase = { version = "0.8.2" }
+starbase_archive = { version = "0.8.4", features = [
     "gz",
     "miette",
     "tar-gz",
@@ -39,18 +39,18 @@ starbase_archive = { version = "0.8.2", features = [
     "zip",
     "zip-deflate",
 ] }
-starbase_events = { version = "0.6.2" }
-starbase_sandbox = { version = "0.7.0" }
-starbase_shell = { version = "0.5.3", features = ["miette"] }
-starbase_styles = { version = "0.4.1" }
-starbase_utils = { version = "0.8.3", default-features = false, features = [
+starbase_events = { version = "0.6.3" }
+starbase_sandbox = { version = "0.7.2" }
+starbase_shell = { version = "0.5.5", features = ["miette"] }
+starbase_styles = { version = "0.4.2" }
+starbase_utils = { version = "0.8.5", default-features = false, features = [
     "json",
     "miette",
     "net",
     "toml",
 ] }
 thiserror = "1.0.63"
-tokio = { version = "1.39.1", features = ["full", "tracing"] }
+tokio = { version = "1.39.2", features = ["full", "tracing"] }
 tracing = "0.1.40"
 uuid = { version = "1.10.0", features = ["v4"] }
 

--- a/crates/cli/src/commands/bin.rs
+++ b/crates/cli/src/commands/bin.rs
@@ -39,7 +39,7 @@ pub async fn bin(session: ProtoSession, args: BinArgs) -> AppResult {
     tool.create_executables(args.shim, args.bin).await?;
 
     if args.bin {
-        for bin in tool.get_bin_locations()? {
+        for bin in tool.get_bin_locations().await? {
             if bin.primary {
                 println!("{}", bin.path.display());
                 return Ok(());
@@ -48,7 +48,7 @@ pub async fn bin(session: ProtoSession, args: BinArgs) -> AppResult {
     }
 
     if args.shim {
-        for shim in tool.get_shim_locations()? {
+        for shim in tool.get_shim_locations().await? {
             if shim.primary {
                 println!("{}", shim.path.display());
                 return Ok(());

--- a/crates/cli/src/commands/clean.rs
+++ b/crates/cli/src/commands/clean.rs
@@ -251,12 +251,12 @@ pub async fn purge_tool(session: &ProtoSession, id: &Id, yes: bool) -> miette::R
         fs::remove_dir_all(inventory_dir)?;
 
         // Delete binaries
-        for bin in tool.get_bin_locations()? {
+        for bin in tool.get_bin_locations().await? {
             session.env.store.unlink_bin(&bin.path)?;
         }
 
         // Delete shims
-        for shim in tool.get_shim_locations()? {
+        for shim in tool.get_shim_locations().await? {
             session.env.store.remove_shim(&shim.path)?;
         }
 

--- a/crates/cli/src/commands/outdated.rs
+++ b/crates/cli/src/commands/outdated.rs
@@ -129,8 +129,9 @@ pub async fn outdated(session: ProtoSession, args: OutdatedArgs) -> AppResult {
                 "Resolving current version"
             );
 
-            let current_version =
-                tool.resolve_version_candidate(&version_resolver, &config_version, true)?;
+            let current_version = tool
+                .resolve_version_candidate(&version_resolver, &config_version, true)
+                .await?;
             let newest_range = get_in_major_range(&config_version);
 
             debug!(
@@ -139,8 +140,9 @@ pub async fn outdated(session: ProtoSession, args: OutdatedArgs) -> AppResult {
                 "Resolving newest version"
             );
 
-            let newest_version =
-                tool.resolve_version_candidate(&version_resolver, &newest_range, false)?;
+            let newest_version = tool
+                .resolve_version_candidate(&version_resolver, &newest_range, false)
+                .await?;
 
             debug!(
                 id = tool.id.as_str(),
@@ -148,8 +150,9 @@ pub async fn outdated(session: ProtoSession, args: OutdatedArgs) -> AppResult {
                 "Resolving latest version"
             );
 
-            let latest_version =
-                tool.resolve_version_candidate(&version_resolver, &initial_version, true)?;
+            let latest_version = tool
+                .resolve_version_candidate(&version_resolver, &initial_version, true)
+                .await?;
 
             Result::<_, miette::Report>::Ok((
                 tool.id,

--- a/crates/cli/src/commands/plugin/info.rs
+++ b/crates/cli/src/commands/plugin/info.rs
@@ -48,16 +48,18 @@ pub async fn info(session: ProtoSession, args: InfoPluginArgs) -> AppResult {
 
     let mut config = session.env.load_config()?.to_owned();
     let tool_config = config.tools.remove(&tool.id).unwrap_or_default();
+    let bins = tool.get_bin_locations().await?;
+    let shims = tool.get_shim_locations().await?;
 
     if args.json {
         let info = PluginInfo {
-            bins: tool.get_bin_locations()?,
+            bins,
             config: tool_config,
             exe_path: tool.get_exe_path()?.to_path_buf(),
             globals_dirs: tool.get_globals_dirs().to_owned(),
             globals_prefix: tool.get_globals_prefix().map(|p| p.to_owned()),
             inventory_dir: tool.get_inventory_dir(),
-            shims: tool.get_shim_locations()?,
+            shims,
             id: tool.id,
             name: tool.metadata.name.clone(),
             manifest: tool.inventory.manifest,
@@ -111,7 +113,7 @@ pub async fn info(session: ProtoSession, args: InfoPluginArgs) -> AppResult {
 
         p.entry_list(
             "Binaries",
-            tool.get_bin_locations()?.into_iter().map(|bin| {
+            bins.into_iter().map(|bin| {
                 format!(
                     "{} {}",
                     color::path(bin.path),
@@ -127,7 +129,7 @@ pub async fn info(session: ProtoSession, args: InfoPluginArgs) -> AppResult {
 
         p.entry_list(
             "Shims",
-            tool.get_shim_locations()?.into_iter().map(|shim| {
+            shims.into_iter().map(|shim| {
                 format!(
                     "{} {}",
                     color::path(shim.path),

--- a/crates/cli/tests/plugins_test.rs
+++ b/crates/cli/tests/plugins_test.rs
@@ -46,7 +46,7 @@ where
 mod plugins {
     use super::*;
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn downloads_and_installs_plugin_from_file() {
         run_tests(|env| {
             let root_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -81,7 +81,7 @@ mod plugins {
         .await;
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn downloads_and_installs_plugin_from_url() {
         run_tests(|env| {
             load_tool_from_locator(

--- a/crates/cli/tests/snapshots/activate_test__activate__passes_args_through.snap
+++ b/crates/cli/tests/snapshots/activate_test__activate__passes_args_through.snap
@@ -5,6 +5,10 @@ expression: "get_activate_output(&assert, &sandbox)"
 # proto hook
 set-env __ORIG_PATH $E:PATH
 
-set @edit:before-readline = $@edit:before-readline {
+fn _proto_hook {
   eval (proto activate elvish --include-global --no-shim --no-bin --export);
+}
+
+set @edit:before-readline = $@edit:before-readline {
+  _proto_hook
 }

--- a/crates/cli/tests/snapshots/activate_test__activate__supports_many_tools.snap
+++ b/crates/cli/tests/snapshots/activate_test__activate__supports_many_tools.snap
@@ -4,6 +4,6 @@ expression: "get_activate_output(&assert, &sandbox)"
 ---
 set -gx __ORIG_PATH $PATH
 
-function __proto_hook --on-variable PWD;
+function _proto_hook --on-variable PWD;
   proto activate fish --export | source
 end;

--- a/crates/cli/tests/snapshots/activate_test__activate__supports_one_tool.snap
+++ b/crates/cli/tests/snapshots/activate_test__activate__supports_one_tool.snap
@@ -12,6 +12,7 @@ _proto_hook() {
   fi
   trap - SIGINT
 }
+
 typeset -ag chpwd_functions
 if (( ! ${chpwd_functions[(I)_proto_hook]} )); then
   chpwd_functions=(_proto_hook $chpwd_functions)

--- a/crates/core/src/tool.rs
+++ b/crates/core/src/tool.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tracing::{debug, instrument, trace, warn};
 use warpgate::{
-    host_funcs::{create_host_functions, HostData},
+    host::{create_host_functions, HostData},
     Id, PluginContainer, PluginLocator, PluginManifest, VirtualPath, Wasm,
 };
 

--- a/crates/core/src/tool.rs
+++ b/crates/core/src/tool.rs
@@ -122,7 +122,6 @@ impl Tool {
                     http_client: Arc::clone(proto.get_plugin_loader()?.get_client()?),
                     virtual_paths: proto.get_virtual_paths(),
                     working_dir: proto.cwd.clone(),
-                    ..Default::default()
                 }),
             )?),
         )

--- a/crates/core/src/tool.rs
+++ b/crates/core/src/tool.rs
@@ -57,7 +57,7 @@ pub struct Tool {
 }
 
 impl Tool {
-    pub fn new(
+    pub async fn new(
         id: Id,
         proto: Arc<ProtoEnvironment>,
         plugin: Arc<PluginContainer>,
@@ -83,23 +83,23 @@ impl Tool {
             version: None,
         };
 
-        tool.register_tool()?;
+        tool.register_tool().await?;
 
         Ok(tool)
     }
 
     #[instrument(name = "new_tool", skip(proto, wasm))]
-    pub fn load<I: AsRef<Id> + Debug, P: AsRef<ProtoEnvironment>>(
+    pub async fn load<I: AsRef<Id> + Debug, P: AsRef<ProtoEnvironment>>(
         id: I,
         proto: P,
         wasm: Wasm,
     ) -> miette::Result<Self> {
         let proto = proto.as_ref();
 
-        Self::load_from_manifest(id, proto, Self::create_plugin_manifest(proto, wasm)?)
+        Self::load_from_manifest(id, proto, Self::create_plugin_manifest(proto, wasm)?).await
     }
 
-    pub fn load_from_manifest<I: AsRef<Id>, P: AsRef<ProtoEnvironment>>(
+    pub async fn load_from_manifest<I: AsRef<Id>, P: AsRef<ProtoEnvironment>>(
         id: I,
         proto: P,
         manifest: PluginManifest,
@@ -125,6 +125,7 @@ impl Tool {
                 }),
             )?),
         )
+        .await
     }
 
     pub fn create_plugin_manifest<P: AsRef<ProtoEnvironment>>(
@@ -146,13 +147,15 @@ impl Tool {
         Ok(manifest)
     }
 
-    fn call_locate_executables(&self) -> miette::Result<LocateExecutablesOutput> {
-        self.plugin.cache_func_with(
-            "locate_executables",
-            LocateExecutablesInput {
-                context: self.create_context(),
-            },
-        )
+    async fn call_locate_executables(&self) -> miette::Result<LocateExecutablesOutput> {
+        self.plugin
+            .cache_func_with(
+                "locate_executables",
+                LocateExecutablesInput {
+                    context: self.create_context(),
+                },
+            )
+            .await
     }
 
     /// Disable internal caching when applicable.
@@ -229,13 +232,16 @@ impl Tool {
 
     /// Register the tool by loading initial metadata and persisting it.
     #[instrument(skip_all)]
-    pub fn register_tool(&mut self) -> miette::Result<()> {
-        let metadata: ToolMetadataOutput = self.plugin.cache_func_with(
-            "register_tool",
-            ToolMetadataInput {
-                id: self.id.to_string(),
-            },
-        )?;
+    pub async fn register_tool(&mut self) -> miette::Result<()> {
+        let metadata: ToolMetadataOutput = self
+            .plugin
+            .cache_func_with(
+                "register_tool",
+                ToolMetadataInput {
+                    id: self.id.to_string(),
+                },
+            )
+            .await?;
 
         let mut inventory = self
             .proto
@@ -274,19 +280,22 @@ impl Tool {
 
     /// Sync the local tool manifest with changes from the plugin.
     #[instrument(skip_all)]
-    pub fn sync_manifest(&mut self) -> miette::Result<()> {
-        if !self.plugin.has_func("sync_manifest") {
+    pub async fn sync_manifest(&mut self) -> miette::Result<()> {
+        if !self.plugin.has_func("sync_manifest").await {
             return Ok(());
         }
 
         debug!(tool = self.id.as_str(), "Syncing manifest with changes");
 
-        let sync_changes: SyncManifestOutput = self.plugin.call_func_with(
-            "sync_manifest",
-            SyncManifestInput {
-                context: self.create_context(),
-            },
-        )?;
+        let sync_changes: SyncManifestOutput = self
+            .plugin
+            .call_func_with(
+                "sync_manifest",
+                SyncManifestInput {
+                    context: self.create_context(),
+                },
+            )
+            .await?;
 
         if sync_changes.skip_sync {
             return Ok(());
@@ -351,12 +360,15 @@ impl Tool {
             }
 
             if env::var("PROTO_BYPASS_VERSION_CHECK").is_err() {
-                versions = self.plugin.cache_func_with(
-                    "load_versions",
-                    LoadVersionsInput {
-                        initial: initial_version.to_owned(),
-                    },
-                )?;
+                versions = self
+                    .plugin
+                    .cache_func_with(
+                        "load_versions",
+                        LoadVersionsInput {
+                            initial: initial_version.to_owned(),
+                        },
+                    )
+                    .await?;
 
                 self.inventory.save_remote_versions(&versions)?;
             }
@@ -419,7 +431,9 @@ impl Tool {
         }
 
         let resolver = self.load_version_resolver(initial_version).await?;
-        let version = self.resolve_version_candidate(&resolver, initial_version, true)?;
+        let version = self
+            .resolve_version_candidate(&resolver, initial_version, true)
+            .await?;
 
         debug!(
             tool = self.id.as_str(),
@@ -434,7 +448,7 @@ impl Tool {
     }
 
     #[instrument(name = "candidate", skip(self, resolver))]
-    pub fn resolve_version_candidate(
+    pub async fn resolve_version_candidate(
         &self,
         resolver: &VersionResolver<'_>,
         initial_candidate: &UnresolvedVersionSpec,
@@ -453,13 +467,16 @@ impl Tool {
             })
         };
 
-        if self.plugin.has_func("resolve_version") {
-            let result: ResolveVersionOutput = self.plugin.call_func_with(
-                "resolve_version",
-                ResolveVersionInput {
-                    initial: initial_candidate.to_owned(),
-                },
-            )?;
+        if self.plugin.has_func("resolve_version").await {
+            let result: ResolveVersionOutput = self
+                .plugin
+                .call_func_with(
+                    "resolve_version",
+                    ResolveVersionInput {
+                        initial: initial_candidate.to_owned(),
+                    },
+                )
+                .await?;
 
             if let Some(candidate) = result.candidate {
                 debug!(
@@ -491,12 +508,12 @@ impl Tool {
         &self,
         current_dir: &Path,
     ) -> miette::Result<Option<(UnresolvedVersionSpec, PathBuf)>> {
-        if !self.plugin.has_func("detect_version_files") {
+        if !self.plugin.has_func("detect_version_files").await {
             return Ok(None);
         }
 
-        let has_parser = self.plugin.has_func("parse_version_file");
-        let result: DetectVersionOutput = self.plugin.cache_func("detect_version_files")?;
+        let has_parser = self.plugin.has_func("parse_version_file").await;
+        let result: DetectVersionOutput = self.plugin.cache_func("detect_version_files").await?;
 
         if !result.ignore.is_empty() {
             if let Some(dir) = current_dir.to_str() {
@@ -526,13 +543,16 @@ impl Tool {
             }
 
             let version = if has_parser {
-                let result: ParseVersionFileOutput = self.plugin.call_func_with(
-                    "parse_version_file",
-                    ParseVersionFileInput {
-                        content,
-                        file: file.clone(),
-                    },
-                )?;
+                let result: ParseVersionFileOutput = self
+                    .plugin
+                    .call_func_with(
+                        "parse_version_file",
+                        ParseVersionFileInput {
+                            content,
+                            file: file.clone(),
+                        },
+                    )
+                    .await?;
 
                 if result.version.is_none() {
                     continue;
@@ -597,15 +617,18 @@ impl Tool {
         );
 
         // Allow plugin to provide their own checksum verification method
-        let verified = if self.plugin.has_func("verify_checksum") {
-            let result: VerifyChecksumOutput = self.plugin.call_func_with(
-                "verify_checksum",
-                VerifyChecksumInput {
-                    checksum_file: self.to_virtual_path(checksum_file),
-                    download_file: self.to_virtual_path(download_file),
-                    context: self.create_context(),
-                },
-            )?;
+        let verified = if self.plugin.has_func("verify_checksum").await {
+            let result: VerifyChecksumOutput = self
+                .plugin
+                .call_func_with(
+                    "verify_checksum",
+                    VerifyChecksumInput {
+                        checksum_file: self.to_virtual_path(checksum_file),
+                        download_file: self.to_virtual_path(download_file),
+                        context: self.create_context(),
+                    },
+                )
+                .await?;
 
             result.verified
 
@@ -637,7 +660,7 @@ impl Tool {
             "Installing tool by building from source"
         );
 
-        if !self.plugin.has_func("build_instructions") {
+        if !self.plugin.has_func("build_instructions").await {
             return Err(ProtoError::UnsupportedBuildFromSource {
                 tool: self.get_name().to_owned(),
             }
@@ -748,13 +771,16 @@ impl Tool {
         );
 
         let client = self.proto.get_plugin_loader()?.get_client()?;
-        let options: DownloadPrebuiltOutput = self.plugin.cache_func_with(
-            "download_prebuilt",
-            DownloadPrebuiltInput {
-                context: self.create_context(),
-                install_dir: self.to_virtual_path(install_dir),
-            },
-        )?;
+        let options: DownloadPrebuiltOutput = self
+            .plugin
+            .cache_func_with(
+                "download_prebuilt",
+                DownloadPrebuiltInput {
+                    context: self.create_context(),
+                    install_dir: self.to_virtual_path(install_dir),
+                },
+            )
+            .await?;
 
         let temp_dir = self.get_temp_dir();
 
@@ -808,15 +834,17 @@ impl Tool {
             "Attempting to unpack archive",
         );
 
-        if self.plugin.has_func("unpack_archive") {
-            self.plugin.call_func_without_output(
-                "unpack_archive",
-                UnpackArchiveInput {
-                    input_file: self.to_virtual_path(&download_file),
-                    output_dir: self.to_virtual_path(install_dir),
-                    context: self.create_context(),
-                },
-            )?;
+        if self.plugin.has_func("unpack_archive").await {
+            self.plugin
+                .call_func_without_output(
+                    "unpack_archive",
+                    UnpackArchiveInput {
+                        input_file: self.to_virtual_path(&download_file),
+                        output_dir: self.to_virtual_path(install_dir),
+                        context: self.create_context(),
+                    },
+                )
+                .await?;
         }
         // Is an archive, unpack it
         else if is_archive_file(&download_file) {
@@ -879,16 +907,19 @@ impl Tool {
 
         // If this function is defined, it acts like an escape hatch and
         // takes precedence over all other install strategies
-        if self.plugin.has_func("native_install") {
+        if self.plugin.has_func("native_install").await {
             debug!(tool = self.id.as_str(), "Installing tool natively");
 
-            let result: NativeInstallOutput = self.plugin.call_func_with(
-                "native_install",
-                NativeInstallInput {
-                    context: self.create_context(),
-                    install_dir: self.to_virtual_path(&install_dir),
-                },
-            )?;
+            let result: NativeInstallOutput = self
+                .plugin
+                .call_func_with(
+                    "native_install",
+                    NativeInstallInput {
+                        context: self.create_context(),
+                        install_dir: self.to_virtual_path(&install_dir),
+                    },
+                )
+                .await?;
 
             if !result.installed && !result.skip_install {
                 return Err(ProtoError::InstallFailed {
@@ -941,15 +972,18 @@ impl Tool {
             return Ok(false);
         }
 
-        if self.plugin.has_func("native_uninstall") {
+        if self.plugin.has_func("native_uninstall").await {
             debug!(tool = self.id.as_str(), "Uninstalling tool natively");
 
-            let result: NativeUninstallOutput = self.plugin.call_func_with(
-                "native_uninstall",
-                NativeUninstallInput {
-                    context: self.create_context(),
-                },
-            )?;
+            let result: NativeUninstallOutput = self
+                .plugin
+                .call_func_with(
+                    "native_uninstall",
+                    NativeUninstallInput {
+                        context: self.create_context(),
+                    },
+                )
+                .await?;
 
             if !result.uninstalled && !result.skip_uninstall {
                 return Err(ProtoError::UninstallFailed {
@@ -1037,8 +1071,8 @@ impl Tool {
     /// Return a list of all binaries that get created in `~/.proto/bin`.
     /// The list will contain the executable config, and an absolute path
     /// to the binaries final location.
-    pub fn get_bin_locations(&self) -> miette::Result<Vec<ExecutableLocation>> {
-        let options = self.call_locate_executables()?;
+    pub async fn get_bin_locations(&self) -> miette::Result<Vec<ExecutableLocation>> {
+        let options = self.call_locate_executables().await?;
         let mut locations = vec![];
 
         let mut add = |name: &str, config: ExecutableConfig, primary: bool| {
@@ -1070,8 +1104,8 @@ impl Tool {
     }
 
     /// Return location information for the primary executable within the tool directory.
-    pub fn get_exe_location(&self) -> miette::Result<Option<ExecutableLocation>> {
-        let options = self.call_locate_executables()?;
+    pub async fn get_exe_location(&self) -> miette::Result<Option<ExecutableLocation>> {
+        let options = self.call_locate_executables().await?;
 
         if let Some(primary) = options.primary {
             if let Some(exe_path) = &primary.exe_path {
@@ -1090,8 +1124,8 @@ impl Tool {
     /// Return a list of all shims that get created in `~/.proto/shims`.
     /// The list will contain the executable config, and an absolute path
     /// to the shims final location.
-    pub fn get_shim_locations(&self) -> miette::Result<Vec<ExecutableLocation>> {
-        let options = self.call_locate_executables()?;
+    pub async fn get_shim_locations(&self) -> miette::Result<Vec<ExecutableLocation>> {
+        let options = self.call_locate_executables().await?;
         let mut locations = vec![];
 
         let mut add = |name: &str, config: ExecutableConfig, primary: bool| {
@@ -1121,7 +1155,7 @@ impl Tool {
     pub async fn locate_executable(&mut self) -> miette::Result<()> {
         debug!(tool = self.id.as_str(), "Locating executable for tool");
 
-        let exe_path = if let Some(location) = self.get_exe_location()? {
+        let exe_path = if let Some(location) = self.get_exe_location().await? {
             location.path
         } else {
             self.get_product_dir().join(self.id.as_str())
@@ -1142,14 +1176,14 @@ impl Tool {
         .into())
     }
 
-    /// Locate the directories that global packages are installed to.
+    /// Locate the directory that local executables are installed to.
     #[instrument(skip_all)]
     pub async fn locate_exes_dir(&mut self) -> miette::Result<()> {
-        if !self.plugin.has_func("locate_executables") || self.exes_dir.is_some() {
+        if !self.plugin.has_func("locate_executables").await || self.exes_dir.is_some() {
             return Ok(());
         }
 
-        let options = self.call_locate_executables()?;
+        let options = self.call_locate_executables().await?;
 
         if let Some(exes_dir) = options.exes_dir {
             self.exes_dir = Some(self.get_product_dir().join(exes_dir));
@@ -1161,7 +1195,7 @@ impl Tool {
     /// Locate the directories that global packages are installed to.
     #[instrument(skip_all)]
     pub async fn locate_globals_dirs(&mut self) -> miette::Result<()> {
-        if !self.plugin.has_func("locate_executables") || !self.globals_dirs.is_empty() {
+        if !self.plugin.has_func("locate_executables").await || !self.globals_dirs.is_empty() {
             return Ok(());
         }
 
@@ -1171,7 +1205,7 @@ impl Tool {
         );
 
         let install_dir = self.get_product_dir();
-        let options = self.call_locate_executables()?;
+        let options = self.call_locate_executables().await?;
 
         self.globals_prefix = options.globals_prefix;
 
@@ -1233,7 +1267,7 @@ impl Tool {
     /// If find only is enabled, will only check if they exist, and not create.
     #[instrument(skip(self))]
     pub async fn generate_shims(&mut self, force: bool) -> miette::Result<()> {
-        let shims = self.get_shim_locations()?;
+        let shims = self.get_shim_locations().await?;
 
         if shims.is_empty() {
             return Ok(());
@@ -1324,7 +1358,7 @@ impl Tool {
     /// Symlink all primary and secondary binaries for the current tool.
     #[instrument(skip(self))]
     pub async fn symlink_bins(&mut self, force: bool) -> miette::Result<()> {
-        let bins = self.get_bin_locations()?;
+        let bins = self.get_bin_locations().await?;
 
         if bins.is_empty() {
             return Ok(());
@@ -1470,7 +1504,7 @@ impl Tool {
         })?;
 
         // Allow plugins to override manifest
-        self.sync_manifest()?;
+        self.sync_manifest().await?;
 
         Ok(true)
     }
@@ -1509,14 +1543,14 @@ impl Tool {
         // If no more default version, delete the symlink,
         // otherwise the OS will throw errors for missing sources
         if removed_default_version || self.inventory.manifest.installed_versions.is_empty() {
-            for bin in self.get_bin_locations()? {
+            for bin in self.get_bin_locations().await? {
                 self.proto.store.unlink_bin(&bin.path)?;
             }
         }
 
         // If no more versions in general, delete all shims
         if self.inventory.manifest.installed_versions.is_empty() {
-            for shim in self.get_shim_locations()? {
+            for shim in self.get_shim_locations().await? {
                 self.proto.store.remove_shim(&shim.path)?;
             }
         }

--- a/crates/core/src/tool.rs
+++ b/crates/core/src/tool.rs
@@ -119,8 +119,10 @@ impl Tool {
                 id.to_owned(),
                 manifest,
                 create_host_functions(HostData {
+                    http_client: Arc::clone(proto.get_plugin_loader()?.get_client()?),
                     virtual_paths: proto.get_virtual_paths(),
                     working_dir: proto.cwd.clone(),
+                    ..Default::default()
                 }),
             )?),
         )

--- a/crates/core/src/tool_loader.rs
+++ b/crates/core/src/tool_loader.rs
@@ -123,7 +123,7 @@ pub async fn load_tool_from_locator(
     inject_default_manifest_config(id, &proto.home, &mut manifest)?;
     inject_proto_manifest_config(id, proto, &mut manifest)?;
 
-    let mut tool = Tool::load_from_manifest(id, proto, manifest)?;
+    let mut tool = Tool::load_from_manifest(id, proto, manifest).await?;
     tool.locator = Some(locator.to_owned());
 
     Ok(tool)

--- a/crates/core/tests/version_detector_test.rs
+++ b/crates/core/tests/version_detector_test.rs
@@ -23,7 +23,7 @@ mod version_detector {
         .unwrap()
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn uses_deepest_prototools() {
         let sandbox = create_empty_sandbox();
         sandbox.create_file("a/.prototools", "node = \"20\"");
@@ -63,7 +63,7 @@ mod version_detector {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn finds_first_available_prototools() {
         let sandbox = create_empty_sandbox();
         sandbox.create_file("a/.prototools", "node = \"20\"");
@@ -80,7 +80,7 @@ mod version_detector {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn finds_first_available_ecosystem() {
         let sandbox = create_empty_sandbox();
         sandbox.create_file(".prototools", "node = \"20\"");
@@ -97,7 +97,7 @@ mod version_detector {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn prefers_prototools() {
         let sandbox = create_empty_sandbox();
         sandbox.create_file("a/.prototools", "node = \"20\"");
@@ -116,7 +116,7 @@ mod version_detector {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn only_uses_prototools() {
         let sandbox = create_empty_sandbox();
         sandbox.create_file("a/package.json", r#"{ "engines": { "node": "16" } }"#);

--- a/crates/pdk-test-utils/src/macros.rs
+++ b/crates/pdk-test-utils/src/macros.rs
@@ -8,9 +8,9 @@ macro_rules! generate_download_install_tests {
         async fn downloads_verifies_installs_tool() {
             let sandbox = create_empty_proto_sandbox();
             let mut plugin = if let Some(schema) = $schema {
-                sandbox.create_schema_plugin($id, schema)
+                sandbox.create_schema_plugin($id, schema).await
             } else {
-                sandbox.create_plugin($id)
+                sandbox.create_plugin($id).await
             };
             let spec = UnresolvedVersionSpec::parse($version).unwrap();
 
@@ -27,11 +27,11 @@ macro_rules! generate_download_install_tests {
             plugin.tool.get_exe_path().unwrap();
 
             // Check things exist
-            for bin in plugin.tool.get_bin_locations().unwrap() {
+            for bin in plugin.tool.get_bin_locations().await.unwrap() {
                 assert!(bin.path.exists());
             }
 
-            for shim in plugin.tool.get_shim_locations().unwrap() {
+            for shim in plugin.tool.get_shim_locations().await.unwrap() {
                 assert!(shim.path.exists());
             }
         }
@@ -40,9 +40,9 @@ macro_rules! generate_download_install_tests {
         async fn downloads_prebuilt_and_checksum_to_temp() {
             let sandbox = create_empty_proto_sandbox();
             let mut plugin = if let Some(schema) = $schema {
-                sandbox.create_schema_plugin($id, schema)
+                sandbox.create_schema_plugin($id, schema).await
             } else {
-                sandbox.create_plugin($id)
+                sandbox.create_plugin($id).await
             };
             let mut tool = plugin.tool;
 
@@ -66,9 +66,9 @@ macro_rules! generate_download_install_tests {
 
             let sandbox = create_empty_proto_sandbox();
             let plugin = if let Some(schema) = $schema {
-                sandbox.create_schema_plugin($id, schema)
+                sandbox.create_schema_plugin($id, schema).await
             } else {
-                sandbox.create_plugin($id)
+                sandbox.create_plugin($id).await
             };
             let mut tool = plugin.tool;
             let spec = VersionSpec::parse($version).unwrap();
@@ -94,9 +94,9 @@ macro_rules! generate_resolve_versions_tests {
         async fn resolves_latest_alias() {
             let sandbox = create_empty_proto_sandbox();
             let mut plugin = if let Some(schema) = $schema {
-                sandbox.create_schema_plugin($id, schema)
+                sandbox.create_schema_plugin($id, schema).await
             } else {
-                sandbox.create_plugin($id)
+                sandbox.create_plugin($id).await
             };
 
             plugin.tool.resolve_version(
@@ -111,9 +111,9 @@ macro_rules! generate_resolve_versions_tests {
         async fn resolve_version_or_alias() {
             let sandbox = create_empty_proto_sandbox();
             let mut plugin = if let Some(schema) = $schema {
-                sandbox.create_schema_plugin($id, schema)
+                sandbox.create_schema_plugin($id, schema).await
             } else {
-                sandbox.create_plugin($id)
+                sandbox.create_plugin($id).await
             };
 
             $(
@@ -140,7 +140,7 @@ macro_rules! generate_resolve_versions_tests {
         //         r#"{"aliases":{"example":"1.0.0"}}"#,
         //     );
 
-        //     let mut plugin = sandbox.create_plugin($id);
+        //     let mut plugin = sandbox.create_plugin($id).await;
 
         //     assert_eq!(
         //         plugin.tool.resolve_version("example").await.unwrap(),
@@ -153,9 +153,9 @@ macro_rules! generate_resolve_versions_tests {
         async fn errors_invalid_alias() {
             let sandbox = create_empty_proto_sandbox();
             let mut plugin = if let Some(schema) = $schema {
-                sandbox.create_schema_plugin($id, schema)
+                sandbox.create_schema_plugin($id, schema).await
             } else {
-                sandbox.create_plugin($id)
+                sandbox.create_plugin($id).await
             };
 
             plugin.tool.resolve_version(
@@ -169,9 +169,9 @@ macro_rules! generate_resolve_versions_tests {
         async fn errors_invalid_version() {
             let sandbox = create_empty_proto_sandbox();
             let mut plugin = if let Some(schema) = $schema {
-                sandbox.create_schema_plugin($id, schema)
+                sandbox.create_schema_plugin($id, schema).await
             } else {
-                sandbox.create_plugin($id)
+                sandbox.create_plugin($id).await
             };
 
             plugin.tool.resolve_version(
@@ -195,9 +195,9 @@ macro_rules! generate_shims_test {
         async fn creates_shims() {
             let sandbox = create_empty_proto_sandbox();
             let mut plugin = if let Some(schema) = $schema {
-                sandbox.create_schema_plugin($id, schema)
+                sandbox.create_schema_plugin($id, schema).await
             } else {
-                sandbox.create_plugin($id)
+                sandbox.create_plugin($id).await
             };
 
             plugin.tool.generate_shims(false).await.unwrap();

--- a/crates/pdk-test-utils/src/macros.rs
+++ b/crates/pdk-test-utils/src/macros.rs
@@ -4,7 +4,7 @@ macro_rules! generate_download_install_tests {
         generate_download_install_tests!($id, $version, None);
     };
     ($id:literal, $version:literal, $schema:expr) => {
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread")]
         async fn downloads_verifies_installs_tool() {
             let sandbox = create_empty_proto_sandbox();
             let mut plugin = if let Some(schema) = $schema {
@@ -36,7 +36,7 @@ macro_rules! generate_download_install_tests {
             }
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread")]
         async fn downloads_prebuilt_and_checksum_to_temp() {
             let sandbox = create_empty_proto_sandbox();
             let mut plugin = if let Some(schema) = $schema {
@@ -57,7 +57,7 @@ macro_rules! generate_download_install_tests {
             assert!(temp_dir.exists());
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread")]
         async fn doesnt_install_if_already_installed() {
             if $version == "canary" {
                 // Canary always overwrites instead of aborting
@@ -90,7 +90,7 @@ macro_rules! generate_resolve_versions_tests {
         generate_resolve_versions_tests!($id, { $( $k => $v, )* }, None);
     };
     ($id:literal, { $( $k:literal => $v:literal, )* }, $schema:expr) => {
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread")]
         async fn resolves_latest_alias() {
             let sandbox = create_empty_proto_sandbox();
             let mut plugin = if let Some(schema) = $schema {
@@ -107,7 +107,7 @@ macro_rules! generate_resolve_versions_tests {
             assert_ne!(plugin.tool.get_resolved_version(), "latest");
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread")]
         async fn resolve_version_or_alias() {
             let sandbox = create_empty_proto_sandbox();
             let mut plugin = if let Some(schema) = $schema {
@@ -130,7 +130,7 @@ macro_rules! generate_resolve_versions_tests {
             )*
         }
 
-        // #[tokio::test]
+        // #[tokio::test(flavor = "multi_thread")]
         // async fn resolve_custom_alias() {
         //
         //     let sandbox = create_empty_proto_sandbox();
@@ -148,7 +148,7 @@ macro_rules! generate_resolve_versions_tests {
         //     );
         // }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread")]
         #[should_panic(expected = "Failed to resolve unknown to a valid supported version")]
         async fn errors_invalid_alias() {
             let sandbox = create_empty_proto_sandbox();
@@ -164,7 +164,7 @@ macro_rules! generate_resolve_versions_tests {
             ).await.unwrap();
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread")]
         #[should_panic(expected = "Failed to resolve 99.99.99 to a valid supported version")]
         async fn errors_invalid_version() {
             let sandbox = create_empty_proto_sandbox();
@@ -191,7 +191,7 @@ macro_rules! generate_shims_test {
         generate_shims_test!($id, [ $($bin),* ], None);
     };
     ($id:literal, [ $($bin:literal),* ], $schema:expr) => {
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread")]
         async fn creates_shims() {
             let sandbox = create_empty_proto_sandbox();
             let mut plugin = if let Some(schema) = $schema {

--- a/crates/pdk-test-utils/src/sandbox.rs
+++ b/crates/pdk-test-utils/src/sandbox.rs
@@ -54,11 +54,11 @@ impl ProtoWasmSandbox {
         ConfigBuilder::new(&self.root, &self.home_dir)
     }
 
-    pub fn create_plugin(&self, id: &str) -> WasmTestWrapper {
-        self.create_plugin_with_config(id, |_| {})
+    pub async fn create_plugin(&self, id: &str) -> WasmTestWrapper {
+        self.create_plugin_with_config(id, |_| {}).await
     }
 
-    pub fn create_plugin_with_config(
+    pub async fn create_plugin_with_config(
         &self,
         id: &str,
         mut op: impl FnMut(&mut ConfigBuilder),
@@ -102,16 +102,17 @@ impl ProtoWasmSandbox {
         // );
 
         WasmTestWrapper {
-            tool: Tool::load_from_manifest(id, proto, manifest).unwrap(),
+            tool: Tool::load_from_manifest(id, proto, manifest).await.unwrap(),
         }
     }
 
-    pub fn create_schema_plugin(&self, id: &str, schema_path: PathBuf) -> WasmTestWrapper {
+    pub async fn create_schema_plugin(&self, id: &str, schema_path: PathBuf) -> WasmTestWrapper {
         self.create_schema_plugin_with_config(id, schema_path, |_| {})
+            .await
     }
 
     #[allow(unused_variables)]
-    pub fn create_schema_plugin_with_config(
+    pub async fn create_schema_plugin_with_config(
         &self,
         id: &str,
         schema_path: PathBuf,
@@ -130,6 +131,7 @@ impl ProtoWasmSandbox {
                 config.toml_schema(schema);
             }
         })
+        .await
     }
 }
 

--- a/crates/pdk-test-utils/src/wrapper.rs
+++ b/crates/pdk-test-utils/src/wrapper.rs
@@ -6,117 +6,146 @@ pub struct WasmTestWrapper {
 }
 
 impl WasmTestWrapper {
-    pub fn detect_version_files(&self) -> DetectVersionOutput {
-        self.tool.plugin.call_func("detect_version_files").unwrap()
+    pub async fn detect_version_files(&self) -> DetectVersionOutput {
+        self.tool
+            .plugin
+            .call_func("detect_version_files")
+            .await
+            .unwrap()
     }
 
-    pub fn download_prebuilt(&self, mut input: DownloadPrebuiltInput) -> DownloadPrebuiltOutput {
+    pub async fn download_prebuilt(
+        &self,
+        mut input: DownloadPrebuiltInput,
+    ) -> DownloadPrebuiltOutput {
         input.context = self.prepare_context(input.context);
 
         self.tool
             .plugin
             .call_func_with("download_prebuilt", input)
+            .await
             .unwrap()
     }
 
-    pub fn load_versions(&self, input: LoadVersionsInput) -> LoadVersionsOutput {
+    pub async fn load_versions(&self, input: LoadVersionsInput) -> LoadVersionsOutput {
         self.tool
             .plugin
             .call_func_with("load_versions", input)
+            .await
             .unwrap()
     }
 
-    pub fn locate_executables(&self, mut input: LocateExecutablesInput) -> LocateExecutablesOutput {
+    pub async fn locate_executables(
+        &self,
+        mut input: LocateExecutablesInput,
+    ) -> LocateExecutablesOutput {
         input.context = self.prepare_context(input.context);
 
         self.tool
             .plugin
             .call_func_with("locate_executables", input)
+            .await
             .unwrap()
     }
 
-    pub fn native_install(&self, mut input: NativeInstallInput) -> NativeInstallOutput {
+    pub async fn native_install(&self, mut input: NativeInstallInput) -> NativeInstallOutput {
         input.context = self.prepare_context(input.context);
 
         self.tool
             .plugin
             .call_func_with("native_install", input)
+            .await
             .unwrap()
     }
 
-    pub fn native_uninstall(&self, mut input: NativeUninstallInput) -> NativeUninstallOutput {
+    pub async fn native_uninstall(&self, mut input: NativeUninstallInput) -> NativeUninstallOutput {
         input.context = self.prepare_context(input.context);
 
         self.tool
             .plugin
             .call_func_with("native_uninstall", input)
+            .await
             .unwrap()
     }
 
-    pub fn parse_version_file(&self, input: ParseVersionFileInput) -> ParseVersionFileOutput {
+    pub async fn parse_version_file(&self, input: ParseVersionFileInput) -> ParseVersionFileOutput {
         self.tool
             .plugin
             .call_func_with("parse_version_file", input)
+            .await
             .unwrap()
     }
 
-    pub fn pre_install(&self, mut input: InstallHook) {
+    pub async fn pre_install(&self, mut input: InstallHook) {
         input.context = self.prepare_context(input.context);
 
         self.tool
             .plugin
             .call_func_without_output("pre_install", input)
+            .await
             .unwrap();
     }
 
-    pub fn pre_run(&self, mut input: RunHook) -> RunHookResult {
+    pub async fn pre_run(&self, mut input: RunHook) -> RunHookResult {
         input.context = self.prepare_context(input.context);
 
-        self.tool.plugin.call_func_with("pre_run", input).unwrap()
+        self.tool
+            .plugin
+            .call_func_with("pre_run", input)
+            .await
+            .unwrap()
     }
 
-    pub fn post_install(&self, mut input: InstallHook) {
+    pub async fn post_install(&self, mut input: InstallHook) {
         input.context = self.prepare_context(input.context);
 
         self.tool
             .plugin
             .call_func_without_output("post_install", input)
+            .await
             .unwrap();
     }
 
-    pub fn register_tool(&self, input: ToolMetadataInput) -> ToolMetadataOutput {
+    pub async fn register_tool(&self, input: ToolMetadataInput) -> ToolMetadataOutput {
         self.tool
             .plugin
             .call_func_with("register_tool", input)
+            .await
             .unwrap()
     }
 
-    pub fn resolve_version(&self, input: ResolveVersionInput) -> ResolveVersionOutput {
+    pub async fn resolve_version(&self, input: ResolveVersionInput) -> ResolveVersionOutput {
         self.tool
             .plugin
             .call_func_with("resolve_version", input)
+            .await
             .unwrap()
     }
 
-    pub fn sync_manifest(&self, mut input: SyncManifestInput) -> SyncManifestOutput {
+    pub async fn sync_manifest(&self, mut input: SyncManifestInput) -> SyncManifestOutput {
         input.context = self.prepare_context(input.context);
 
         self.tool
             .plugin
             .call_func_with("sync_manifest", input)
+            .await
             .unwrap()
     }
 
-    pub fn sync_shell_profile(&self, mut input: SyncShellProfileInput) -> SyncShellProfileOutput {
+    pub async fn sync_shell_profile(
+        &self,
+        mut input: SyncShellProfileInput,
+    ) -> SyncShellProfileOutput {
         input.context = self.prepare_context(input.context);
 
         self.tool
             .plugin
             .call_func_with("sync_shell_profile", input)
+            .await
             .unwrap()
     }
 
-    pub fn unpack_archive(&self, mut input: UnpackArchiveInput) {
+    pub async fn unpack_archive(&self, mut input: UnpackArchiveInput) {
         input.input_file = self.tool.to_virtual_path(&input.input_file);
         input.output_dir = self.tool.to_virtual_path(&input.output_dir);
 
@@ -124,16 +153,18 @@ impl WasmTestWrapper {
             .tool
             .plugin
             .call_func_with("unpack_archive", input)
+            .await
             .unwrap();
     }
 
-    pub fn verify_checksum(&self, mut input: VerifyChecksumInput) -> VerifyChecksumOutput {
+    pub async fn verify_checksum(&self, mut input: VerifyChecksumInput) -> VerifyChecksumOutput {
         input.checksum_file = self.tool.to_virtual_path(&input.checksum_file);
         input.download_file = self.tool.to_virtual_path(&input.download_file);
 
         self.tool
             .plugin
             .call_func_with("verify_checksum", input)
+            .await
             .unwrap()
     }
 

--- a/crates/warpgate-api/src/host_funcs.rs
+++ b/crates/warpgate-api/src/host_funcs.rs
@@ -146,7 +146,6 @@ impl SendRequestInput {
     pub fn new(url: impl AsRef<str>) -> Self {
         Self {
             url: url.as_ref().to_owned(),
-            ..Default::default()
         }
     }
 }

--- a/crates/warpgate-api/src/host_funcs.rs
+++ b/crates/warpgate-api/src/host_funcs.rs
@@ -141,17 +141,25 @@ api_struct!(
     }
 );
 
+impl SendRequestInput {
+    /// Create a new send request with the provided url.
+    pub fn new(url: impl AsRef<str>) -> Self {
+        Self {
+            url: url.as_ref().to_owned(),
+            ..Default::default()
+        }
+    }
+}
+
 impl From<&str> for SendRequestInput {
     fn from(url: &str) -> Self {
-        SendRequestInput {
-            url: url.to_owned(),
-        }
+        SendRequestInput::new(url)
     }
 }
 
 impl From<String> for SendRequestInput {
     fn from(url: String) -> Self {
-        SendRequestInput { url }
+        SendRequestInput::new(url)
     }
 }
 

--- a/crates/warpgate-pdk/src/api.rs
+++ b/crates/warpgate-pdk/src/api.rs
@@ -1,9 +1,13 @@
-use extism_pdk::{memory::internal::memory_bytes, MemoryHandle};
+use extism_pdk::{memory::internal::load, MemoryHandle};
 use warpgate_api::SendRequestOutput;
 
 pub fn populate_send_request_output(output: &mut SendRequestOutput) {
     if output.body.is_empty() {
-        output.body =
-            unsafe { memory_bytes(MemoryHandle::new(output.body_offset, output.body_length)) };
+        let handle = unsafe { MemoryHandle::new(output.body_offset, output.body_length) };
+        let mut body = vec![0; handle.length as usize];
+
+        load(handle, &mut body);
+
+        output.body = body;
     }
 }

--- a/crates/warpgate-pdk/src/api.rs
+++ b/crates/warpgate-pdk/src/api.rs
@@ -1,0 +1,9 @@
+use extism_pdk::{memory::internal::memory_bytes, MemoryHandle};
+use warpgate_api::SendRequestOutput;
+
+pub fn populate_send_request_output(output: &mut SendRequestOutput) {
+    if output.body.is_empty() {
+        output.body =
+            unsafe { memory_bytes(MemoryHandle::new(output.body_offset, output.body_length)) };
+    }
+}

--- a/crates/warpgate-pdk/src/funcs.rs
+++ b/crates/warpgate-pdk/src/funcs.rs
@@ -16,7 +16,7 @@ extern "ExtismHost" {
 }
 
 /// Fetch the provided request and return a response object.
-#[deprecated]
+#[deprecated(note = "Use `fetch_*` instead.")]
 pub fn fetch(req: HttpRequest, body: Option<String>) -> AnyResult<HttpResponse> {
     debug!("Fetching <url>{}</url>", req.url);
 
@@ -58,7 +58,7 @@ where
 /// Fetch the provided URL, deserialize the response as JSON,
 /// and cache the response in memory for subsequent WASM function calls.
 #[allow(deprecated)]
-#[deprecated]
+#[deprecated(note = "Use `fetch_*` instead.")]
 pub fn fetch_url_with_cache<R, U>(url: U) -> AnyResult<R>
 where
     R: DeserializeOwned,
@@ -132,7 +132,7 @@ where
     Ok(response)
 }
 
-/// Fetch the provided URL and deserialize the response as bytes.
+/// Fetch the provided URL and return the response as bytes.
 pub fn fetch_bytes<U>(url: U) -> AnyResult<Vec<u8>>
 where
     U: AsRef<str>,
@@ -149,7 +149,7 @@ where
     do_fetch(url)?.json()
 }
 
-/// Fetch the provided URL and deserialize the response as text.
+/// Fetch the provided URL and return the response as text.
 pub fn fetch_text<U>(url: U) -> AnyResult<String>
 where
     U: AsRef<str>,
@@ -157,7 +157,7 @@ where
     do_fetch(url)?.text()
 }
 
-/// Load all git tags from the provided remote URL.
+/// Load all Git tags from the provided remote URL.
 /// The `git` binary must exist on the current machine.
 pub fn load_git_tags<U>(url: U) -> AnyResult<Vec<String>>
 where
@@ -211,9 +211,11 @@ pub fn command_exists(env: &HostEnvironment, command: &str) -> bool {
     );
 
     let result = if env.os == HostOS::Windows {
-        let line = format!("Get-Command {command}");
-
-        exec_command!(raw, "powershell", ["-Command", &line])
+        exec_command!(
+            raw,
+            "powershell",
+            ["-Command", format!("Get-Command {command}").as_str()]
+        )
     } else {
         exec_command!(raw, "which", [command])
     };

--- a/crates/warpgate-pdk/src/lib.rs
+++ b/crates/warpgate-pdk/src/lib.rs
@@ -1,5 +1,7 @@
+mod api;
 mod funcs;
 mod macros;
 
+pub use api::*;
 pub use funcs::*;
 pub use warpgate_api::*;

--- a/crates/warpgate-pdk/src/macros.rs
+++ b/crates/warpgate-pdk/src/macros.rs
@@ -56,6 +56,25 @@ macro_rules! exec_command {
     };
 }
 
+/// Calls the `send_request` host function to send an HTTP request
+/// and return a response. Not OK responses must be handled by the guest.
+#[macro_export]
+macro_rules! send_request {
+    (input, $input:expr) => {
+        unsafe {
+            let output = send_request(Json($input))?.0;
+            warpgate_pdk::populate_send_request_output(&mut output);
+            output
+        }
+    };
+    ($url:literal) => {
+        send_request!(input, SendRequestInput::new($url))
+    };
+    ($url:expr) => {
+        send_request!(input, SendRequestInput::new($url))
+    };
+}
+
 /// Calls the `get_env_var` or `set_env_var` host function to manage
 /// environment variables on the host.
 ///

--- a/crates/warpgate-pdk/src/macros.rs
+++ b/crates/warpgate-pdk/src/macros.rs
@@ -62,8 +62,8 @@ macro_rules! exec_command {
 macro_rules! send_request {
     (input, $input:expr) => {
         unsafe {
-            let output = send_request(Json($input))?.0;
-            warpgate_pdk::populate_send_request_output(&mut output);
+            let mut output = send_request(Json($input))?.0;
+            populate_send_request_output(&mut output);
             output
         }
     };

--- a/crates/warpgate-pdk/src/macros.rs
+++ b/crates/warpgate-pdk/src/macros.rs
@@ -25,6 +25,7 @@ macro_rules! exec_command {
         exec_command!(raw, ExecCommandInput::pipe($cmd, $args))
     };
     (raw, $input:expr) => {
+        #[allow(clippy::macro_metavars_in_unsafe)]
         unsafe { exec_command(Json($input)) }
     };
 

--- a/crates/warpgate-pdk/src/macros.rs
+++ b/crates/warpgate-pdk/src/macros.rs
@@ -25,8 +25,10 @@ macro_rules! exec_command {
         exec_command!(raw, ExecCommandInput::pipe($cmd, $args))
     };
     (raw, $input:expr) => {
-        #[allow(clippy::macro_metavars_in_unsafe)]
-        unsafe { exec_command(Json($input)) }
+        {
+            #[allow(clippy::macro_metavars_in_unsafe)]
+            unsafe { exec_command(Json($input)) }
+        }
     };
 
     // Pipe

--- a/crates/warpgate-pdk/src/macros.rs
+++ b/crates/warpgate-pdk/src/macros.rs
@@ -60,13 +60,12 @@ macro_rules! exec_command {
 /// and return a response. Not OK responses must be handled by the guest.
 #[macro_export]
 macro_rules! send_request {
-    (input, $input:expr) => {
-        unsafe {
-            let mut output = send_request(Json($input))?.0;
-            populate_send_request_output(&mut output);
-            output
-        }
-    };
+    (input, $input:expr) => {{
+        #[allow(clippy::macro_metavars_in_unsafe)]
+        let mut output = unsafe { send_request(Json($input))?.0 };
+        populate_send_request_output(&mut output);
+        output
+    }};
     ($url:literal) => {
         send_request!(input, SendRequestInput::new($url))
     };

--- a/crates/warpgate/Cargo.toml
+++ b/crates/warpgate/Cargo.toml
@@ -16,6 +16,7 @@ once_map = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["json", "rustls-tls-native-roots"] }
 schematic = { workspace = true, optional = true, features = ["schema"] }
+scc = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/warpgate/Cargo.toml
+++ b/crates/warpgate/Cargo.toml
@@ -23,6 +23,7 @@ starbase_archive = { workspace = true }
 starbase_utils = { workspace = true, features = ["glob", "net"] }
 starbase_styles = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true }
 tracing = { workspace = true }
 
 # Enabling certs for extism!
@@ -30,7 +31,6 @@ ureq = { version = "2.10.0", features = ["native-certs"] }
 
 [dev-dependencies]
 starbase_sandbox = { workspace = true }
-tokio = { workspace = true }
 
 [features]
 default = []

--- a/crates/warpgate/Cargo.toml
+++ b/crates/warpgate/Cargo.toml
@@ -12,7 +12,6 @@ warpgate_api = { version = "0.9.0", path = "../warpgate-api" }
 extism = { workspace = true, features = ["http"] }
 miette = { workspace = true }
 once_cell = { workspace = true }
-once_map = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["json", "rustls-tls-native-roots"] }
 schematic = { workspace = true, optional = true, features = ["schema"] }

--- a/crates/warpgate/src/host_funcs.rs
+++ b/crates/warpgate/src/host_funcs.rs
@@ -281,9 +281,12 @@ fn send_request(
 
             let memory = plugin.memory_new(Vec::from(body))?;
 
-            let _ = data
-                .http_cache
-                .insert(input.url, (memory.offset, memory.length));
+            // Only cache successful requests
+            if status == 200 {
+                let _ = data
+                    .http_cache
+                    .insert(input.url, (memory.offset, memory.length));
+            }
 
             (memory.offset, memory.length, status)
         }

--- a/crates/warpgate/src/host_funcs.rs
+++ b/crates/warpgate/src/host_funcs.rs
@@ -167,6 +167,7 @@ fn exec_command(
     };
 
     trace!(
+        plugin = plugin.id().to_string(),
         command = &input.command,
         args = ?input.args,
         env = ?input.env,
@@ -201,6 +202,7 @@ fn exec_command(
     let debug_output = bool_var("WARPGATE_DEBUG_COMMAND");
 
     trace!(
+        plugin = plugin.id().to_string(),
         command = ?bin,
         exit_code = output.exit_code,
         stderr = if debug_output {
@@ -235,7 +237,11 @@ fn send_request(
     let data = user_data.get()?;
     let data = data.lock().unwrap();
 
-    trace!(url = &input.url, "Sending request from plugin");
+    trace!(
+        plugin = plugin.id().to_string(),
+        url = &input.url,
+        "Sending request to URL",
+    );
 
     let response = Handle::current().block_on(async {
         let mut client = data.http_client.get(&input.url);
@@ -253,11 +259,12 @@ fn send_request(
     let status = response.status().as_u16();
 
     trace!(
+        plugin = plugin.id().to_string(),
         url = &input.url,
         length = response.content_length(),
         status,
         ok = response.status().is_success(),
-        "Sent request from plugin"
+        "Received response from URL"
     );
 
     let body = Handle::current().block_on(async {
@@ -292,6 +299,7 @@ fn get_env_var(
     let value = env::var(&name).unwrap_or_default();
 
     trace!(
+        plugin = plugin.id().to_string(),
         name = &name,
         value = &value,
         "Read environment variable from host"
@@ -325,6 +333,7 @@ fn set_env_var(
             .collect::<Vec<_>>();
 
         trace!(
+            plugin = plugin.id().to_string(),
             name = &name,
             path = ?new_path,
             "Adding paths to PATH environment variable on host"
@@ -336,6 +345,7 @@ fn set_env_var(
         env::set_var("PATH", env::join_paths(path)?);
     } else {
         trace!(
+            plugin = plugin.id().to_string(),
             name = &name,
             value = &value,
             "Wrote environment variable to host"
@@ -361,6 +371,7 @@ fn from_virtual_path(
     let real_path = helpers::from_virtual_path(&data.virtual_paths, &original_path);
 
     trace!(
+        plugin = plugin.id().to_string(),
         original_path = ?original_path,
         real_path = ?real_path,
         "Converted a path into a real path"
@@ -385,6 +396,7 @@ fn to_virtual_path(
     let virtual_path = helpers::to_virtual_path(&data.virtual_paths, &original_path);
 
     trace!(
+        plugin = plugin.id().to_string(),
         original_path = ?original_path,
         virtual_path = ?virtual_path.virtual_path(),
         "Converted a path into a virtual path"

--- a/crates/warpgate/src/lib.rs
+++ b/crates/warpgate/src/lib.rs
@@ -2,7 +2,7 @@ mod client;
 mod endpoints;
 mod error;
 mod helpers;
-pub mod host_funcs;
+pub mod host;
 mod id;
 mod loader;
 mod plugin;

--- a/crates/warpgate/src/loader.rs
+++ b/crates/warpgate/src/loader.rs
@@ -24,7 +24,7 @@ pub type OfflineChecker = Arc<fn() -> bool>;
 #[derive(Clone)]
 pub struct PluginLoader {
     /// Instance of our HTTP client.
-    http_client: OnceCell<reqwest::Client>,
+    http_client: OnceCell<Arc<reqwest::Client>>,
 
     /// Options to pass to the HTTP client.
     http_options: HttpOptions,
@@ -60,9 +60,9 @@ impl PluginLoader {
     }
 
     /// Return the HTTP client, or create it if it does not exist.
-    pub fn get_client(&self) -> miette::Result<&reqwest::Client> {
+    pub fn get_client(&self) -> miette::Result<&Arc<reqwest::Client>> {
         self.http_client
-            .get_or_try_init(|| create_http_client_with_options(&self.http_options))
+            .get_or_try_init(|| create_http_client_with_options(&self.http_options).map(Arc::new))
     }
 
     /// Load a plugin using the provided locator. File system plugins are loaded directly,

--- a/crates/warpgate/src/plugin.rs
+++ b/crates/warpgate/src/plugin.rs
@@ -12,6 +12,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use system_env::{SystemArch, SystemLibc, SystemOS};
 use tokio::sync::RwLock;
+use tokio::task::block_in_place;
 use tracing::{instrument, trace};
 use warpgate_api::{HostEnvironment, VirtualPath};
 
@@ -217,7 +218,7 @@ impl PluginContainer {
             color::property(func),
         );
 
-        let output = instance.call(func, input).map_err(|error| {
+        let output = block_in_place(|| instance.call(func, input)).map_err(|error| {
             if is_incompatible_runtime(&error) {
                 return WarpgateError::IncompatibleRuntime {
                     id: self.id.clone(),

--- a/crates/warpgate/src/plugin.rs
+++ b/crates/warpgate/src/plugin.rs
@@ -214,7 +214,7 @@ impl PluginContainer {
             id = self.id.as_str(),
             plugin = &uuid,
             input = %String::from_utf8_lossy(input),
-            "Calling plugin function {}",
+            "Calling guest function {}",
             color::property(func),
         );
 
@@ -257,7 +257,7 @@ impl PluginContainer {
             id = self.id.as_str(),
             plugin = &uuid,
             output = %String::from_utf8_lossy(output),
-            "Called plugin function {}",
+            "Called guest function {}",
             color::property(func),
         );
 

--- a/plugins/Cargo.lock
+++ b/plugins/Cargo.lock
@@ -812,7 +812,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "toml 0.8.15",
+ "toml 0.8.19",
  "tracing",
  "tracing-subscriber",
  "ureq",
@@ -2000,7 +2000,7 @@ dependencies = [
  "shell-words",
  "starbase_archive",
  "starbase_styles",
- "starbase_utils 0.8.4",
+ "starbase_utils",
  "thiserror",
  "tracing",
  "url",
@@ -2025,6 +2025,7 @@ name = "proto_pdk_api"
 version = "0.22.0"
 dependencies = [
  "rustc-hash 2.0.0",
+ "schematic",
  "semver",
  "serde",
  "serde_json",
@@ -2042,13 +2043,13 @@ dependencies = [
  "proto_pdk_api",
  "serde",
  "serde_json",
- "starbase_sandbox 0.7.1",
+ "starbase_sandbox",
  "warpgate",
 ]
 
 [[package]]
 name = "proto_shim"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "command-group",
  "dirs 5.0.1",
@@ -2062,7 +2063,7 @@ dependencies = [
  "proto_pdk",
  "proto_pdk_test_utils",
  "serde",
- "starbase_sandbox 0.6.2",
+ "starbase_sandbox",
  "tokio",
 ]
 
@@ -2256,12 +2257,6 @@ name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
-
-[[package]]
-name = "relative-path"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
@@ -2473,9 +2468,9 @@ dependencies = [
 
 [[package]]
 name = "schematic"
-version = "0.16.6"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39662af6f427584874872ecc0e42888bccd0c42510d32d519c4ac9319f4c52f3"
+checksum = "4952b2fab03cea740a66c0ca502d16f31ad5d3cc0a803541778f20715ebd0088"
 dependencies = [
  "garde",
  "indexmap 2.2.6",
@@ -2483,18 +2478,19 @@ dependencies = [
  "schematic_macros",
  "schematic_types",
  "serde",
+ "serde_json",
  "serde_path_to_error",
  "starbase_styles",
  "thiserror",
- "toml 0.8.15",
+ "toml 0.8.19",
  "tracing",
 ]
 
 [[package]]
 name = "schematic_macros"
-version = "0.16.6"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9747db30b2549f7a3d5c5c61e00a4da45d6fe7f4a413594ffc5e598f5ced1330"
+checksum = "4568cc8e3cc136c4231041062419bebcf69f13e8c05fb34d4c715cc5c33ebbc4"
 dependencies = [
  "convert_case",
  "darling",
@@ -2505,13 +2501,15 @@ dependencies = [
 
 [[package]]
 name = "schematic_types"
-version = "0.8.4"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6196a0b23e5b4ee02e3894a937606fc49ccc9211e1650a9bef759062cfff3d58"
+checksum = "9939a1953cd54de031828aabb6b9e37191c45328c0620f7286ccc76a35a6ac05"
 dependencies = [
  "indexmap 2.2.6",
+ "semver",
+ "serde",
  "serde_json",
- "toml 0.8.15",
+ "toml 0.8.19",
  "url",
 ]
 
@@ -2585,6 +2583,7 @@ version = "1.0.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ab380d7d9f22ef3f21ad3e6c1ebe8e4fc7a2000ccba2e4d71fc96f15b2cb609"
 dependencies = [
+ "indexmap 2.2.6",
  "itoa",
  "memchr",
  "ryu",
@@ -2603,9 +2602,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
+checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
 dependencies = [
  "serde",
 ]
@@ -2741,28 +2740,12 @@ dependencies = [
  "miette",
  "rustc-hash 2.0.0",
  "starbase_styles",
- "starbase_utils 0.8.4",
+ "starbase_utils",
  "thiserror",
  "tracing",
  "xz2",
  "zip",
  "zstd",
-]
-
-[[package]]
-name = "starbase_sandbox"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dc8cc21fc2c389549297a2049074bf22a34aceb8ed8d31be6e1df42648abcb8"
-dependencies = [
- "assert_cmd",
- "assert_fs",
- "clean-path",
- "insta",
- "once_cell",
- "predicates",
- "pretty_assertions",
- "starbase_utils 0.7.5",
 ]
 
 [[package]]
@@ -2777,7 +2760,7 @@ dependencies = [
  "insta",
  "predicates",
  "pretty_assertions",
- "starbase_utils 0.8.4",
+ "starbase_utils",
 ]
 
 [[package]]
@@ -2789,20 +2772,6 @@ dependencies = [
  "dirs 5.0.1",
  "owo-colors",
  "supports-color",
-]
-
-[[package]]
-name = "starbase_utils"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06fac1efba629ebe53fd2363b0af2a7b4f9a2a79540e53b1f0bbdd08c3cb6fbf"
-dependencies = [
- "dirs 5.0.1",
- "once_cell",
- "relative-path",
- "starbase_styles",
- "thiserror",
- "tracing",
 ]
 
 [[package]]
@@ -2821,7 +2790,7 @@ dependencies = [
  "starbase_styles",
  "thiserror",
  "tokio",
- "toml 0.8.15",
+ "toml 0.8.19",
  "tracing",
  "url",
  "wax",
@@ -3066,21 +3035,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.15"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac2caab0bf757388c6c0ae23b3293fdb463fee59434529014f85e3263b995c28"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.16",
+ "toml_edit 0.22.20",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 dependencies = [
  "serde",
 ]
@@ -3098,15 +3067,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.16"
+version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "278f3d518e152219c994ce877758516bca5e118eaed6996192a774fb9fbf0788"
+checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.8",
+ "winnow 0.6.18",
 ]
 
 [[package]]
@@ -3361,7 +3330,7 @@ dependencies = [
  "sha2",
  "starbase_archive",
  "starbase_styles",
- "starbase_utils 0.8.4",
+ "starbase_utils",
  "system_env",
  "thiserror",
  "tokio",
@@ -3611,7 +3580,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "sha2",
- "toml 0.8.15",
+ "toml 0.8.19",
  "windows-sys 0.52.0",
  "zstd",
 ]
@@ -4157,9 +4126,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.8"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c52e9c97a68071b23e836c9380edae937f17b9c4667bd021973efc689f618d"
+checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
 dependencies = [
  "memchr",
 ]

--- a/plugins/Cargo.lock
+++ b/plugins/Cargo.lock
@@ -76,13 +76,14 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.14"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed72493ac66d5804837f480ab3766c72bdfab91a65e565fc54fa9e42db0073a8"
+checksum = "dc1835b7f27878de8525dc71410b5a31cdcc5f230aed5ba5df968e09c201b23d"
 dependencies = [
  "anstyle",
  "bstr",
  "doc-comment",
+ "libc",
  "predicates",
  "predicates-core",
  "predicates-tree",
@@ -91,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "assert_fs"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd762e110c8ed629b11b6cde59458cc1c71de78ebbcc30099fc8e0403a2a2ec"
+checksum = "7efdb1fdb47602827a342857666feb372712cbc64b414172bd6b167a02927674"
 dependencies = [
  "anstyle",
  "doc-comment",
@@ -970,9 +971,9 @@ dependencies = [
 
 [[package]]
 name = "fs4"
-version = "0.8.4"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7e180ac76c23b45e767bd7ae9579bc0bb458618c4bc71835926e098e61d15f8"
+checksum = "e8c6b3bd49c37d2aa3f3f2220233b29a7cd23f79d1fe70e5337d25fb390793de"
 dependencies = [
  "rustix",
  "windows-sys 0.52.0",
@@ -1092,7 +1093,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 dependencies = [
  "fallible-iterator",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "stable_deref_trait",
 ]
 
@@ -1138,7 +1139,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1358,9 +1359,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -1754,7 +1755,7 @@ checksum = "d8dd6c0cdf9429bce006e1362bfce61fa1bfd8c898a643ed8d2b471934701d3d"
 dependencies = [
  "crc32fast",
  "hashbrown 0.14.3",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "memchr",
 ]
 
@@ -1889,9 +1890,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "predicates"
-version = "3.1.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
+checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
 dependencies = [
  "anstyle",
  "difflib",
@@ -1983,7 +1984,7 @@ dependencies = [
 name = "proto_core"
 version = "0.39.3"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "miette",
  "minisign-verify",
  "once_cell",
@@ -2216,9 +2217,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2450,9 +2451,9 @@ dependencies = [
 
 [[package]]
 name = "scc"
-version = "2.1.6"
+version = "2.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ccfb12511cdb770157ace92d7dda771e498445b78f9886e8cdbc5140a4eced"
+checksum = "79da19444d9da7a9a82b80ecf059eceba6d3129d84a8610fd25ff2364f255466"
 dependencies = [
  "sdd",
 ]
@@ -2473,7 +2474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4952b2fab03cea740a66c0ca502d16f31ad5d3cc0a803541778f20715ebd0088"
 dependencies = [
  "garde",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "miette",
  "schematic_macros",
  "schematic_types",
@@ -2505,7 +2506,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9939a1953cd54de031828aabb6b9e37191c45328c0620f7286ccc76a35a6ac05"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "semver",
  "serde",
  "serde_json",
@@ -2521,9 +2522,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sdd"
-version = "2.1.0"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "177258b64c0faaa9ffd3c65cd3262c2bc7e2588dbbd9c1641d0346145c1bbda8"
+checksum = "0495e4577c672de8254beb68d01a9b62d0e8a13c099edecdbedccce3223cd29f"
 
 [[package]]
 name = "security-framework"
@@ -2559,18 +2560,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.207"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "5665e14a49a4ea1b91029ba7d3bca9f299e1f7cfa194388ccc20f14743e784f2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.207"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "6aea2634c86b0e8ef2cfdc0c340baede54ec27b1e46febd7f80dffb2aa44a00e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2579,11 +2580,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.121"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab380d7d9f22ef3f21ad3e6c1ebe8e4fc7a2000ccba2e4d71fc96f15b2cb609"
+checksum = "66ad62847a56b3dba58cc891acd13884b9c61138d330c0d7b6181713d4fce38d"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "itoa",
  "memchr",
  "ryu",
@@ -2731,9 +2732,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "starbase_archive"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f872d80fef76f04dda2083d5fcd9248f145259bcfb7c8a681f720a850896ad0c"
+checksum = "e6b412349652a360e5141521688d97c739fbe025e49ada64354550a1193e1edb"
 dependencies = [
  "binstall-tar",
  "flate2",
@@ -2750,9 +2751,9 @@ dependencies = [
 
 [[package]]
 name = "starbase_sandbox"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd6f9ea85ee2cfea36c1d1dd9454cc1e37cf893ed9eabf1444b40a288482dc"
+checksum = "66fc04e95ede168033c1c1825d1cb266c706ca35e955b0e4b337fbf5cc5d5bbc"
 dependencies = [
  "assert_cmd",
  "assert_fs",
@@ -2776,9 +2777,9 @@ dependencies = [
 
 [[package]]
 name = "starbase_utils"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "641c9b34e4221ca637c645d0bbbc9935a0e4283b986f5605c20200c70b2d6f55"
+checksum = "d8353d4dd059139755ceafe835d95292e049b44d99e78de0f2718df0bfa33c4d"
 dependencies = [
  "dirs 5.0.1",
  "fs4",
@@ -3060,7 +3061,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "toml_datetime",
  "winnow 0.5.26",
 ]
@@ -3071,7 +3072,7 @@ version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -3486,7 +3487,7 @@ dependencies = [
  "ahash",
  "bitflags 2.4.1",
  "hashbrown 0.14.3",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "semver",
 ]
 
@@ -3516,7 +3517,7 @@ dependencies = [
  "fxprof-processed-profile",
  "gimli",
  "hashbrown 0.14.3",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "ittapi",
  "libc",
  "libm",
@@ -3640,7 +3641,7 @@ dependencies = [
  "cpp_demangle",
  "cranelift-entity",
  "gimli",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "log",
  "object 0.33.0",
  "postcard",
@@ -3749,7 +3750,7 @@ checksum = "c936a52ce69c28de2aa3b5fb4f2dbbb2966df304f04cccb7aca4ba56d915fda0"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "wit-parser",
 ]
 
@@ -4161,7 +4162,7 @@ checksum = "78c83dab33a9618d86cfe3563cc864deffd08c17efc5db31a3b7cd1edeffe6e1"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "log",
  "semver",
  "serde",
@@ -4246,7 +4247,7 @@ dependencies = [
  "crossbeam-utils",
  "displaydoc",
  "flate2",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "memchr",
  "thiserror",
  "zopfli",

--- a/plugins/Cargo.lock
+++ b/plugins/Cargo.lock
@@ -24,7 +24,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -38,12 +37,6 @@ checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "allocator-api2"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "ambient-authority"
@@ -119,7 +112,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -227,39 +220,6 @@ name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
-
-[[package]]
-name = "cached"
-version = "0.51.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0feb64151eed3da6107fddd2d717a6ca4b9dbd74e43784c55c841d1abfe5a295"
-dependencies = [
- "ahash",
- "cached_proc_macro",
- "cached_proc_macro_types",
- "hashbrown 0.14.3",
- "instant",
- "once_cell",
- "thiserror",
-]
-
-[[package]]
-name = "cached_proc_macro"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771aa57f3b17da6c8bcacb187bb9ec9bc81c8160e72342e67c329e0e1651a669"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
-name = "cached_proc_macro_types"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "cap-fs-ext"
@@ -505,7 +465,7 @@ dependencies = [
  "hashbrown 0.14.3",
  "log",
  "regalloc2",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "smallvec",
  "target-lexicon",
 ]
@@ -640,9 +600,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.9"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83b2eb4d90d12bdda5ed17de686c2acb4c57914f8f921b8da7e112b5a36f3fe1"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -650,27 +610,27 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.9"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622687fe0bac72a04e5599029151f5796111b90f1baaa9b544d807a5e31cd120"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.9"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -690,7 +650,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -785,7 +745,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -852,7 +812,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "toml 0.8.14",
+ "toml 0.8.15",
  "tracing",
  "tracing-subscriber",
  "ureq",
@@ -888,7 +848,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -925,7 +885,7 @@ checksum = "3a024b0f20295098d1d19ad443fad077c1d8c1d81d09a2c20f0618ebd201517e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1081,9 +1041,9 @@ dependencies = [
 
 [[package]]
 name = "garde"
-version = "0.18.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fa8fb3ffe035745c6194540b2064b2fe275f32367fbb4eb026024b7921e2e5"
+checksum = "0a3233677ea1554a48235d81bb59d2a41654969a8e29a1316c48105fd1701693"
 dependencies = [
  "compact_str",
  "garde_derive",
@@ -1094,14 +1054,14 @@ dependencies = [
 
 [[package]]
 name = "garde_derive"
-version = "0.18.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf62650515830c41553b72bd49ec20fb120226f9277c7f2847f071cf998325b"
+checksum = "8796f322e43105351a7ec35148807b32b5b6058a539656dafe4a5b456d5ca41f"
 dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1207,7 +1167,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
  "ahash",
- "allocator-api2",
 ]
 
 [[package]]
@@ -1218,9 +1177,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.3"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "http"
@@ -1290,15 +1249,16 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
  "http",
  "hyper",
  "hyper-util",
- "rustls 0.22.4",
+ "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -1349,124 +1309,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_collections"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
-
-[[package]]
-name = "icu_normalizer"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
-
-[[package]]
-name = "icu_properties"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f8ac670d7422d7f76b32e17a5db556510825b29ec9154f235977c9caba61036"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_locid_transform",
- "icu_properties_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
-
-[[package]]
-name = "icu_provider"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_provider_macros",
- "stable_deref_trait",
- "tinystr",
- "writeable",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
 name = "id-arena"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1480,14 +1322,12 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "1.0.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4716a3a0933a1d01c2f72450e89596eb51dd34ef3c211ccd875acdf1f8fe47ed"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
- "icu_normalizer",
- "icu_properties",
- "smallvec",
- "utf8_iter",
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -1537,15 +1377,6 @@ dependencies = [
  "lazy_static",
  "linked-hash-map",
  "similar",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -1640,9 +1471,12 @@ dependencies = [
 
 [[package]]
 name = "json-strip-comments"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d129799327c8f80861e467c59b825ba24c277dba6ad0d71a141dc98f9e04ee"
+checksum = "b271732a960335e715b6b2ae66a086f115c74eb97360e996d2bd809bfc063bba"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "lazy_static"
@@ -1690,12 +1524,6 @@ name = "linux-raw-sys"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
-
-[[package]]
-name = "litemap"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
 
 [[package]]
 name = "lock_api"
@@ -1748,7 +1576,7 @@ dependencies = [
  "manyhow-macros",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1779,9 +1607,9 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memfd"
@@ -1821,7 +1649,7 @@ checksum = "dcf09caffaac8068c346b6df2a7fc27a177fd20b39421a39ce0a211bde679a6c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1853,13 +1681,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
 dependencies = [
+ "hermit-abi",
  "libc",
  "wasi",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1909,16 +1738,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "object"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1944,18 +1763,6 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
-
-[[package]]
-name = "once_map"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa7085055bbe9c8edbd982048dbcf8181794d4a81cb04a11931673e63cc18dc6"
-dependencies = [
- "ahash",
- "hashbrown 0.14.3",
- "parking_lot",
- "stable_deref_trait",
-]
 
 [[package]]
 name = "openssl-probe"
@@ -2033,7 +1840,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2142,9 +1949,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -2169,14 +1976,13 @@ dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "proto_core"
-version = "0.36.3"
+version = "0.39.3"
 dependencies = [
- "cached",
  "indexmap 2.2.6",
  "miette",
  "minisign-verify",
@@ -2185,7 +1991,7 @@ dependencies = [
  "proto_shim",
  "regex",
  "reqwest",
- "rustc-hash",
+ "rustc-hash 2.0.0",
  "schematic",
  "semver",
  "serde",
@@ -2193,9 +1999,8 @@ dependencies = [
  "sha2",
  "shell-words",
  "starbase_archive",
- "starbase_events",
- "starbase_styles 0.4.0",
- "starbase_utils 0.7.5",
+ "starbase_styles",
+ "starbase_utils 0.8.4",
  "thiserror",
  "tracing",
  "url",
@@ -2206,20 +2011,20 @@ dependencies = [
 
 [[package]]
 name = "proto_pdk"
-version = "0.20.0"
+version = "0.22.0"
 dependencies = [
  "extism-pdk",
  "proto_pdk_api",
- "rustc-hash",
+ "rustc-hash 2.0.0",
  "serde",
  "warpgate_pdk",
 ]
 
 [[package]]
 name = "proto_pdk_api"
-version = "0.20.0"
+version = "0.22.0"
 dependencies = [
- "rustc-hash",
+ "rustc-hash 2.0.0",
  "semver",
  "serde",
  "serde_json",
@@ -2231,19 +2036,19 @@ dependencies = [
 
 [[package]]
 name = "proto_pdk_test_utils"
-version = "0.24.1"
+version = "0.26.0"
 dependencies = [
  "proto_core",
  "proto_pdk_api",
  "serde",
  "serde_json",
- "starbase_sandbox 0.6.2",
+ "starbase_sandbox 0.7.1",
  "warpgate",
 ]
 
 [[package]]
 name = "proto_shim"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "command-group",
  "dirs 5.0.1",
@@ -2257,7 +2062,7 @@ dependencies = [
  "proto_pdk",
  "proto_pdk_test_utils",
  "serde",
- "starbase_sandbox 0.5.0",
+ "starbase_sandbox 0.6.2",
  "tokio",
 ]
 
@@ -2268,6 +2073,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ceeeeabace7857413798eb1ffa1e9c905a9946a57d81fb69b4b71c4d8eb3ad"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 1.1.0",
+ "rustls",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddf517c03a109db8100448a4be38d498df8a210a99fe0e1b9eaf39e78c640efe"
+dependencies = [
+ "bytes",
+ "rand",
+ "ring",
+ "rustc-hash 1.1.0",
+ "rustls",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bffec3605b73c6f1754535084a85229fa8a30f86014e6c81aeec4abb68b0285"
+dependencies = [
+ "libc",
+ "once_cell",
+ "socket2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2357,7 +2208,7 @@ checksum = "ad156d539c879b7a24a363a2016d77961786e71f48f2e2fc8302a92abd2429a6"
 dependencies = [
  "hashbrown 0.13.2",
  "log",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "slice-group-by",
  "smallvec",
 ]
@@ -2414,9 +2265,9 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2437,7 +2288,8 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.22.4",
+ "quinn",
+ "rustls",
  "rustls-native-certs",
  "rustls-pemfile",
  "rustls-pki-types",
@@ -2505,6 +2357,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+
+[[package]]
 name = "rustix"
 version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2521,26 +2379,15 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.9"
+version = "0.23.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629648aced5775d558af50b2b4c7b02983a04b312126d45eeead26e7caa498b9"
+checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
 dependencies = [
  "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
-dependencies = [
- "log",
+ "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.4",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -2576,19 +2423,9 @@ checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.7"
+version = "0.102.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
+checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2617,6 +2454,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ccfb12511cdb770157ace92d7dda771e498445b78f9886e8cdbc5140a4eced"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2627,9 +2473,9 @@ dependencies = [
 
 [[package]]
 name = "schematic"
-version = "0.16.4"
+version = "0.16.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a97356d9a387d6963940ab05de6ac9dbee0c3c97090247954c3d4c2ddc5b8d"
+checksum = "39662af6f427584874872ecc0e42888bccd0c42510d32d519c4ac9319f4c52f3"
 dependencies = [
  "garde",
  "indexmap 2.2.6",
@@ -2638,34 +2484,34 @@ dependencies = [
  "schematic_types",
  "serde",
  "serde_path_to_error",
- "starbase_styles 0.4.0",
+ "starbase_styles",
  "thiserror",
- "toml 0.8.14",
+ "toml 0.8.15",
  "tracing",
 ]
 
 [[package]]
 name = "schematic_macros"
-version = "0.16.4"
+version = "0.16.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "906eff11b3963e20f5d33fb6dfc67d84351769917970c0d7ebf86e1782d869b5"
+checksum = "9747db30b2549f7a3d5c5c61e00a4da45d6fe7f4a413594ffc5e598f5ced1330"
 dependencies = [
  "convert_case",
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "schematic_types"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "788660c0972a2aab386e2b4b8bd304e0b21c21751e2722cead28d059597d3dad"
+checksum = "6196a0b23e5b4ee02e3894a937606fc49ccc9211e1650a9bef759062cfff3d58"
 dependencies = [
  "indexmap 2.2.6",
  "serde_json",
- "toml 0.8.14",
+ "toml 0.8.15",
  "url",
 ]
 
@@ -2676,14 +2522,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sct"
-version = "0.7.1"
+name = "sdd"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
+checksum = "177258b64c0faaa9ffd3c65cd3262c2bc7e2588dbbd9c1641d0346145c1bbda8"
 
 [[package]]
 name = "security-framework"
@@ -2719,31 +2561,32 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.203"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.203"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "4ab380d7d9f22ef3f21ad3e6c1ebe8e4fc7a2000ccba2e4d71fc96f15b2cb609"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -2889,61 +2732,21 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "starbase_archive"
-version = "0.7.4"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1159e924d28043b3eb045d9a70e30312a50d31c7271ee0720865a32ba36042bf"
+checksum = "f872d80fef76f04dda2083d5fcd9248f145259bcfb7c8a681f720a850896ad0c"
 dependencies = [
  "binstall-tar",
  "flate2",
  "miette",
- "rustc-hash",
- "starbase_styles 0.4.0",
- "starbase_utils 0.7.5",
+ "rustc-hash 2.0.0",
+ "starbase_styles",
+ "starbase_utils 0.8.4",
  "thiserror",
  "tracing",
  "xz2",
  "zip",
  "zstd",
-]
-
-[[package]]
-name = "starbase_events"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96e6586ad2f10fcbc6d30fe330b7ea88709de3d55db6259a64e309937016b4e"
-dependencies = [
- "async-trait",
- "miette",
- "starbase_macros",
- "tokio",
-]
-
-[[package]]
-name = "starbase_macros"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052d4a67b75ca00709992b99a332679b21d621d3aad441a11d89dc4e1d42bd14"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
-name = "starbase_sandbox"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46eb2113d05c21fea19742d5df590641a44373eaa75c9178e6c8888d9ab31286"
-dependencies = [
- "assert_cmd",
- "assert_fs",
- "clean-path",
- "insta",
- "once_cell",
- "predicates",
- "pretty_assertions",
- "starbase_utils 0.6.1",
 ]
 
 [[package]]
@@ -2963,39 +2766,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "starbase_styles"
-version = "0.3.1"
+name = "starbase_sandbox"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e21769f0b11c591f655f8563217d92f55176f53c6e9224854b1f14801c6cee"
+checksum = "25dd6f9ea85ee2cfea36c1d1dd9454cc1e37cf893ed9eabf1444b40a288482dc"
 dependencies = [
- "dirs 5.0.1",
- "owo-colors",
- "supports-color",
+ "assert_cmd",
+ "assert_fs",
+ "clean-path",
+ "insta",
+ "predicates",
+ "pretty_assertions",
+ "starbase_utils 0.8.4",
 ]
 
 [[package]]
 name = "starbase_styles"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e483937f25c81ee4a5b70b608436025d23bffa656d62793ea5bbe6e9b94206d"
+checksum = "44854a14e28e3b1d602d802576162380504df73efae50d4b901934d25579524b"
 dependencies = [
  "dirs 5.0.1",
  "owo-colors",
  "supports-color",
-]
-
-[[package]]
-name = "starbase_utils"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602b821bd1b020210432bdc5152056defca02dab1f601e86093cb12e842d0fa5"
-dependencies = [
- "dirs 5.0.1",
- "once_cell",
- "relative-path",
- "starbase_styles 0.3.1",
- "thiserror",
- "tracing",
 ]
 
 [[package]]
@@ -3005,18 +2798,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06fac1efba629ebe53fd2363b0af2a7b4f9a2a79540e53b1f0bbdd08c3cb6fbf"
 dependencies = [
  "dirs 5.0.1",
+ "once_cell",
+ "relative-path",
+ "starbase_styles",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "starbase_utils"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "641c9b34e4221ca637c645d0bbbc9935a0e4283b986f5605c20200c70b2d6f55"
+dependencies = [
+ "dirs 5.0.1",
  "fs4",
  "json-strip-comments",
  "miette",
- "once_cell",
- "relative-path",
  "reqwest",
  "serde",
  "serde_json",
- "starbase_styles 0.4.0",
+ "starbase_styles",
  "thiserror",
  "tokio",
- "toml 0.8.14",
+ "toml 0.8.15",
  "tracing",
  "url",
  "wax",
@@ -3062,9 +2867,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.66"
+version = "2.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3073,20 +2878,9 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "synstructure"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "system-configuration"
@@ -3163,22 +2957,22 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -3192,52 +2986,57 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinystr"
-version = "0.7.6"
+name = "tinyvec"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
 dependencies = [
- "displaydoc",
- "zerovec",
+ "tinyvec_macros",
 ]
 
 [[package]]
-name = "tokio"
-version = "1.38.0"
+name = "tinyvec_macros"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "tracing",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.22.4",
+ "rustls",
  "rustls-pki-types",
  "tokio",
 ]
@@ -3267,14 +3066,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.14"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
+checksum = "ac2caab0bf757388c6c0ae23b3293fdb463fee59434529014f85e3263b995c28"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.14",
+ "toml_edit 0.22.16",
 ]
 
 [[package]]
@@ -3299,9 +3098,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.14"
+version = "0.22.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
+checksum = "278f3d518e152219c994ce877758516bca5e118eaed6996192a774fb9fbf0788"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
@@ -3357,7 +3156,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -3412,10 +3211,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -3443,25 +3257,26 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.9.1"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cdd25c339e200129fe4de81451814e5228c9b771d57378817d6117cc2b3f97"
+checksum = "72139d247e5f97a3eff96229a7ae85ead5328a39efe76f8bf5a06313d505b6ea"
 dependencies = [
- "base64 0.21.5",
+ "base64 0.22.1",
  "flate2",
  "log",
  "once_cell",
- "rustls 0.21.9",
- "rustls-webpki 0.101.7",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "url",
  "webpki-roots",
 ]
 
 [[package]]
 name = "url"
-version = "2.5.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c25da092f0a868cdf09e8674cd3b7ef3a7d92a24253e663a2fb85e2496de56"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -3470,22 +3285,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
 name = "uuid"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom",
 ]
@@ -3504,13 +3307,14 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "version_spec"
-version = "0.5.2"
+version = "0.6.1"
 dependencies = [
  "human-sort",
  "regex",
  "schematic",
  "semver",
  "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -3543,33 +3347,35 @@ dependencies = [
 
 [[package]]
 name = "warpgate"
-version = "0.15.0"
+version = "0.16.1"
 dependencies = [
  "extism",
  "miette",
  "once_cell",
- "once_map",
  "regex",
  "reqwest",
+ "scc",
  "schematic",
  "serde",
  "serde_json",
  "sha2",
  "starbase_archive",
- "starbase_styles 0.4.0",
- "starbase_utils 0.7.5",
+ "starbase_styles",
+ "starbase_utils 0.8.4",
  "system_env",
  "thiserror",
+ "tokio",
  "tracing",
+ "ureq",
  "warpgate_api",
 ]
 
 [[package]]
 name = "warpgate_api"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
- "rustc-hash",
+ "rustc-hash 2.0.0",
  "schematic",
  "serde",
  "serde_json",
@@ -3579,7 +3385,7 @@ dependencies = [
 
 [[package]]
 name = "warpgate_pdk"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "extism-pdk",
  "serde",
@@ -3639,7 +3445,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
  "wasm-bindgen-shared",
 ]
 
@@ -3673,7 +3479,7 @@ checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3805,7 +3611,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "sha2",
- "toml 0.8.14",
+ "toml 0.8.15",
  "windows-sys 0.52.0",
  "zstd",
 ]
@@ -3819,7 +3625,7 @@ dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
  "wit-parser",
@@ -3946,7 +3752,7 @@ checksum = "d4cedc5bfef3db2a85522ee38564b47ef3b7fc7c92e94cacbce99808e63cdd47"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -4036,9 +3842,12 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.3"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
+checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "wiggle"
@@ -4066,7 +3875,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "shellexpand",
- "syn 2.0.66",
+ "syn 2.0.72",
  "witx",
 ]
 
@@ -4078,7 +3887,7 @@ checksum = "0b47d2b4442ce93106dba5d1a9c59d5f85b5732878bb3d0598d3c93c0d01b16b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
  "wiggle-generate",
 ]
 
@@ -4406,18 +4215,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
-name = "writeable"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
-
-[[package]]
 name = "xattr"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4444,30 +4241,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
-name = "yoke"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
-dependencies = [
- "serde",
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
- "synstructure",
-]
-
-[[package]]
 name = "zerocopy"
 version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4484,28 +4257,7 @@ checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
-]
-
-[[package]]
-name = "zerofrom"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
- "synstructure",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -4515,32 +4267,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
-name = "zerovec"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2cc8827d6c0994478a15c53f374f46fbd41bea663d809b14744bc42e6b109c"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97cf56601ee5052b4417d90c8755c6683473c926039908196cf35d99f893ebe7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
 name = "zip"
-version = "2.1.3"
+version = "2.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775a2b471036342aa69bc5a602bc889cb0a06cda00477d0c69566757d5553d39"
+checksum = "40dd8c92efc296286ce1fbd16657c5dbefff44f1b4ca01cc5f517d8b7b3d3e2e"
 dependencies = [
  "arbitrary",
  "crc32fast",
@@ -4569,9 +4299,9 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d789b1514203a1120ad2429eae43a7bd32b90976a7bb8a05f7ec02fa88cc23a"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
 dependencies = [
  "zstd-safe",
 ]

--- a/plugins/wasm-test/src/lib.rs
+++ b/plugins/wasm-test/src/lib.rs
@@ -52,6 +52,10 @@ pub fn testing_macros(_: ()) -> FnResult<()> {
     let _ = exec_command!(raw, "git", args);
     let _ = exec_command!(raw, "git", ["a", "b", "c"]);
 
+    // Requests
+    send_request!("https://some/url");
+    send_request!(input, SendRequestInput::new("https://some/url"));
+
     // Env vars
     let name = "VAR";
 

--- a/plugins/wasm-test/src/lib.rs
+++ b/plugins/wasm-test/src/lib.rs
@@ -10,6 +10,7 @@ extern "ExtismHost" {
     fn from_virtual_path(path: String) -> String;
     fn get_env_var(name: String) -> String;
     fn host_log(input: Json<HostLogInput>);
+    fn send_request(input: Json<SendRequestInput>) -> Json<SendRequestOutput>;
     fn set_env_var(name: String, value: String);
     fn to_virtual_path(path: String) -> String;
 }
@@ -205,8 +206,8 @@ struct NodeDistVersion {
 #[plugin_fn]
 pub fn load_versions(Json(_): Json<LoadVersionsInput>) -> FnResult<Json<LoadVersionsOutput>> {
     let mut output = LoadVersionsOutput::default();
-    let response: Vec<NodeDistVersion> =
-        fetch_url_with_cache("https://nodejs.org/dist/index.json")?;
+    let response: Vec<NodeDistVersion> = fetch_json("https://nodejs.org/dist/index.json")?;
+    // fetch_url_with_cache("https://nodejs.org/dist/index.json")?;
 
     for (index, item) in response.iter().enumerate() {
         let version = Version::parse(&item.version[1..])?;

--- a/plugins/wasm-test/src/lib.rs
+++ b/plugins/wasm-test/src/lib.rs
@@ -207,7 +207,6 @@ struct NodeDistVersion {
 pub fn load_versions(Json(_): Json<LoadVersionsInput>) -> FnResult<Json<LoadVersionsOutput>> {
     let mut output = LoadVersionsOutput::default();
     let response: Vec<NodeDistVersion> = fetch_json("https://nodejs.org/dist/index.json")?;
-    // fetch_url_with_cache("https://nodejs.org/dist/index.json")?;
 
     for (index, item) in response.iter().enumerate() {
         let version = Version::parse(&item.version[1..])?;


### PR DESCRIPTION
Requests made from WASM need to use the same HTTP settings (https://moonrepo.dev/docs/proto/config#settingshttp) as the proto binary, which uses reqwest, but WASM uses ureq. 