### PR TITLE
feat(registry): Add git-native-issue plugin

### DIFF
--- a/registry/data/third-party.json
+++ b/registry/data/third-party.json
@@ -482,6 +482,19 @@
       ]
     },
     {
+      "id": "git-issue",
+      "locator": "https://raw.githubusercontent.com/remenoscodes/git-native-issue/main/proto/plugin.toml",
+      "format": "toml",
+      "name": "git-native-issue",
+      "description": "Distributed issue tracking embedded in Git — track issues locally, sync anywhere.",
+      "author": "remenoscodes",
+      "homepageUrl": "https://github.com/remenoscodes/git-native-issue",
+      "repositoryUrl": "https://github.com/remenoscodes/git-native-issue",
+      "bins": [
+        "git-issue"
+      ]
+    },
+    {
       "id": "gitleaks",
       "locator": "https://raw.githubusercontent.com/Phault/proto-toml-plugins/main/gitleaks/plugin.toml",
       "format": "toml",


### PR DESCRIPTION
## Plugin: git-native-issue

**Tool**: [git-native-issue](https://github.com/remenoscodes/git-native-issue) — Distributed issue tracking using Git's native data model
**Plugin**: TOML format, hosted at `proto/plugin.toml` in the repo
**Platforms**: Linux, macOS (POSIX shell scripts)
**Binary**: `git-issue`

Tested locally with `proto install git-issue 1.3.3` — downloads, extracts, and runs correctly.