### PR TITLE
fix: replace `kubectl` plugin

### DIFF
--- a/registry/data/third-party.json
+++ b/registry/data/third-party.json
@@ -273,12 +273,12 @@
     {
       "id": "dotenvx",
       "locator": "https://gist.githubusercontent.com/alexbepple/9740643dbe1b2d423490b1fee21af807/raw/e2d85b647da191d339dfbf3e3e1cefb21616e7c7/dotenvx.toml",
-      "repositoryUrl": "https://gist.github.com/alexbepple/9740643dbe1b2d423490b1fee21af807",
       "format": "toml",
-      "author": "alexbepple",
       "name": "dotenvx",
-      "homepageUrl": "https://dotenvx.com/",
       "description": "Inject your env at runtime. A better dotenv – from the creator of dotenv.",
+      "author": "alexbepple",
+      "homepageUrl": "https://dotenvx.com/",
+      "repositoryUrl": "https://gist.github.com/alexbepple/9740643dbe1b2d423490b1fee21af807",
       "bins": [
         "dotenvx"
       ]
@@ -672,13 +672,13 @@
     },
     {
       "id": "kubectl",
-      "locator": "https://raw.githubusercontent.com/stk0vrfl0w/proto-toml-plugins/main/plugins/kubectl.toml",
+      "locator": "https://raw.githubusercontent.com/trillion-labs/proto-plugins/refs/heads/main/kubectl.toml",
       "format": "toml",
       "name": "kubectl",
       "description": "Kubernetes command line tool.",
-      "author": "stk0vrfl0w",
+      "author": "Trillion Labs",
       "homepageUrl": "https://kubernetes.io/",
-      "repositoryUrl": "https://github.com/stk0vrfl0w/proto-toml-plugins/blob/main/plugins/kubectl.toml",
+      "repositoryUrl": "https://github.com/trillion-labs/proto-plugins",
       "devicon": "kubernetes",
       "bins": [
         "kubectl"


### PR DESCRIPTION
Current `kubectl` plugin doesn't work since it uses old URL (storage.googleapis.com), which is [deprecated](https://github.com/kubernetes/k8s.io/issues/2396).

This commit replaces the `kubectl` plugin that uses new URL (dl.k8s.io) instead.