### PR TITLE
feat: add nu plugin to registry

### DIFF
--- a/registry/data/third-party.json
+++ b/registry/data/third-party.json
@@ -1026,6 +1026,35 @@
       ]
     },
     {
+      "id": "nu",
+      "locator": "github://Hebilicious/proto-nu",
+      "format": "wasm",
+      "name": "Nushell",
+      "description": "A modern shell written in Rust with structured data pipelines.",
+      "author": "Hebilicious",
+      "homepageUrl": "https://www.nushell.sh/",
+      "repositoryUrl": "https://github.com/Hebilicious/proto-nu",
+      "bins": [
+        "nu",
+        "nu_plugin_custom_values",
+        "nu_plugin_example",
+        "nu_plugin_formats",
+        "nu_plugin_gstat",
+        "nu_plugin_inc",
+        "nu_plugin_polars",
+        "nu_plugin_query",
+        "nu_plugin_stress_internals"
+      ],
+      "detectionSources": [
+        {
+          "file": ".nu-version"
+        },
+        {
+          "file": ".nushell-version"
+        }
+      ]
+    },
+    {
       "id": "ocaml",
       "locator": "github://Hebilicious/proto-ocaml",
       "format": "wasm",


### PR DESCRIPTION
## Summary
This adds the published `nu` WASM plugin to the third-party proto registry so Nushell can be discovered through `proto plugin search` and installed with the GitHub locator.

Plugin repository: https://github.com/Hebilicious/proto-nu
Published release: https://github.com/Hebilicious/proto-nu/releases/tag/v0.1.0

The registry entry uses:
- locator: `github://Hebilicious/proto-nu`
- format: `wasm`
- bins: `nu` plus the bundled `nu_plugin_*` executables exposed by Nushell release archives
- detection sources: `.nu-version`, `.nushell-version`

The plugin installs official Nushell release archives from `nushell/nushell`, verifies downloads against `SHA256SUMS`, and exposes the primary `nu` executable through proto.

## Validation
- not run locally per request; relying on CI
- the plugin has a published GitHub release with the WASM asset expected by the `github://` locator
- the plugin repo CI passed Rust tests, WASM build, and Docker e2e install before publishing
- this registry change is limited to a single new `nu` entry in `registry/data/third-party.json`