### PR TITLE
registry: replace archived dotnet WASM plugin with TOML alternative

### DIFF
--- a/registry/data/third-party.json
+++ b/registry/data/third-party.json
@@ -383,14 +383,20 @@
     },
     {
       "id": "dotnet",
-      "locator": "github://Phault/proto-dotnet-plugin",
-      "format": "wasm",
+      "locator": "https://raw.githubusercontent.com/RemiKalbe/proto-dotnet-plugin/main/plugin.toml",
+      "format": "toml",
       "name": ".NET",
       "description": ".NET is the free, open-source, cross-platform framework for building modern apps and powerful cloud services.",
-      "author": "Phault",
+      "author": "RemiKalbe",
       "homepageUrl": "https://dotnet.microsoft.com/",
-      "repositoryUrl": "https://github.com/Phault/proto-dotnet-plugin",
+      "repositoryUrl": "https://github.com/RemiKalbe/proto-dotnet-plugin",
       "devicon": "dot-net",
+      "detectionSources": [
+        {
+          "file": "global.json",
+          "url": "https://learn.microsoft.com/en-us/dotnet/core/tools/global-json"
+        }
+      ],
       "bins": [
         "dotnet"
       ]


### PR DESCRIPTION
## Summary

- Replaces the dotnet registry entry pointing to the archived [Phault/proto-dotnet-plugin](https://github.com/Phault/proto-dotnet-plugin) (WASM) with a working TOML-based plugin at [RemiKalbe/proto-dotnet-plugin](https://github.com/RemiKalbe/proto-dotnet-plugin)
- The old WASM plugin has a bug where it hardcodes `/proto/temp` as an absolute path instead of using the virtual filesystem, causing `zsh: no such file or directory: /proto/temp/dotnet-install.sh` on install. The repo is archived so it can't be fixed.
- The new TOML plugin downloads pre-built SDK archives directly from Microsoft's CDN (`builds.dotnet.microsoft.com`), resolves versions from `dotnet/sdk` git tags, and supports macOS/Linux/Windows on arm64/x64
- Adds `detectionSources` for `global.json`

## Testing

```bash
proto plugin add dotnet "https://raw.githubusercontent.com/RemiKalbe/proto-dotnet-plugin/main/plugin.toml"
proto install dotnet 9.0.205
dotnet --version  # 9.0.205
```

Tested on macOS (Apple Silicon) with .NET 8.0.418, 9.0.205, and 10.0.201.