### PR TITLE
fix: canary is not reinstalled unless install --force is used. #(618)

### DIFF
--- a/crates/cli/src/commands/install.rs
+++ b/crates/cli/src/commands/install.rs
@@ -40,6 +40,12 @@ pub struct InstallArgs {
 
     #[arg(
         long,
+        help = "Force reinstallation of tool even if it is already installed"
+    )]
+    pub force: bool,
+
+    #[arg(
+        long,
         help = "When installing one, pin the resolved version to .prototools"
     )]
     pub pin: Option<Option<PinOption>>,
@@ -220,8 +226,8 @@ pub async fn do_install(
 
     let resolved_version = tool.get_resolved_version();
 
-    // Check if already installed, or if canary, overwrite previous install
-    if !version.is_canary() && tool.is_setup(&version).await? {
+    // Check if already installed, or if forced, overwrite previous install
+    if !args.force && tool.is_setup(&version).await? {
         pin_version(tool, &version, &pin_type).await?;
         finish_pb(false, &resolved_version);
 
@@ -310,6 +316,7 @@ pub async fn do_install(
             InstallOptions {
                 on_download_chunk: Some(on_download_chunk),
                 on_phase_change: Some(on_phase_change),
+                force: args.force,
                 ..InstallOptions::default()
             },
         )

--- a/crates/cli/tests/install_uninstall_test.rs
+++ b/crates/cli/tests/install_uninstall_test.rs
@@ -104,7 +104,11 @@ mod install_uninstall {
     fn install_and_reinstall_canary_tool() {
         let sandbox = create_empty_proto_sandbox();
         let tool_dir = sandbox.path().join(".proto/tools/node/canary");
-        let tool_bin = sandbox.path().join(".proto/tools/node/canary/bin/node");
+        let tool_bin = if cfg!(windows) {
+            sandbox.path().join(".proto/tools/node/canary/node.exe")
+        } else {
+            sandbox.path().join(".proto/tools/node/canary/bin/node")
+        };
 
         assert!(!tool_dir.exists());
         assert!(!tool_bin.exists());


### PR DESCRIPTION
This PR is a proposal to fix #618 