### PR TITLE
Register claude-code plugin

### DIFF
--- a/registry/data/third-party.json
+++ b/registry/data/third-party.json
@@ -189,6 +189,19 @@
       ]
     },
     {
+      "id": "claude-code",
+      "locator": "github://BarretoTech/proto-claude-code-plugin",
+      "format": "wasm",
+      "name": "Claude Code",
+      "description": "An agentic coding tool that lives in your terminal.",
+      "author": "BarretoTech",
+      "homepageUrl": "https://github.com/anthropics/claude-code",
+      "repositoryUrl": "https://github.com/BarretoTech/proto-claude-code-plugin",
+      "bins": [
+        "claude"
+      ]
+    },
+    {
       "id": "composer",
       "locator": "github://KonstantinKai/proto-composer-plugin",
       "format": "wasm",


### PR DESCRIPTION
## Summary
- Adds [Claude Code](https://github.com/anthropics/claude-code) (Anthropic's agentic coding CLI) as a third-party WASM plugin
- Plugin source: [BarretoTech/proto-claude-code-plugin](https://github.com/BarretoTech/proto-claude-code-plugin)
- Enables installation via `proto install claude-code`, providing the `claude` executable

## Test plan
- [ ] Verify JSON is valid and entry is alphabetically sorted
- [ ] Run `proto plugin search claude` to confirm discoverability after merge