### PR TITLE
feat: add infisical-cli to plugin registry (supports v0.41.91+)

### DIFF
--- a/registry/data/third-party.json
+++ b/registry/data/third-party.json
@@ -629,6 +629,19 @@
       ]
     },
     {
+      "id": "infisical-cli",
+      "locator": "https://raw.githubusercontent.com/edocli/proto-plugins/main/infisical/plugin.toml",
+      "format": "toml",
+      "name": "Infisical CLI",
+      "description": "The official Infisical CLI: Inject secrets into applications and manage your Infisical infrastructure.",
+      "author": "9:06 PM",
+      "homepageUrl": "https://infisical.com/",
+      "repositoryUrl": "https://github.com/Infisical/cli",
+      "bins": [
+        "infisical"
+      ]
+    },
+    {
       "id": "jira",
       "locator": "https://raw.githubusercontent.com/Phault/proto-toml-plugins/main/jira/plugin.toml",
       "format": "toml",


### PR DESCRIPTION
This PR adds a new plugin entry `infisical-cli`.

### Rationale for new ID (`infisical-cli`)
There is an existing entry for `infisical` in the registry, which points to the older repository structure or distribution method.

The Infisical team has migrated their CLI to a dedicated repository (`Infisical/cli`) starting from version **v0.41.91**. This new plugin is specifically configured to work with this new structure.

I have chosen the ID `infisical-cli` to avoid conflicts with the existing `infisical` plugin and to ensure backward compatibility for users relying on the old configuration.

### Scope
* **Target Repository:** `Infisical/cli`
* **Supported Versions:** v0.41.91 and later.
* **Format:** TOML
