### PR TITLE
fix(test): pin Node 22 for pnpm 11 compat, increase clean timeouts

### DIFF
--- a/crates/cli/tests/clean_test.rs
+++ b/crates/cli/tests/clean_test.rs
@@ -13,7 +13,7 @@ mod clean {
             .run_bin(|cmd| {
                 cmd.arg("clean")
                     .arg("--yes")
-                    .timeout(Duration::from_mins(3));
+                    .timeout(Duration::from_mins(5));
             })
             .success();
     }
@@ -60,7 +60,7 @@ mod clean {
                 cmd.arg("install")
                     .arg("protostar")
                     .arg("1.0.0")
-                    .timeout(Duration::from_mins(3));
+                    .timeout(Duration::from_mins(5));
             })
             .success();
 
@@ -69,7 +69,7 @@ mod clean {
                 cmd.arg("install")
                     .arg("protostar")
                     .arg("2.0.0")
-                    .timeout(Duration::from_mins(3));
+                    .timeout(Duration::from_mins(5));
             })
             .success();
 
@@ -78,7 +78,7 @@ mod clean {
                 cmd.arg("install")
                     .arg("protostar")
                     .arg("3.0.0")
-                    .timeout(Duration::from_mins(3));
+                    .timeout(Duration::from_mins(5));
             })
             .success();
 
@@ -111,7 +111,7 @@ mod clean {
                     .arg("tools")
                     .arg("--days")
                     .arg("1")
-                    .timeout(Duration::from_mins(3));
+                    .timeout(Duration::from_mins(5));
             })
             .success();
 

--- a/crates/cli/tests/plugins_test.rs
+++ b/crates/cli/tests/plugins_test.rs
@@ -266,9 +266,11 @@ mod plugins {
         fn supports_node_and_package_managers() {
             let sandbox = create_empty_proto_sandbox();
 
+            // Pin Node to 22 (LTS) — pnpm 11+ requires Node >= 22.13 and
+            // will crash with ERR_UNKNOWN_BUILTIN_MODULE if run on Node 20.
             sandbox
                 .run_bin(|cmd| {
-                    cmd.arg("install").arg("node");
+                    cmd.arg("install").arg("node").arg("22");
                 })
                 .success();
 

--- a/crates/cli/tests/snapshots/plugins_test__plugins__builtins__supports_node_and_package_managers.snap
+++ b/crates/cli/tests/snapshots/plugins_test__plugins__builtins__supports_node_and_package_managers.snap
@@ -13,8 +13,16 @@ expression: "fs::read_to_string(sandbox.path().join(\".proto/shims/registry.json
     "alt_bin": true,
     "parent": "npm"
   },
+  "pn": {
+    "alt_bin": true,
+    "parent": "pnpm"
+  },
   "pnpm": {},
   "pnpx": {
+    "alt_bin": true,
+    "parent": "pnpm"
+  },
+  "pnx": {
     "alt_bin": true,
     "parent": "pnpm"
   },


### PR DESCRIPTION
## Summary

Fixes two pre-existing test failures that affect CI on `master`:

### 1. `supports_node_and_package_managers` — pnpm 11 / Node incompatibility

pnpm 11+ requires Node >= 22.13 (uses `node:sqlite`). The test installs "latest" node which can resolve to 20.x on CI, causing pnpm to crash:

```
warn: This version of pnpm requires at least Node.js v22.13
Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite
```

**Fix:** Pin node to `22` in the test sandbox. Also updates the shim registry snapshot for pnpm 11's new `pn` and `pnx` secondary executable aliases.

### 2. `clean_test` — timeout flakiness

The clean command can take 2-3 minutes on slow CI runners. The 3-minute timeout was occasionally exceeded by seconds, causing sporadic failures.

**Fix:** Increase timeout from 3 to 5 minutes.

## Changes

- `crates/cli/tests/plugins_test.rs` — pin `node 22` in `supports_node_and_package_managers`
- `crates/cli/tests/clean_test.rs` — increase command timeouts from 3 to 5 minutes
- `crates/cli/tests/snapshots/...snap` — add `pn` and `pnx` entries for pnpm 11