### PR TITLE
refactor: Use enum to unify function string literals.

### DIFF
--- a/crates/cli/src/commands/install.rs
+++ b/crates/cli/src/commands/install.rs
@@ -7,7 +7,7 @@ use crate::workflows::{InstallOutcome, InstallWorkflowManager, InstallWorkflowPa
 use clap::Args;
 use iocraft::prelude::element;
 use proto_core::{ConfigMode, Id, PinLocation, Tool, ToolSpec};
-use proto_pdk_api::InstallStrategy;
+use proto_pdk_api::{InstallStrategy, PluginFunction};
 use starbase::AppResult;
 use starbase_console::ui::*;
 use starbase_console::utils::formats::format_duration;
@@ -78,7 +78,11 @@ impl InstallArgs {
             info!("Build mode enabled. Only tools that support build from source will install.");
 
             for tool in tools {
-                if tool.plugin.has_func("build_instructions").await {
+                if tool
+                    .plugin
+                    .has_func(PluginFunction::BuildInstructions)
+                    .await
+                {
                     list.push(tool);
                 }
             }
@@ -86,7 +90,7 @@ impl InstallArgs {
             info!("Prebuilt mode enabled. Only tools that support prebuilts will install.");
 
             for tool in tools {
-                if tool.plugin.has_func("download_prebuilt").await {
+                if tool.plugin.has_func(PluginFunction::DownloadPrebuilt).await {
                     list.push(tool);
                 }
             }

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -7,7 +7,7 @@ use proto_core::flow::detect::ProtoDetectError;
 use proto_core::{
     Id, PROTO_PLUGIN_KEY, ProtoConfigEnvOptions, ProtoEnvironment, ProtoLoaderError, Tool, ToolSpec,
 };
-use proto_pdk_api::{ExecutableConfig, RunHook, RunHookResult};
+use proto_pdk_api::{ExecutableConfig, HookFunction, RunHook, RunHookResult};
 use proto_shim::{exec_command_and_replace, locate_proto_exe};
 use starbase::AppResult;
 use starbase_styles::color;
@@ -403,7 +403,7 @@ pub async fn run(session: ProtoSession, args: RunArgs) -> AppResult {
     };
 
     // Run before hook
-    let hook_result = if tool.plugin.has_func("pre_run").await {
+    let hook_result = if tool.plugin.has_func(HookFunction::PreRun).await {
         let globals_dir = tool.locate_globals_dir().await?;
         let globals_prefix = tool.locate_globals_prefix().await?;
 
@@ -414,7 +414,7 @@ pub async fn run(session: ProtoSession, args: RunArgs) -> AppResult {
 
         tool.plugin
             .call_func_with(
-                "pre_run",
+                HookFunction::PreRun,
                 RunHook {
                     context: tool.create_context(),
                     globals_dir: globals_dir.map(|dir| tool.to_virtual_path(&dir)),

--- a/crates/core/src/flow/detect.rs
+++ b/crates/core/src/flow/detect.rs
@@ -172,15 +172,19 @@ impl Tool {
         &self,
         current_dir: &Path,
     ) -> Result<Option<(UnresolvedVersionSpec, PathBuf)>, ProtoDetectError> {
-        if !self.plugin.has_func("detect_version_files").await {
+        if !self
+            .plugin
+            .has_func(PluginFunction::DetectVersionFiles)
+            .await
+        {
             return Ok(None);
         }
 
-        let has_parser = self.plugin.has_func("parse_version_file").await;
+        let has_parser = self.plugin.has_func(PluginFunction::ParseVersionFile).await;
         let output: DetectVersionOutput = self
             .plugin
             .cache_func_with(
-                "detect_version_files",
+                PluginFunction::DetectVersionFiles,
                 DetectVersionInput {
                     context: self.create_unresolved_context(),
                 },
@@ -217,7 +221,7 @@ impl Tool {
                 let output: ParseVersionFileOutput = self
                     .plugin
                     .call_func_with(
-                        "parse_version_file",
+                        PluginFunction::ParseVersionFile,
                         ParseVersionFileInput {
                             content,
                             context: self.create_unresolved_context(),

--- a/crates/core/src/flow/install.rs
+++ b/crates/core/src/flow/install.rs
@@ -79,11 +79,11 @@ impl Tool {
         let verified;
 
         // Allow plugin to provide their own checksum verification method
-        if self.plugin.has_func("verify_checksum").await {
+        if self.plugin.has_func(PluginFunction::VerifyChecksum).await {
             let output: VerifyChecksumOutput = self
                 .plugin
                 .call_func_with(
-                    "verify_checksum",
+                    PluginFunction::VerifyChecksum,
                     VerifyChecksumInput {
                         checksum_file: self.to_virtual_path(checksum_file),
                         download_file: self.to_virtual_path(download_file),
@@ -129,7 +129,11 @@ impl Tool {
             "Installing tool by building from source"
         );
 
-        if !self.plugin.has_func("build_instructions").await {
+        if !self
+            .plugin
+            .has_func(PluginFunction::BuildInstructions)
+            .await
+        {
             return Err(ProtoInstallError::UnsupportedBuildFromSource {
                 tool: self.get_name().to_owned(),
             });
@@ -138,7 +142,7 @@ impl Tool {
         let output: BuildInstructionsOutput = self
             .plugin
             .cache_func_with(
-                "build_instructions",
+                PluginFunction::BuildInstructions,
                 BuildInstructionsInput {
                     context: self.create_context(),
                     install_dir: self.to_virtual_path(install_dir),
@@ -233,7 +237,7 @@ impl Tool {
             "Installing tool by downloading a pre-built archive"
         );
 
-        if !self.plugin.has_func("download_prebuilt").await {
+        if !self.plugin.has_func(PluginFunction::DownloadPrebuilt).await {
             return Err(ProtoInstallError::UnsupportedDownloadPrebuilt {
                 tool: self.get_name().to_owned(),
             });
@@ -245,7 +249,7 @@ impl Tool {
         let output: DownloadPrebuiltOutput = self
             .plugin
             .cache_func_with(
-                "download_prebuilt",
+                PluginFunction::DownloadPrebuilt,
                 DownloadPrebuiltInput {
                     context: self.create_context(),
                     install_dir: self.to_virtual_path(install_dir),
@@ -358,7 +362,7 @@ impl Tool {
             "Attempting to unpack archive",
         );
 
-        if self.plugin.has_func("unpack_archive").await {
+        if self.plugin.has_func(PluginFunction::UnpackArchive).await {
             options.on_phase_change.as_ref().inspect(|func| {
                 func(InstallPhase::Unpack {
                     file: download_filename.clone(),
@@ -367,7 +371,7 @@ impl Tool {
 
             self.plugin
                 .call_func_without_output(
-                    "unpack_archive",
+                    PluginFunction::UnpackArchive,
                     UnpackArchiveInput {
                         input_file: self.to_virtual_path(&download_file),
                         output_dir: self.to_virtual_path(install_dir),
@@ -437,7 +441,7 @@ impl Tool {
 
         // If this function is defined, it acts like an escape hatch and
         // takes precedence over all other install strategies
-        if self.plugin.has_func("native_install").await {
+        if self.plugin.has_func(PluginFunction::NativeInstall).await {
             debug!(tool = self.id.as_str(), "Installing tool natively");
 
             options.on_phase_change.as_ref().inspect(|func| {
@@ -449,7 +453,7 @@ impl Tool {
             let output: NativeInstallOutput = self
                 .plugin
                 .call_func_with(
-                    "native_install",
+                    PluginFunction::NativeInstall,
                     NativeInstallInput {
                         context: self.create_context(),
                         install_dir: self.to_virtual_path(&install_dir),
@@ -532,13 +536,13 @@ impl Tool {
             return Ok(false);
         }
 
-        if self.plugin.has_func("native_uninstall").await {
+        if self.plugin.has_func(PluginFunction::NativeUninstall).await {
             debug!(tool = self.id.as_str(), "Uninstalling tool natively");
 
             let output: NativeUninstallOutput = self
                 .plugin
                 .call_func_with(
-                    "native_uninstall",
+                    PluginFunction::NativeUninstall,
                     NativeUninstallInput {
                         context: self.create_context(),
                         uninstall_dir: self.to_virtual_path(&install_dir),

--- a/crates/core/src/flow/locate.rs
+++ b/crates/core/src/flow/locate.rs
@@ -2,7 +2,9 @@ pub use super::locate_error::ProtoLocateError;
 use crate::helpers::{ENV_VAR, normalize_path_separators};
 use crate::layout::BinManager;
 use crate::tool::Tool;
-use proto_pdk_api::{ExecutableConfig, LocateExecutablesInput, LocateExecutablesOutput};
+use proto_pdk_api::{
+    ExecutableConfig, LocateExecutablesInput, LocateExecutablesOutput, PluginFunction,
+};
 use proto_shim::{get_exe_file_name, get_shim_file_name};
 use serde::Serialize;
 use starbase_utils::fs;
@@ -31,7 +33,7 @@ impl Tool {
         Ok(self
             .plugin
             .cache_func_with(
-                "locate_executables",
+                PluginFunction::LocateExecutables,
                 LocateExecutablesInput {
                     context: self.create_context(),
                     install_dir: self.to_virtual_path(self.get_product_dir()),
@@ -140,7 +142,7 @@ impl Tool {
             let output: LocateExecutablesOutput = self
                 .plugin
                 .cache_func_with(
-                    "locate_executables",
+                    PluginFunction::LocateExecutables,
                     LocateExecutablesInput {
                         context: self.create_context(),
                         install_dir: self.to_virtual_path(self.get_product_dir()),
@@ -270,7 +272,12 @@ impl Tool {
     /// Locate the directory that local executables are installed to.
     #[instrument(skip_all)]
     pub async fn locate_exes_dirs(&mut self) -> Result<Vec<PathBuf>, ProtoLocateError> {
-        if self.exes_dirs.is_empty() && self.plugin.has_func("locate_executables").await {
+        if self.exes_dirs.is_empty()
+            && self
+                .plugin
+                .has_func(PluginFunction::LocateExecutables)
+                .await
+        {
             let output = self.call_locate_executables().await?;
 
             #[allow(deprecated)]
@@ -350,7 +357,11 @@ impl Tool {
             return Ok(self.globals_dirs.clone());
         }
 
-        if !self.plugin.has_func("locate_executables").await {
+        if !self
+            .plugin
+            .has_func(PluginFunction::LocateExecutables)
+            .await
+        {
             return Ok(vec![]);
         }
 
@@ -430,7 +441,11 @@ impl Tool {
     #[instrument(skip_all)]
     pub async fn locate_globals_prefix(&mut self) -> Result<Option<String>, ProtoLocateError> {
         if self.globals_prefix.is_none() {
-            if !self.plugin.has_func("locate_executables").await {
+            if !self
+                .plugin
+                .has_func(PluginFunction::LocateExecutables)
+                .await
+            {
                 return Ok(None);
             }
 

--- a/crates/core/src/flow/resolve.rs
+++ b/crates/core/src/flow/resolve.rs
@@ -40,7 +40,7 @@ impl Tool {
                 versions = self
                     .plugin
                     .cache_func_with(
-                        "load_versions",
+                        PluginFunction::LoadVersions,
                         LoadVersionsInput {
                             context: self.create_unresolved_context(),
                             initial: initial_version.to_owned(),
@@ -71,7 +71,7 @@ impl Tool {
     /// Register the backend by acquiring necessary source files.
     #[instrument(skip_all)]
     pub async fn register_backend(&mut self) -> Result<(), ProtoResolveError> {
-        if !self.plugin.has_func("register_backend").await || self.backend_registered {
+        if !self.plugin.has_func(PluginFunction::RegisterBackend).await || self.backend_registered {
             return Ok(());
         }
 
@@ -82,7 +82,7 @@ impl Tool {
         let metadata: RegisterBackendOutput = self
             .plugin
             .cache_func_with(
-                "register_backend",
+                PluginFunction::RegisterBackend,
                 RegisterBackendInput {
                     context: self.create_unresolved_context(),
                     id: self.id.to_string(),
@@ -280,11 +280,11 @@ impl Tool {
             })
         };
 
-        if self.plugin.has_func("resolve_version").await {
+        if self.plugin.has_func(PluginFunction::ResolveVersion).await {
             let output: ResolveVersionOutput = self
                 .plugin
                 .call_func_with(
-                    "resolve_version",
+                    PluginFunction::ResolveVersion,
                     ResolveVersionInput {
                         context: self.create_unresolved_context(),
                         initial: initial_candidate.to_owned(),

--- a/crates/core/src/flow/setup.rs
+++ b/crates/core/src/flow/setup.rs
@@ -7,7 +7,7 @@ use crate::lockfile::LockRecord;
 use crate::tool::Tool;
 use crate::tool_manifest::ToolManifestVersion;
 use crate::tool_spec::ToolSpec;
-use proto_pdk_api::{SyncManifestInput, SyncManifestOutput};
+use proto_pdk_api::{PluginFunction, SyncManifestInput, SyncManifestOutput};
 use starbase_utils::fs;
 use std::collections::{BTreeMap, BTreeSet};
 use tracing::{debug, instrument};
@@ -224,7 +224,7 @@ impl Tool {
     /// Sync the local tool manifest with changes from the plugin.
     #[instrument(skip_all)]
     pub async fn sync_manifest(&mut self) -> Result<(), ProtoSetupError> {
-        if !self.plugin.has_func("sync_manifest").await {
+        if !self.plugin.has_func(PluginFunction::SyncManifest).await {
             return Ok(());
         }
 
@@ -233,7 +233,7 @@ impl Tool {
         let output: SyncManifestOutput = self
             .plugin
             .call_func_with(
-                "sync_manifest",
+                PluginFunction::SyncManifest,
                 SyncManifestInput {
                     context: self.create_context(),
                 },

--- a/crates/core/src/tool.rs
+++ b/crates/core/src/tool.rs
@@ -180,7 +180,7 @@ impl Tool {
 
     /// Return true if this tool instance is a backend plugin.
     pub async fn is_backend_plugin(&self) -> bool {
-        if self.plugin.has_func("register_backend").await {
+        if self.plugin.has_func(PluginFunction::RegisterBackend).await {
             Backend::variants()
                 .iter()
                 .any(|var| var.to_string() == self.id.as_str())
@@ -242,7 +242,7 @@ impl Tool {
         let metadata: RegisterToolOutput = self
             .plugin
             .cache_func_with(
-                "register_tool",
+                PluginFunction::RegisterTool,
                 RegisterToolInput {
                     id: self.id.to_string(),
                 },

--- a/crates/pdk-api/src/api/mod.rs
+++ b/crates/pdk-api/src/api/mod.rs
@@ -14,6 +14,166 @@ pub use checksum::*;
 pub use semver::{Version, VersionReq};
 pub use source::*;
 
+/// Enumeration of all available plugin functions that can be implemented by plugins.
+///
+/// This enum provides type-safe access to plugin function names and eliminates
+/// the risk of typos when calling plugin functions. Each variant corresponds to
+/// a specific plugin function with its associated input/output types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PluginFunction {
+    /// Register and configure a tool with proto.
+    ///
+    /// Called when proto first loads a plugin to get basic metadata about the tool
+    /// including its name, type, and configuration schema.
+    ///
+    /// **Input:** [`RegisterToolInput`] | **Output:** [`RegisterToolOutput`]
+    RegisterTool,
+
+    /// Register a backend with proto.
+    ///
+    /// Allows plugins to define custom backends for sourcing tools from locations
+    /// other than the default registry.
+    ///
+    /// **Input:** [`RegisterBackendInput`] | **Output:** [`RegisterBackendOutput`]
+    RegisterBackend,
+
+    /// Detect version files in a project.
+    ///
+    /// Returns a list of file patterns that should be checked for version information
+    /// when auto-detecting tool versions.
+    ///
+    /// **Input:** [`DetectVersionInput`] | **Output:** [`DetectVersionOutput`]
+    DetectVersionFiles,
+
+    /// Parse version information from files.
+    ///
+    /// Extracts version specifications from configuration files like `.nvmrc`,
+    /// `package.json`, `pyproject.toml`, etc.
+    ///
+    /// **Input:** [`ParseVersionFileInput`] | **Output:** [`ParseVersionFileOutput`]
+    ParseVersionFile,
+
+    /// Load available versions for a tool.
+    ///
+    /// Fetches the list of available versions that can be installed, including
+    /// version aliases like "latest" or "lts".
+    ///
+    /// **Input:** [`LoadVersionsInput`] | **Output:** [`LoadVersionsOutput`]
+    LoadVersions,
+
+    /// Resolve version specifications to concrete versions.
+    ///
+    /// Takes version requirements or aliases and resolves them to specific
+    /// installable versions.
+    ///
+    /// **Input:** [`ResolveVersionInput`] | **Output:** [`ResolveVersionOutput`]
+    ResolveVersion,
+
+    /// Download prebuilt tool archives.
+    ///
+    /// Provides URLs and metadata for downloading pre-compiled tool binaries
+    /// instead of building from source.
+    ///
+    /// **Input:** [`DownloadPrebuiltInput`] | **Output:** [`DownloadPrebuiltOutput`]
+    DownloadPrebuilt,
+
+    /// Provide build instructions for tools.
+    ///
+    /// Returns the steps needed to build a tool from source, including dependencies,
+    /// build commands, and environment requirements.
+    ///
+    /// **Input:** [`BuildInstructionsInput`] | **Output:** [`BuildInstructionsOutput`]
+    BuildInstructions,
+
+    /// Unpack downloaded archives.
+    ///
+    /// Handles custom unpacking logic for tool archives when the default extraction
+    /// methods are insufficient.
+    ///
+    /// **Input:** [`UnpackArchiveInput`] | **Output:** None
+    UnpackArchive,
+
+    /// Verify download checksums.
+    ///
+    /// Provides custom checksum verification logic for downloaded tool archives
+    /// to ensure integrity.
+    ///
+    /// **Input:** [`VerifyChecksumInput`] | **Output:** [`VerifyChecksumOutput`]
+    VerifyChecksum,
+
+    /// Native tool installation.
+    ///
+    /// Handles tool installation using the tool's own installation methods rather
+    /// than proto's standard process.
+    ///
+    /// **Input:** [`NativeInstallInput`] | **Output:** [`NativeInstallOutput`]
+    NativeInstall,
+
+    /// Native tool uninstallation.
+    ///
+    /// Handles tool removal using the tool's own uninstallation methods rather
+    /// than simple directory deletion.
+    ///
+    /// **Input:** [`NativeUninstallInput`] | **Output:** [`NativeUninstallOutput`]
+    NativeUninstall,
+
+    /// Locate tool executables.
+    ///
+    /// Identifies where executables are located within an installed tool and
+    /// configures them for proto's shim system.
+    ///
+    /// **Input:** [`LocateExecutablesInput`] | **Output:** [`LocateExecutablesOutput`]
+    LocateExecutables,
+
+    /// Sync the tool manifest.
+    ///
+    /// Allows plugins to update proto's inventory of installed versions with
+    /// external changes.
+    ///
+    /// **Input:** [`SyncManifestInput`] | **Output:** [`SyncManifestOutput`]
+    SyncManifest,
+
+    /// Sync shell profile configuration.
+    ///
+    /// Configures shell environment variables and PATH modifications needed for
+    /// the tool to work properly.
+    ///
+    /// **Input:** [`SyncShellProfileInput`] | **Output:** [`SyncShellProfileOutput`]
+    SyncShellProfile,
+}
+
+impl PluginFunction {
+    /// Get the string representation of the plugin function name.
+    ///
+    /// This returns the actual function name that should be used when calling
+    /// the plugin function via WASM.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::RegisterTool => "register_tool",
+            Self::RegisterBackend => "register_backend",
+            Self::DetectVersionFiles => "detect_version_files",
+            Self::ParseVersionFile => "parse_version_file",
+            Self::LoadVersions => "load_versions",
+            Self::ResolveVersion => "resolve_version",
+            Self::DownloadPrebuilt => "download_prebuilt",
+            Self::BuildInstructions => "build_instructions",
+            Self::UnpackArchive => "unpack_archive",
+            Self::VerifyChecksum => "verify_checksum",
+            Self::NativeInstall => "native_install",
+            Self::NativeUninstall => "native_uninstall",
+            Self::LocateExecutables => "locate_executables",
+            Self::SyncManifest => "sync_manifest",
+            Self::SyncShellProfile => "sync_shell_profile",
+        }
+    }
+}
+
+impl AsRef<str> for PluginFunction {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
 pub(crate) fn is_false(value: &bool) -> bool {
     !(*value)
 }

--- a/crates/pdk-api/src/hooks.rs
+++ b/crates/pdk-api/src/hooks.rs
@@ -3,6 +3,57 @@ use rustc_hash::FxHashMap;
 use std::path::PathBuf;
 use warpgate_api::*;
 
+/// Enumeration of all available hook functions that can be implemented by plugins.
+///
+/// Hook functions are called at specific points during proto operations to allow
+/// plugins to customize behavior, perform setup/cleanup, or modify the environment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum HookFunction {
+    /// Pre-install hook.
+    ///
+    /// Called before a tool installation begins, allowing plugins to perform setup
+    /// tasks, validate prerequisites, or modify the installation environment.
+    ///
+    /// **Input:** [`InstallHook`] | **Output:** None
+    PreInstall,
+
+    /// Post-install hook.
+    ///
+    /// Called after a tool installation completes successfully, allowing plugins
+    /// to perform cleanup tasks, configure the tool, or set up additional resources.
+    ///
+    /// **Input:** [`InstallHook`] | **Output:** None
+    PostInstall,
+
+    /// Pre-run hook.
+    ///
+    /// Called before executing a tool binary, allowing plugins to modify environment
+    /// variables, validate runtime conditions, or perform setup.
+    ///
+    /// **Input:** [`RunHook`] | **Output:** [`RunHookResult`]
+    PreRun,
+}
+
+impl HookFunction {
+    /// Get the string representation of the hook function name.
+    ///
+    /// This returns the actual function name that should be used when calling
+    /// the hook function via WASM.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::PreInstall => "pre_install",
+            Self::PostInstall => "post_install",
+            Self::PreRun => "pre_run",
+        }
+    }
+}
+
+impl AsRef<str> for HookFunction {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
 api_struct!(
     /// Input passed to the `pre_install` and `post_install` hooks,
     /// while a `proto install` command is running.

--- a/crates/pdk-test-utils/src/wrapper.rs
+++ b/crates/pdk-test-utils/src/wrapper.rs
@@ -17,7 +17,7 @@ impl WasmTestWrapper {
 
         self.tool
             .plugin
-            .call_func_with("detect_version_files", input)
+            .call_func_with(PluginFunction::DetectVersionFiles, input)
             .await
             .unwrap()
     }
@@ -30,7 +30,7 @@ impl WasmTestWrapper {
 
         self.tool
             .plugin
-            .call_func_with("download_prebuilt", input)
+            .call_func_with(PluginFunction::DownloadPrebuilt, input)
             .await
             .unwrap()
     }
@@ -40,7 +40,7 @@ impl WasmTestWrapper {
 
         self.tool
             .plugin
-            .call_func_with("load_versions", input)
+            .call_func_with(PluginFunction::LoadVersions, input)
             .await
             .unwrap()
     }
@@ -53,7 +53,7 @@ impl WasmTestWrapper {
 
         self.tool
             .plugin
-            .call_func_with("locate_executables", input)
+            .call_func_with(PluginFunction::LocateExecutables, input)
             .await
             .unwrap()
     }
@@ -63,7 +63,7 @@ impl WasmTestWrapper {
 
         self.tool
             .plugin
-            .call_func_with("native_install", input)
+            .call_func_with(PluginFunction::NativeInstall, input)
             .await
             .unwrap()
     }
@@ -73,7 +73,7 @@ impl WasmTestWrapper {
 
         self.tool
             .plugin
-            .call_func_with("native_uninstall", input)
+            .call_func_with(PluginFunction::NativeUninstall, input)
             .await
             .unwrap()
     }
@@ -87,7 +87,7 @@ impl WasmTestWrapper {
 
         self.tool
             .plugin
-            .call_func_with("parse_version_file", input)
+            .call_func_with(PluginFunction::ParseVersionFile, input)
             .await
             .unwrap()
     }
@@ -97,7 +97,7 @@ impl WasmTestWrapper {
 
         self.tool
             .plugin
-            .call_func_without_output("pre_install", input)
+            .call_func_without_output(HookFunction::PreInstall, input)
             .await
             .unwrap();
     }
@@ -107,7 +107,7 @@ impl WasmTestWrapper {
 
         self.tool
             .plugin
-            .call_func_with("pre_run", input)
+            .call_func_with(HookFunction::PreRun, input)
             .await
             .unwrap()
     }
@@ -117,7 +117,7 @@ impl WasmTestWrapper {
 
         self.tool
             .plugin
-            .call_func_without_output("post_install", input)
+            .call_func_without_output(HookFunction::PostInstall, input)
             .await
             .unwrap();
     }
@@ -127,7 +127,7 @@ impl WasmTestWrapper {
 
         self.tool
             .plugin
-            .call_func_with("register_backend", input)
+            .call_func_with(PluginFunction::RegisterBackend, input)
             .await
             .unwrap()
     }
@@ -135,7 +135,7 @@ impl WasmTestWrapper {
     pub async fn register_tool(&self, input: RegisterToolInput) -> RegisterToolOutput {
         self.tool
             .plugin
-            .call_func_with("register_tool", input)
+            .call_func_with(PluginFunction::RegisterTool, input)
             .await
             .unwrap()
     }
@@ -145,7 +145,7 @@ impl WasmTestWrapper {
 
         self.tool
             .plugin
-            .call_func_with("resolve_version", input)
+            .call_func_with(PluginFunction::ResolveVersion, input)
             .await
             .unwrap()
     }
@@ -155,7 +155,7 @@ impl WasmTestWrapper {
 
         self.tool
             .plugin
-            .call_func_with("sync_manifest", input)
+            .call_func_with(PluginFunction::SyncManifest, input)
             .await
             .unwrap()
     }
@@ -168,7 +168,7 @@ impl WasmTestWrapper {
 
         self.tool
             .plugin
-            .call_func_with("sync_shell_profile", input)
+            .call_func_with(PluginFunction::SyncShellProfile, input)
             .await
             .unwrap()
     }
@@ -180,7 +180,7 @@ impl WasmTestWrapper {
         let _: EmptyInput = self
             .tool
             .plugin
-            .call_func_with("unpack_archive", input)
+            .call_func_with(PluginFunction::UnpackArchive, input)
             .await
             .unwrap();
     }
@@ -191,7 +191,7 @@ impl WasmTestWrapper {
 
         self.tool
             .plugin
-            .call_func_with("verify_checksum", input)
+            .call_func_with(PluginFunction::VerifyChecksum, input)
             .await
             .unwrap()
     }


### PR DESCRIPTION
…and add documentation for convenience.

## Problem You Are Trying to Solve

There are many plugin capabilities accessed via `tool.plugin.has_func("xxx")`, but we are hardcoding those function names in various places. This makes it challenging for plugin developers to identify them.

## Description

- Introduce enumeration of all available plugin functions that can be implemented by plugins.
- Enhanced documentation for all plugin function with its associated input/output types.
- Updated hardcoded strings with predefined `PluginFunction` and `HookFunction`

## Screenshot

<img width="1974" height="2116" alt="image" src="https://github.com/user-attachments/assets/053224d2-19a8-4a4c-89e6-29f4de40ce9f" />

