### PR TITLE
fix: run_global_tool

### DIFF
--- a/crates/cli/tests/run_test.rs
+++ b/crates/cli/tests/run_test.rs
@@ -48,15 +48,29 @@ mod run {
     fn errors_if_no_version_detected() {
         let sandbox = create_empty_proto_sandbox();
 
+        // Note that moon must not be installed in the system without proto for this test to pass.
         let assert = sandbox
             .run_bin(|cmd| {
-                cmd.arg("run").arg("node");
+                cmd.arg("run").arg("moon");
             })
             .failure();
 
         assert.stderr(predicate::str::contains(
             "Failed to detect an applicable version",
         ));
+    }
+
+    #[test]
+    fn runs_tool_from_path_if_proto_fails() {
+        let sandbox = create_empty_proto_sandbox();
+
+        // Note that node must be installed in the system without proto for this test to pass.
+        // In github CI task runners this is usually the case.
+        sandbox
+            .run_bin(|cmd| {
+                cmd.arg("run").arg("node").arg("--version");
+            })
+            .success();
     }
 
     #[test]


### PR DESCRIPTION
Addresses issue in: https://github.com/moonrepo/proto/issues/785

It seems that `run_global_tool` was not correctly catching the case a left over shim from some project was present, but there was no globally pinned version. When the user attempted to run the native binary proto would automatically detect that the plugin was one of the built in ones and run through the regular process likely to provide the auto install option. I updated `locate_tool` to ignore the built-in plugins check if it detects that it is running from a shim since a shim should imply that the user should have a pinned version in one of the config files.