### PR TITLE
feat: add PROTO_TEMP_DIR env var to configure download cache dir

### DIFF
--- a/crates/core/src/helpers.rs
+++ b/crates/core/src/helpers.rs
@@ -80,10 +80,8 @@ pub fn is_archive_file<P: AsRef<Path>>(path: P) -> bool {
     is_supported_archive_extension(path.as_ref())
 }
 
-/// Returns the download cache directory from the `PROTO_DOWNLOAD_CACHE` environment variable.
-/// If the variable is not set or is empty, returns `None`.
-pub fn get_download_cache_dir() -> Option<PathBuf> {
-    envx::path_var("PROTO_DOWNLOAD_CACHE").filter(|p| !p.as_os_str().is_empty())
+pub fn get_temp_dir() -> Option<PathBuf> {
+    envx::path_var("PROTO_TEMP_DIR")
 }
 
 pub fn now() -> u128 {


### PR DESCRIPTION
This allows users to store downloaded archives in a different location from PROTO_HOME, useful for:
- Docker in CI/CD environments

When set, proto uses PROTO_TEMP_DIR instead of PROTO_HOME/temp for downloading and caching tool archives.

Discussed in https://discord.com/channels/974160221452763146/1427187927623925872