### PR TITLE
build: fix compilation on ARM Linux

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,6 +3,3 @@ codegen-units = 1
 lto = true
 panic = "abort"
 strip = "debuginfo"
-
-[target.aarch64-unknown-linux-gnu]
-linker = "aarch64-linux-gnu-gcc"


### PR DESCRIPTION
The configuration only applies correctly for cross builds, I think.

Fixes #747