### PR TITLE
refactor: Replace debug function with macro for improved logging and bin size

### DIFF
--- a/crates/cli/src/main_shim.rs
+++ b/crates/cli/src/main_shim.rs
@@ -16,17 +16,19 @@ static DEBUG: OnceLock<bool> = OnceLock::new();
 // We don't want to pull the entire `tracing` or `log` crates
 // into this binary, as we want it to be super lean. So we have
 // this very rudimentary logging system.
-fn debug(op: impl FnOnce() -> String) {
-    if *DEBUG.get_or_init(|| env::var("PROTO_DEBUG_SHIM").is_ok()) {
-        println!("{}", op());
-    }
+macro_rules! debug {
+    ($($arg:tt)*) => {
+        if *DEBUG.get_or_init(|| env::var("PROTO_DEBUG_SHIM").is_ok()) {
+            println!($($arg)*);
+        }
+    };
 }
 
 fn get_proto_home() -> Result<PathBuf> {
-    debug(|| "Determining proto home direcory".into());
+    debug!("Determining proto home direcory");
 
     if let Ok(root) = env::var("PROTO_HOME") {
-        debug(|| format!("Found in `PROTO_HOME` environment variable: {root}"));
+        debug!("Found in `PROTO_HOME` environment variable: {}", root);
 
         return Ok(root.into());
     }
@@ -34,7 +36,7 @@ fn get_proto_home() -> Result<PathBuf> {
     if let Ok(root) = env::var("XDG_DATA_HOME") {
         let xdg_dir = PathBuf::from(root).join("proto");
 
-        debug(|| format!("Found in `XDG_DATA_HOME` environment variable: {xdg_dir:?}"));
+        debug!("Found in `XDG_DATA_HOME` environment variable: {:?}", xdg_dir);
 
         return Ok(xdg_dir);
     }
@@ -44,7 +46,7 @@ fn get_proto_home() -> Result<PathBuf> {
         .ok_or_else(|| anyhow!("Unable to determine user home directory."))?
         .join(".proto");
 
-    debug(|| format!("Using system home directory: {home_dir:?}"));
+    debug!("Using system home directory: {:?}", home_dir);
 
     Ok(home_dir)
 }
@@ -56,24 +58,24 @@ fn create_command(args: Vec<OsString>, shim_name: &str) -> Result<Command> {
 
     // Load the shims registry if it exists
     if registry_path.exists() {
-        debug(|| format!("Loading shim registry config: {registry_path:?}"));
+        debug!("Loading shim registry config: {:?}", registry_path);
 
         let file = fs::read_to_string(registry_path)?;
         let mut registry = json_parse(&file).unwrap_or(Json::Null);
 
-        debug(|| format!("Loaded: {file}"));
-        debug(|| format!("Extracting {shim_name} config"));
+        debug!("Loaded: {}", file);
+        debug!("Extracting {} config", shim_name);
 
         if let Json::Object(shims) = &mut registry {
             if let Some(shim_entry) = shims.remove(shim_name) {
                 if shim_entry.is_object() {
                     shim = shim_entry;
-                    debug(|| "Extracted".into());
+                    debug!("Extracted");
                 } else {
-                    debug(|| "Not extracted, config is not an object".into());
+                    debug!("Not extracted, config is not an object");
                 }
             } else {
-                debug(|| "Not extracted, key does not exist".into());
+                debug!("Not extracted, key does not exist");
             }
         }
     }
@@ -82,7 +84,7 @@ fn create_command(args: Vec<OsString>, shim_name: &str) -> Result<Command> {
     let mut passthrough_args = vec![];
 
     if let Json::Array(before_args) = &shim["before_args"] {
-        debug(|| "Inheriting config `before_args`".into());
+        debug!("Inheriting config `before_args`");
 
         for arg in before_args {
             if let Json::Str(arg) = arg {
@@ -92,7 +94,7 @@ fn create_command(args: Vec<OsString>, shim_name: &str) -> Result<Command> {
     }
 
     if args.len() > 1 {
-        debug(|| "Inheriting args passed on the command line".into());
+        debug!("Inheriting args passed on the command line");
 
         for (i, arg) in args.into_iter().enumerate() {
             if i == 0 {
@@ -104,7 +106,7 @@ fn create_command(args: Vec<OsString>, shim_name: &str) -> Result<Command> {
     }
 
     if let Json::Array(after_args) = &shim["after_args"] {
-        debug(|| "Inheriting config `after_args`".into());
+        debug!("Inheriting config `after_args`");
 
         for arg in after_args {
             if let Json::Str(arg) = arg {
@@ -116,7 +118,7 @@ fn create_command(args: Vec<OsString>, shim_name: &str) -> Result<Command> {
     // Create the command and handle alternate logic
     let proto_bin = locate_proto_exe("proto").unwrap_or_else(|| "proto".into());
 
-    debug(|| format!("Locating proto binary: {proto_bin:?}"));
+    debug!("Locating proto binary: {:?}", proto_bin);
 
     let mut command = Command::new(proto_bin);
 
@@ -125,32 +127,32 @@ fn create_command(args: Vec<OsString>, shim_name: &str) -> Result<Command> {
     // command.arg("--version");
 
     if let Json::Str(parent_name) = &shim["parent"] {
-        debug(|| "Inheriting config `parent`".into());
-        debug(|| format!("Running parent tool {parent_name}"));
+        debug!("Inheriting config `parent`");
+        debug!("Running parent tool {}", parent_name);
 
         command.args(["run", parent_name]);
 
         if matches!(shim["alt_bin"], Json::Bool(true)) {
-            debug(|| "Inheriting config `alt_bin`".into());
-            debug(|| format!("Running tool alternate {shim_name}"));
+            debug!("Inheriting config `alt_bin`");
+            debug!("Running tool alternate {}", shim_name);
 
             command.args(["--alt", shim_name]);
         }
     } else {
-        debug(|| format!("Running tool {shim_name}"));
+        debug!("Running tool {}", shim_name);
 
         command.args(["run", shim_name]);
     }
 
     if !passthrough_args.is_empty() {
-        debug(|| format!("Passing through arguments: {passthrough_args:?}"));
+        debug!("Passing through arguments: {:?}", passthrough_args);
 
         command.arg("--");
         command.args(passthrough_args);
     }
 
     if let Json::Object(env_vars) = &shim["env_vars"] {
-        debug(|| "Inheriting config `env_vars`".into());
+        debug!("Inheriting config `env_vars`");
 
         for (env, value) in env_vars {
             if let Json::Str(var) = value {
@@ -159,7 +161,7 @@ fn create_command(args: Vec<OsString>, shim_name: &str) -> Result<Command> {
         }
     }
 
-    debug(|| "Created proto command".into());
+    debug!("Created proto command");
 
     Ok(command)
 }
@@ -167,16 +169,16 @@ fn create_command(args: Vec<OsString>, shim_name: &str) -> Result<Command> {
 pub fn main() -> Result<()> {
     sigpipe::reset();
 
-    debug(|| "Running proto shim".into());
+    debug!("Running proto shim");
 
     // Extract arguments to pass-through
     let args = env::args_os().collect::<Vec<_>>();
 
-    debug(|| format!("Extracting arguments: {args:?}"));
+    debug!("Extracting arguments: {:?}", args);
 
     let exe_path = env::current_exe().unwrap_or_else(|_| PathBuf::from(&args[0]));
 
-    debug(|| format!("Extracting current executable: {exe_path:?}"));
+    debug!("Extracting current executable: {:?}", exe_path);
 
     // Extract the tool from the shim's file name
     let shim_name = exe_path
@@ -186,7 +188,7 @@ pub fn main() -> Result<()> {
         .to_lowercase()
         .replace(".exe", "");
 
-    debug(|| format!("Determining tool from shim name: {shim_name}"));
+    debug!("Determining tool from shim name: {}", shim_name);
 
     if shim_name.is_empty() || shim_name.contains("proto-shim") {
         return Err(anyhow!(
@@ -195,14 +197,14 @@ pub fn main() -> Result<()> {
     }
 
     // Create and execute the command
-    debug(|| "Creating proto command with arguments".into());
+    debug!("Creating proto command with arguments");
 
     let mut command = create_command(args, &shim_name)?;
     command.env("PROTO_SHIM_NAME", shim_name);
     command.env("PROTO_SHIM_PATH", exe_path);
 
-    debug(|| "Executing proto command".into());
-    debug(|| "This will replace the current process and stop debugging!".into());
+    debug!("Executing proto command");
+    debug!("This will replace the current process and stop debugging!");
 
     // Must be the last line!
     Ok(exec_command_and_replace(command)?)

--- a/crates/cli/src/main_shim.rs
+++ b/crates/cli/src/main_shim.rs
@@ -28,7 +28,7 @@ fn get_proto_home() -> Result<PathBuf> {
     debug!("Determining proto home direcory");
 
     if let Ok(root) = env::var("PROTO_HOME") {
-        debug!("Found in `PROTO_HOME` environment variable: {}", root);
+        debug!("Found in `PROTO_HOME` environment variable: {root}");
 
         return Ok(root.into());
     }
@@ -36,7 +36,7 @@ fn get_proto_home() -> Result<PathBuf> {
     if let Ok(root) = env::var("XDG_DATA_HOME") {
         let xdg_dir = PathBuf::from(root).join("proto");
 
-        debug!("Found in `XDG_DATA_HOME` environment variable: {:?}", xdg_dir);
+        debug!("Found in `XDG_DATA_HOME` environment variable: {xdg_dir:?}");
 
         return Ok(xdg_dir);
     }
@@ -46,7 +46,7 @@ fn get_proto_home() -> Result<PathBuf> {
         .ok_or_else(|| anyhow!("Unable to determine user home directory."))?
         .join(".proto");
 
-    debug!("Using system home directory: {:?}", home_dir);
+    debug!("Using system home directory: {home_dir:?}");
 
     Ok(home_dir)
 }
@@ -58,13 +58,13 @@ fn create_command(args: Vec<OsString>, shim_name: &str) -> Result<Command> {
 
     // Load the shims registry if it exists
     if registry_path.exists() {
-        debug!("Loading shim registry config: {:?}", registry_path);
+        debug!("Loading shim registry config: {registry_path:?}");
 
         let file = fs::read_to_string(registry_path)?;
         let mut registry = json_parse(&file).unwrap_or(Json::Null);
 
-        debug!("Loaded: {}", file);
-        debug!("Extracting {} config", shim_name);
+        debug!("Loaded: {file}");
+        debug!("Extracting {shim_name} config");
 
         if let Json::Object(shims) = &mut registry {
             if let Some(shim_entry) = shims.remove(shim_name) {
@@ -118,7 +118,7 @@ fn create_command(args: Vec<OsString>, shim_name: &str) -> Result<Command> {
     // Create the command and handle alternate logic
     let proto_bin = locate_proto_exe("proto").unwrap_or_else(|| "proto".into());
 
-    debug!("Locating proto binary: {:?}", proto_bin);
+    debug!("Locating proto binary: {proto_bin:?}");
 
     let mut command = Command::new(proto_bin);
 
@@ -128,24 +128,24 @@ fn create_command(args: Vec<OsString>, shim_name: &str) -> Result<Command> {
 
     if let Json::Str(parent_name) = &shim["parent"] {
         debug!("Inheriting config `parent`");
-        debug!("Running parent tool {}", parent_name);
+        debug!("Running parent tool {parent_name}");
 
         command.args(["run", parent_name]);
 
         if matches!(shim["alt_bin"], Json::Bool(true)) {
             debug!("Inheriting config `alt_bin`");
-            debug!("Running tool alternate {}", shim_name);
+            debug!("Running tool alternate {shim_name}");
 
             command.args(["--alt", shim_name]);
         }
     } else {
-        debug!("Running tool {}", shim_name);
+        debug!("Running tool {shim_name}");
 
         command.args(["run", shim_name]);
     }
 
     if !passthrough_args.is_empty() {
-        debug!("Passing through arguments: {:?}", passthrough_args);
+        debug!("Passing through arguments: {passthrough_args:?}");
 
         command.arg("--");
         command.args(passthrough_args);
@@ -174,11 +174,11 @@ pub fn main() -> Result<()> {
     // Extract arguments to pass-through
     let args = env::args_os().collect::<Vec<_>>();
 
-    debug!("Extracting arguments: {:?}", args);
+    debug!("Extracting arguments: {args:?}");
 
     let exe_path = env::current_exe().unwrap_or_else(|_| PathBuf::from(&args[0]));
 
-    debug!("Extracting current executable: {:?}", exe_path);
+    debug!("Extracting current executable: {exe_path:?}");
 
     // Extract the tool from the shim's file name
     let shim_name = exe_path
@@ -188,7 +188,7 @@ pub fn main() -> Result<()> {
         .to_lowercase()
         .replace(".exe", "");
 
-    debug!("Determining tool from shim name: {}", shim_name);
+    debug!("Determining tool from shim name: {shim_name}");
 
     if shim_name.is_empty() || shim_name.contains("proto-shim") {
         return Err(anyhow!(


### PR DESCRIPTION
This pull request refactors the logging mechanism in `crates/cli/src/main_shim.rs` by replacing the `debug` function with a `debug!` macro.

### Refactor of Logging Mechanism:

* **Introduction of `debug!` macro**: The `debug` function has been replaced with a macro to streamline logging calls and eliminate the need for closures. This change enhances performance, improves code readability, and reduces the binary size 😃.

### Binary Size Comparison:

-  Simply run `cargo build --bin proto-shim --release` and check the size. The macro version is even smaller:
```sh
➜  proto git:(op/shim-min-size) wc -c target/release/proto-shim target/release/proto-shim-origin 
  487,872 target/release/proto-shim
  487,920 target/release/proto-shim-origin
```
Surprisingly, both are smaller than the actual 564K released on GitHub.

After checking the release workflow, the difference is due to the cargo-dist configuration:
```
[profile.dist]
inherits = "release"
lto = "thin"
```
The local configuration is:
```
[profile.release]
codegen-units = 1
lto = true
panic = "abort"
strip = "debuginfo"
```
After temporarily synchronizing the `lto = "thin"` configuration and re-comparing, the macro version remains smaller:
```
➜  proto git:(master) ✗ wc -c target/release/proto-shim-thin-origin-fn target/release/proto-shim-thin-macro 
  560,160 target/release/proto-shim-thin-origin-fn
  543,648 target/release/proto-shim-thin-macro
```