### PR TITLE
new: add Mago plugin to third-party registry

### DIFF
--- a/registry/data/third-party.json
+++ b/registry/data/third-party.json
@@ -948,6 +948,19 @@
       ]
     },
     {
+      "id": "mago",
+      "locator": "https://raw.githubusercontent.com/Bocom/proto-toml-plugins/main/mago.toml",
+      "format": "toml",
+      "name": "Mago",
+      "description": "Static analyzer, linter, and formatter for PHP.",
+      "author": "Bocom",
+      "homepageUrl": "https://mago.carthage.software/",
+      "repositoryUrl": "https://github.com/Bocom/proto-toml-plugins",
+      "bins": [
+        "mago"
+      ]
+    },
+    {
       "id": "migrate",
       "locator": "https://raw.githubusercontent.com/jamesukiyo/proto-plugins/master/migrate.toml",
       "format": "toml",


### PR DESCRIPTION
[Mago](https://mago.carthage.software) is a static analyzer, linter, and formatter for PHP, written in Rust.

Tested on Windows (x64), Linux (x64) and macOS (arm64).