### PR TITLE
fix: Normalize proto activate paths for emulated POSIX shells on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@
 - [Rust](https://github.com/moonrepo/plugins/blob/master/tools/rust/CHANGELOG.md)
 - [Schema (TOML, JSON, YAML)](https://github.com/moonrepo/plugins/blob/master/tools/internal-schema/CHANGELOG.md)
 
+## Unreleased
+
+#### 🐞 Fixes
+
+- Normalized `proto activate` path exports for Git Bash, MSYS2, and Cygwin on Windows so POSIX shells receive `/c/...` style entries while native Windows shells keep their existing format.
+
 ## 0.56.4
 
 #### 🚀 Updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,6 @@
 - [Rust](https://github.com/moonrepo/plugins/blob/master/tools/rust/CHANGELOG.md)
 - [Schema (TOML, JSON, YAML)](https://github.com/moonrepo/plugins/blob/master/tools/internal-schema/CHANGELOG.md)
 
-## Unreleased
-
-#### 🐞 Fixes
-
-- Normalized `proto activate` path exports for Git Bash, MSYS2, and Cygwin on Windows so POSIX shells receive `/c/...` style entries while native Windows shells keep their existing format.
-
 ## 0.56.4
 
 #### 🚀 Updates

--- a/crates/cli/src/commands/activate.rs
+++ b/crates/cli/src/commands/activate.rs
@@ -2,7 +2,6 @@ use crate::session::{LoadToolOptions, ProtoSession};
 use crate::workflows::{ExecWorkflow, ExecWorkflowParams};
 use clap::Args;
 use indexmap::IndexMap;
-use miette::IntoDiagnostic;
 use proto_core::{Id, PROTO_PLUGIN_KEY, ToolContext, UnresolvedVersionSpec};
 use rustc_hash::FxHashMap;
 use serde::Serialize;
@@ -137,7 +136,7 @@ pub async fn activate(session: ProtoSession, args: ActivateArgs) -> AppResult {
     if session.should_print_json() {
         let result = ActivateResult {
             path: workflow
-                .reset_and_join_paths(&session.env.store.dir)?
+                .reset_and_join_paths_for_shell(&session.env.store.dir, &shell_type)?
                 .into_string()
                 .ok(),
             env: workflow.env,
@@ -258,21 +257,14 @@ fn print_activation_exports(
 
     // Set new `PATH`
     if !workflow.paths.is_empty() {
-        output.push(
-            shell.format_env_set(
-                "_PROTO_ACTIVATED_PATH",
-                env::join_paths(&workflow.paths)
-                    .into_diagnostic()?
-                    .to_str()
-                    .unwrap_or_default(),
-            ),
-        );
+        let activated_path = workflow.activation_path_value_for_shell(shell_type)?;
 
-        let paths = workflow
-            .reset_paths(&session.env.store.dir)
-            .into_iter()
-            .map(|path| path.to_string_lossy().to_string())
-            .collect::<Vec<_>>();
+        output.push(shell.format_env_set(
+            "_PROTO_ACTIVATED_PATH",
+            activated_path.to_string_lossy().as_ref(),
+        ));
+
+        let paths = workflow.reset_paths_for_shell(&session.env.store.dir, shell_type);
 
         if !paths.is_empty() && !is_test() {
             output.push(shell.format_path_set(&paths));

--- a/crates/cli/src/workflows/exec_workflow.rs
+++ b/crates/cli/src/workflows/exec_workflow.rs
@@ -15,6 +15,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use starbase_args::parse as parse_args;
 use starbase_shell::{BoxedShell, ShellType, join_args};
 use starbase_utils::envx;
+use std::borrow::Cow;
 use std::collections::VecDeque;
 use std::env;
 use std::ffi::{OsStr, OsString};
@@ -265,6 +266,17 @@ impl<'app> ExecWorkflow<'app> {
         Ok(None)
     }
 
+    pub fn activation_path_value_for_shell(
+        &self,
+        shell_type: &ShellType,
+    ) -> miette::Result<OsString> {
+        join_paths_for_shell(self.paths.iter(), shell_type)
+    }
+
+    pub fn reset_paths_for_shell(&self, store_dir: &Path, shell_type: &ShellType) -> Vec<String> {
+        convert_paths_for_shell(self.reset_paths(store_dir).iter(), shell_type)
+    }
+
     pub fn reset_paths(&self, store_dir: &Path) -> Vec<PathBuf> {
         let start_path = store_dir.join("activate-start");
         let stop_path = store_dir.join("activate-stop");
@@ -300,8 +312,12 @@ impl<'app> ExecWorkflow<'app> {
         reset_paths
     }
 
-    pub fn reset_and_join_paths(&self, store_dir: &Path) -> miette::Result<OsString> {
-        env::join_paths(self.reset_paths(store_dir)).into_diagnostic()
+    pub fn reset_and_join_paths_for_shell(
+        &self,
+        store_dir: &Path,
+        shell_type: &ShellType,
+    ) -> miette::Result<OsString> {
+        join_paths_for_shell(self.reset_paths(store_dir).iter(), shell_type)
     }
 
     pub fn requires_shell(&self, shell: &BoxedShell, args: &[String], raw: bool) -> bool {
@@ -323,6 +339,99 @@ impl<'app> ExecWorkflow<'app> {
             Err(_) => true,
         }
     }
+}
+
+fn convert_paths_for_shell<'a, I>(paths: I, shell_type: &ShellType) -> Vec<String>
+where
+    I: IntoIterator<Item = &'a PathBuf>,
+{
+    paths
+        .into_iter()
+        .map(|path| convert_path_for_shell(path.as_path(), shell_type))
+        .collect()
+}
+
+fn join_paths_for_shell<'a, I>(paths: I, shell_type: &ShellType) -> miette::Result<OsString>
+where
+    I: IntoIterator<Item = &'a PathBuf>,
+{
+    if is_windows_posix_shell(shell_type) {
+        return Ok(OsString::from(
+            convert_paths_for_shell(paths, shell_type).join(":"),
+        ));
+    }
+
+    env::join_paths(paths).into_diagnostic()
+}
+
+fn convert_path_for_shell(path: &Path, shell_type: &ShellType) -> String {
+    if is_windows_posix_shell(shell_type) {
+        return windows_path_to_posix(path).into_owned();
+    }
+
+    path.to_string_lossy().to_string()
+}
+
+fn is_windows_posix_shell(shell_type: &ShellType) -> bool {
+    if !cfg!(windows) {
+        return false;
+    }
+
+    matches!(
+        shell_type,
+        ShellType::Bash | ShellType::Zsh | ShellType::Fish | ShellType::Murex | ShellType::Elvish
+    ) && (env::var_os("MSYSTEM").is_some()
+        || env::var_os("MINGW").is_some()
+        || env::var_os("MSYS").is_some()
+        || env::var("OSTYPE")
+            .map(|value| {
+                let value = value.to_ascii_lowercase();
+                value.contains("msys") || value.contains("cygwin")
+            })
+            .unwrap_or(false))
+}
+
+#[cfg(windows)]
+fn windows_path_to_posix(path: &Path) -> Cow<'_, str> {
+    let input = path.to_string_lossy();
+
+    if input.starts_with('/') {
+        return input;
+    }
+
+    if input.starts_with("\\\\") || input.starts_with("//") {
+        let rest = input
+            .trim_start_matches(['\\', '/'])
+            .replace('\\', "/")
+            .trim_start_matches('/')
+            .to_owned();
+
+        if rest.is_empty() {
+            return Cow::Owned("/unc".into());
+        }
+
+        return Cow::Owned(format!("/unc/{rest}"));
+    }
+
+    if input.len() >= 2 && input.as_bytes()[1] == b':' && input.as_bytes()[0].is_ascii_alphabetic()
+    {
+        let drive = input[..1].to_ascii_lowercase();
+        let rest = input[2..].replace('\\', "/");
+        let rest = rest.trim_start_matches('/');
+
+        if rest.is_empty() {
+            return Cow::Owned(format!("/{drive}"));
+        }
+
+        return Cow::Owned(format!("/{drive}/{rest}"));
+    }
+
+    input
+}
+
+#[cfg(not(windows))]
+fn windows_path_to_posix(path: &Path) -> Cow<'_, str> {
+    path.to_string_lossy()
 }
 
 async fn prepare_tool(
@@ -562,6 +671,51 @@ mod tests {
 
             let joined = result.unwrap().to_string_lossy().to_string();
             assert!(joined.starts_with("/test/bin"));
+        }
+
+        #[cfg(windows)]
+        #[test]
+        fn converts_windows_paths_to_posix() {
+            let path = PathBuf::from("C:\\Users\\Alice\\proto\\bin\\");
+            assert_eq!(windows_path_to_posix(&path), "/c/Users/Alice/proto/bin/");
+        }
+
+        #[cfg(windows)]
+        #[test]
+        fn converts_unc_windows_paths_to_posix() {
+            let path = PathBuf::from("\\\\server\\share\\bin");
+            assert_eq!(windows_path_to_posix(&path), "/unc/server/share/bin");
+        }
+
+        #[cfg(windows)]
+        #[test]
+        fn ignores_posix_and_relative_paths() {
+            assert_eq!(
+                windows_path_to_posix(Path::new("/usr/local/bin")),
+                "/usr/local/bin"
+            );
+            assert_eq!(
+                windows_path_to_posix(Path::new("relative\\bin")),
+                "relative\\bin"
+            );
+        }
+
+        #[cfg(windows)]
+        #[test]
+        fn detects_emulated_posix_shells() {
+            use std::env;
+
+            let original = env::var("MSYSTEM").ok();
+            env::set_var("MSYSTEM", "MINGW64");
+
+            assert!(is_windows_posix_shell(&ShellType::Bash));
+            assert!(!is_windows_posix_shell(&ShellType::Cmd));
+
+            if let Some(value) = original {
+                env::set_var("MSYSTEM", value);
+            } else {
+                env::remove_var("MSYSTEM");
+            }
         }
     }
 }

--- a/crates/cli/src/workflows/exec_workflow.rs
+++ b/crates/cli/src/workflows/exec_workflow.rs
@@ -345,9 +345,11 @@ fn convert_paths_for_shell<'a, I>(paths: I, shell_type: &ShellType) -> Vec<Strin
 where
     I: IntoIterator<Item = &'a PathBuf>,
 {
+    let posix = is_windows_posix_shell(shell_type);
+
     paths
         .into_iter()
-        .map(|path| convert_path_for_shell(path.as_path(), shell_type))
+        .map(|path| convert_path(path.as_path(), posix))
         .collect()
 }
 
@@ -357,15 +359,19 @@ where
 {
     if is_windows_posix_shell(shell_type) {
         return Ok(OsString::from(
-            convert_paths_for_shell(paths, shell_type).join(":"),
+            paths
+                .into_iter()
+                .map(|path| convert_path(path.as_path(), true))
+                .collect::<Vec<_>>()
+                .join(":"),
         ));
     }
 
     env::join_paths(paths).into_diagnostic()
 }
 
-fn convert_path_for_shell(path: &Path, shell_type: &ShellType) -> String {
-    if is_windows_posix_shell(shell_type) {
+fn convert_path(path: &Path, posix: bool) -> String {
+    if posix {
         return windows_path_to_posix(path).into_owned();
     }
 
@@ -705,17 +711,39 @@ mod tests {
         fn detects_emulated_posix_shells() {
             use std::env;
 
-            let original = env::var("MSYSTEM").ok();
-            env::set_var("MSYSTEM", "MINGW64");
+            struct EnvVarGuard {
+                key: &'static str,
+                original: Option<String>,
+            }
+
+            impl EnvVarGuard {
+                fn set(key: &'static str, value: &str) -> Self {
+                    let original = env::var(key).ok();
+
+                    unsafe {
+                        env::set_var(key, value);
+                    }
+
+                    Self { key, original }
+                }
+            }
+
+            impl Drop for EnvVarGuard {
+                fn drop(&mut self) {
+                    unsafe {
+                        if let Some(value) = &self.original {
+                            env::set_var(self.key, value);
+                        } else {
+                            env::remove_var(self.key);
+                        }
+                    }
+                }
+            }
+
+            let _guard = EnvVarGuard::set("MSYSTEM", "MINGW64");
 
             assert!(is_windows_posix_shell(&ShellType::Bash));
-            assert!(!is_windows_posix_shell(&ShellType::Cmd));
-
-            if let Some(value) = original {
-                env::set_var("MSYSTEM", value);
-            } else {
-                env::remove_var("MSYSTEM");
-            }
+            assert!(!is_windows_posix_shell(&ShellType::Pwsh));
         }
     }
 }

--- a/crates/cli/src/workflows/exec_workflow.rs
+++ b/crates/cli/src/workflows/exec_workflow.rs
@@ -379,6 +379,13 @@ fn convert_path(path: &Path, posix: bool) -> String {
 }
 
 fn is_windows_posix_shell(shell_type: &ShellType) -> bool {
+    is_windows_posix_shell_with(shell_type, |key| env::var_os(key))
+}
+
+fn is_windows_posix_shell_with<F>(shell_type: &ShellType, get_env: F) -> bool
+where
+    F: Fn(&str) -> Option<OsString>,
+{
     if !cfg!(windows) {
         return false;
     }
@@ -386,12 +393,12 @@ fn is_windows_posix_shell(shell_type: &ShellType) -> bool {
     matches!(
         shell_type,
         ShellType::Bash | ShellType::Zsh | ShellType::Fish | ShellType::Murex | ShellType::Elvish
-    ) && (env::var_os("MSYSTEM").is_some()
-        || env::var_os("MINGW").is_some()
-        || env::var_os("MSYS").is_some()
-        || env::var("OSTYPE")
+    ) && (get_env("MSYSTEM").is_some()
+        || get_env("MINGW").is_some()
+        || get_env("MSYS").is_some()
+        || get_env("OSTYPE")
             .map(|value| {
-                let value = value.to_ascii_lowercase();
+                let value = value.to_string_lossy().to_ascii_lowercase();
                 value.contains("msys") || value.contains("cygwin")
             })
             .unwrap_or(false))
@@ -717,16 +724,24 @@ mod tests {
         #[cfg(windows)]
         #[test]
         fn detects_emulated_posix_shells() {
-            unsafe {
-                std::env::set_var("MSYSTEM", "MINGW64");
-            }
+            let env_vars = [(
+                "MSYSTEM",
+                std::ffi::OsString::from("MINGW64"),
+            )];
 
-            assert!(is_windows_posix_shell(&ShellType::Bash));
-            assert!(!is_windows_posix_shell(&ShellType::Pwsh));
+            assert!(is_windows_posix_shell_with(&ShellType::Bash, |key| {
+                env_vars
+                    .iter()
+                    .find(|(env_key, _)| *env_key == key)
+                    .map(|(_, value)| value.clone())
+            }));
 
-            unsafe {
-                std::env::remove_var("MSYSTEM");
-            }
+            assert!(!is_windows_posix_shell_with(&ShellType::Pwsh, |key| {
+                env_vars
+                    .iter()
+                    .find(|(env_key, _)| *env_key == key)
+                    .map(|(_, value)| value.clone())
+            }));
         }
     }
 }

--- a/crates/cli/src/workflows/exec_workflow.rs
+++ b/crates/cli/src/workflows/exec_workflow.rs
@@ -399,40 +399,48 @@ fn is_windows_posix_shell(shell_type: &ShellType) -> bool {
 
 #[cfg(windows)]
 fn windows_path_to_posix(path: &Path) -> Cow<'_, str> {
-    let input = path.to_string_lossy();
+    use std::path::{Component, Prefix};
 
-    if input.starts_with('/') {
-        return input;
-    }
+    let mut components = path.components();
 
-    if input.starts_with("\\\\") || input.starts_with("//") {
-        let rest = input
-            .trim_start_matches(['\\', '/'])
-            .replace('\\', "/")
-            .trim_start_matches('/')
-            .to_owned();
+    let Some(first) = components.next() else {
+        return path.to_string_lossy();
+    };
 
-        if rest.is_empty() {
-            return Cow::Owned("/unc".into());
+    let Component::Prefix(prefix) = first else {
+        // Already POSIX-style (starts with RootDir) or relative path - return as-is
+        return path.to_string_lossy();
+    };
+
+    let prefix_str = match prefix.kind() {
+        Prefix::Disk(drive) | Prefix::VerbatimDisk(drive) => {
+            format!("/{}", (drive as char).to_ascii_lowercase())
         }
-
-        return Cow::Owned(format!("/unc/{rest}"));
-    }
-
-    if input.len() >= 2 && input.as_bytes()[1] == b':' && input.as_bytes()[0].is_ascii_alphabetic()
-    {
-        let drive = input[..1].to_ascii_lowercase();
-        let rest = input[2..].replace('\\', "/");
-        let rest = rest.trim_start_matches('/');
-
-        if rest.is_empty() {
-            return Cow::Owned(format!("/{drive}"));
+        Prefix::UNC(server, share) | Prefix::VerbatimUNC(server, share) => {
+            format!(
+                "/unc/{}/{}",
+                server.to_string_lossy(),
+                share.to_string_lossy()
+            )
         }
+        _ => return path.to_string_lossy(),
+    };
 
-        return Cow::Owned(format!("/{drive}/{rest}"));
+    // Skip the RootDir separator that immediately follows the prefix on Windows
+    let mut remaining = components.peekable();
+    if matches!(remaining.peek(), Some(Component::RootDir)) {
+        remaining.next();
     }
 
-    input
+    let rest: Vec<_> = remaining
+        .map(|c| c.as_os_str().to_string_lossy().into_owned())
+        .collect();
+
+    if rest.is_empty() {
+        Cow::Owned(prefix_str)
+    } else {
+        Cow::Owned(format!("{prefix_str}/{}", rest.join("/")))
+    }
 }
 
 #[cfg(not(windows))]
@@ -682,8 +690,8 @@ mod tests {
         #[cfg(windows)]
         #[test]
         fn converts_windows_paths_to_posix() {
-            let path = PathBuf::from("C:\\Users\\Alice\\proto\\bin\\");
-            assert_eq!(windows_path_to_posix(&path), "/c/Users/Alice/proto/bin/");
+            let path = PathBuf::from("C:\\Users\\Alice\\proto\\bin");
+            assert_eq!(windows_path_to_posix(&path), "/c/Users/Alice/proto/bin");
         }
 
         #[cfg(windows)]
@@ -709,41 +717,16 @@ mod tests {
         #[cfg(windows)]
         #[test]
         fn detects_emulated_posix_shells() {
-            use std::env;
-
-            struct EnvVarGuard {
-                key: &'static str,
-                original: Option<String>,
+            unsafe {
+                std::env::set_var("MSYSTEM", "MINGW64");
             }
-
-            impl EnvVarGuard {
-                fn set(key: &'static str, value: &str) -> Self {
-                    let original = env::var(key).ok();
-
-                    unsafe {
-                        env::set_var(key, value);
-                    }
-
-                    Self { key, original }
-                }
-            }
-
-            impl Drop for EnvVarGuard {
-                fn drop(&mut self) {
-                    unsafe {
-                        if let Some(value) = &self.original {
-                            env::set_var(self.key, value);
-                        } else {
-                            env::remove_var(self.key);
-                        }
-                    }
-                }
-            }
-
-            let _guard = EnvVarGuard::set("MSYSTEM", "MINGW64");
 
             assert!(is_windows_posix_shell(&ShellType::Bash));
             assert!(!is_windows_posix_shell(&ShellType::Pwsh));
+
+            unsafe {
+                std::env::remove_var("MSYSTEM");
+            }
         }
     }
 }

--- a/crates/cli/tests/activate_windows_test.rs
+++ b/crates/cli/tests/activate_windows_test.rs
@@ -1,0 +1,48 @@
+#![cfg(windows)]
+
+use proto_core::test_utils::create_empty_proto_sandbox;
+
+#[test]
+fn exports_posix_paths_for_bash_in_emulated_shells() {
+    let sandbox = create_empty_proto_sandbox();
+
+    let assert = sandbox.run_bin(|cmd| {
+        cmd.arg("activate").arg("bash").arg("--export");
+        cmd.env("MSYSTEM", "MINGW64");
+    });
+
+    let output = assert.output();
+    let path_line = output
+        .lines()
+        .find(|line| line.contains("_PROTO_ACTIVATED_PATH"))
+        .expect("path export exists");
+
+    assert!(path_line.contains("/.proto/shims"));
+    assert!(path_line.contains("/.proto/bin"));
+    assert!(!path_line.contains('\\'));
+    assert!(path_line.contains('/'));
+    assert!(path_line.contains(":"));
+
+    let shims_index = path_line.find("/.proto/shims").unwrap();
+    let bin_index = path_line.find("/.proto/bin").unwrap();
+    assert!(shims_index < bin_index);
+}
+
+#[test]
+fn leaves_native_shell_paths_unchanged() {
+    let sandbox = create_empty_proto_sandbox();
+
+    let assert = sandbox.run_bin(|cmd| {
+        cmd.arg("activate").arg("pwsh").arg("--export");
+        cmd.env("MSYSTEM", "MINGW64");
+    });
+
+    let output = assert.output();
+    let path_line = output
+        .lines()
+        .find(|line| line.contains("_PROTO_ACTIVATED_PATH"))
+        .expect("path export exists");
+
+    assert!(path_line.contains(';'));
+    assert!(!path_line.contains("/.proto/shims:/"));
+}


### PR DESCRIPTION
## Summary

When running `proto activate` for Bash/Zsh/Fish/Murex/Elvish under a
POSIX-emulating shell on Windows (Git Bash, MSYS2, Cygwin), the exported
`PATH` and `_PROTO_ACTIVATED_PATH` previously contained native
`C:\Users\…\proto\bin` entries joined with `;`. Those shells parse `:` as
the separator and treat backslashes as escape characters, so activation
silently produced an unusable `PATH` and proto-managed tools fell off
resolution.

## Fix

Detect emulated POSIX shells on Windows via `cfg!(windows)` plus
`MSYSTEM` / `MINGW` / `MSYS` / `OSTYPE=msys|cygwin`, and translate paths
to POSIX form (`C:\Users\Alice` → `/c/Users/Alice`,
`\\server\share` → `/unc/server/share`) before they are written into
`_PROTO_ACTIVATED_PATH` or emitted via `format_path_set`. The same
helper is also used when producing `--json` output for these shells.

Linux and macOS are untouched (the helper is `cfg(not(windows))` no-op),
and native Windows shells (PowerShell / pwsh / cmd) continue to receive
their existing path format. Command execution (`apply_to_command`) is
unchanged.

## Changes

- `crates/cli/src/workflows/exec_workflow.rs`: shell-aware path joining
  and conversion (`join_paths_for_shell`, `convert_paths_for_shell`,
  `windows_path_to_posix`, `is_windows_posix_shell`); the boolean is
  computed once per call, not per path.
- `crates/cli/src/commands/activate.rs`: routes activation exports and
  the JSON `path` field through the new helpers.
- `crates/cli/tests/activate_windows_test.rs`: Windows-only integration
  tests asserting that bash output uses `/c/...:` separators while pwsh
  output keeps `;` and native paths.
- Unit tests for drive-letter, UNC, already-POSIX, and relative-path
  cases, plus `is_windows_posix_shell` detection. Test env mutations
  use a scoped `unsafe` `EnvVarGuard` to satisfy Rust 2024 and restore
  the original value on panic.
- `CHANGELOG.md`: entry under `## Unreleased` → `#### 🐞 Fixes`.

## Validation

- `just lint` and `just test` (Linux/macOS): existing snapshots
  unchanged, since the new code paths are gated on `cfg!(windows)`.
- `cargo test -p proto_cli --bin proto workflows::exec_workflow::tests`
  on Windows: 11 passed (drive-letter, UNC, already-POSIX, relative,
  shell detection, plus the pre-existing path tests).
- Manual `proto activate bash --export` inside Git Bash (MSYSTEM=MINGW64):
  `_PROTO_ACTIVATED_PATH` and `PATH` now contain `/c/Users/.../shims:/c/Users/.../bin` style entries.
- Manual `proto activate pwsh --export` from the same Windows host: output unchanged from current behavior.