### PR TITLE
Add third-party plugin for `geoipupdate`

### DIFF
--- a/registry/data/third-party.json
+++ b/registry/data/third-party.json
@@ -442,6 +442,19 @@
       ]
     },
     {
+      "id": "geoipupdate",
+      "locator": "https://raw.githubusercontent.com/maxmind/geoipupdate/main/proto.yaml",
+      "format": "yaml",
+      "name": "GeoIPUpdate",
+      "description": "Updater for GeoIP2 and GeoLite databases."
+      "author": "maxmind",
+      "homepageUrl": "https://dev.maxmind.com/geoip",
+      "repositoryUrl": "https://github.com/maxmind/geoipupdate",
+      "bins": [
+        "geoipupdate"
+      ],
+    },
+    {
       "id": "gh",
       "locator": "https://raw.githubusercontent.com/appthrust/proto-toml-plugins/main/gh/plugin.toml",
       "format": "toml",


### PR DESCRIPTION
`geoipupdate` is a tool to manage GeoIP2 and GeoLite database caches, which are used to geolocate IP addresses. I added a Proto plugin definition in https://github.com/maxmind/geoipupdate/pull/453, so I'd like to add it to the public tool registry as well.