### PR TITLE
Add irb to Ruby registry

### DIFF
--- a/registry/data/built-in.json
+++ b/registry/data/built-in.json
@@ -237,7 +237,8 @@
         "ruby",
         "rake",
         "gem",
-        "bundle"
+        "bundle",
+        "irb"
       ],
       "detectionSources": [
         {


### PR DESCRIPTION
Make proto recognise the `irb` executable so that it gets added to the shims.

Related PR: https://github.com/moonrepo/plugins/pull/92