### PR TITLE
deps: Update schema tool version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@
 - [Rust](https://github.com/moonrepo/plugins/blob/master/tools/rust/CHANGELOG.md)
 - [Schema (TOML, JSON, YAML)](https://github.com/moonrepo/plugins/blob/master/tools/internal-schema/CHANGELOG.md)
 
+## Unreleased
+
+#### 🧩 Plugins
+
+- Updated `schema_tool` to v0.16.4.
+  - Added additional `version` tokens to TOML, JSON, and YAML plugins.
+
 ## 0.45.1
 
 #### 🐞 Fixes

--- a/crates/core/src/proto_config.rs
+++ b/crates/core/src/proto_config.rs
@@ -412,7 +412,7 @@ impl ProtoConfig {
             self.plugins.insert(
                 Id::raw(SCHEMA_PLUGIN_KEY),
                 PluginLocator::Url(Box::new(UrlLocator {
-                    url: "https://github.com/moonrepo/plugins/releases/download/schema_tool-v0.16.3/schema_tool.wasm".into()
+                    url: "https://github.com/moonrepo/plugins/releases/download/schema_tool-v0.16.4/schema_tool.wasm".into()
                 }))
             );
         }


### PR DESCRIPTION
See moonrepo/proto#711

This is dependant on moonrepo/plugins#34 first being released, and assumes the released version of `schema_tool` is `0.16.4`. If this changes, this PR also needs updated.

*I have assumed this will be released as 0.45.2 when bumping the version - if not then this will affect moonrepo/moon#1820*