### PR TITLE
Add Archgate CLI plugin to third-party registry

### DIFF
--- a/registry/data/third-party.json
+++ b/registry/data/third-party.json
@@ -44,6 +44,19 @@
       ]
     },
     {
+      "id": "archgate",
+      "locator": "github://archgate/proto-plugin",
+      "format": "wasm",
+      "name": "Archgate",
+      "description": "Enforce Architecture Decision Records as executable rules.",
+      "author": "archgate",
+      "homepageUrl": "https://cli.archgate.dev",
+      "repositoryUrl": "https://github.com/archgate/proto-plugin",
+      "bins": [
+        "archgate"
+      ]
+    },
+    {
       "id": "argo",
       "locator": "https://raw.githubusercontent.com/appthrust/proto-toml-plugins/main/argo/plugin.toml",
       "format": "toml",


### PR DESCRIPTION
## Summary

- Adds [Archgate CLI](https://cli.archgate.dev) to the third-party plugin registry
- Archgate enforces Architecture Decision Records (ADRs) as executable, machine-checkable rules
- WASM plugin hosted at [archgate/proto-plugin](https://github.com/archgate/proto-plugin)
- Supports macOS (arm64), Linux (x64), and Windows (x64)

## Usage

```toml
[plugins]
archgate = "github://archgate/proto-plugin"
```