### PR TITLE
chore: Update nightly.yml to include conditional build job

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,6 +17,7 @@ permissions:
 
 jobs:
   build:
+    if: (github.event_name == 'schedule' && github.repository == 'moonrepo/proto') || (github.event_name != 'schedule')
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Remove useless nightly workflow run in forked repo, if it's pre-destined to error and die, why let it run and alive, tho? It'd better if it never alive.

...and potentially make GitHub and it's parent (Microsoft) go bankrupt within 999,999,999 Millenia :)

(What a happy day I finally became a contributor to this Rust repo, Yeay!)