### PR TITLE
registry: add Azure CLI plugin

### DIFF
--- a/registry/data/third-party.json
+++ b/registry/data/third-party.json
@@ -97,6 +97,27 @@
       ]
     },
     {
+      "id": "azure-cli",
+      "locator": "github://BarretoTech/proto-azure-cli-plugin",
+      "format": "wasm",
+      "name": "Azure CLI",
+      "description": "Cross-platform command-line tool for managing Azure resources.",
+      "author": "BarretoTech",
+      "homepageUrl": "https://learn.microsoft.com/en-us/cli/azure/",
+      "repositoryUrl": "https://github.com/BarretoTech/proto-azure-cli-plugin",
+      "devicon": "azure",
+      "bins": [
+        "az"
+      ],
+      "detectionSources": [
+        {
+          "file": ".tool-versions",
+          "label": "asdf",
+          "url": "https://asdf-vm.com/manage/configuration.html"
+        }
+      ]
+    },
+    {
       "id": "bazel",
       "locator": "https://raw.githubusercontent.com/Phault/proto-toml-plugins/main/bazel/plugin.toml",
       "format": "toml",


### PR DESCRIPTION
## Summary

Adds an entry for [`proto-azure-cli-plugin`](https://github.com/BarretoTech/proto-azure-cli-plugin) — a WASM plugin for managing per-version Azure CLI (`az`) installs side-by-side via proto.

The plugin dispatches by host OS:

- **macOS arm64/x64** and **Windows x64** — direct download of the official prebuilt archives Microsoft attaches to each [`azure-cli-<v>`](https://github.com/Azure/azure-cli/releases) GitHub release (`*-macos-{arm64,x86_64}.tar.gz`, `*-x64.zip`). The archives bundle their own Python 3.13 runtime, so there are no host prerequisites.
- **Linux** (any libc, x64/arm64) — Microsoft publishes no portable artifact, so the plugin uses proto's `native_install` to create a per-version venv with the host's `python3` and `pip install azure-cli==<version>` into it. Requires Python 3.10+ with the `venv` module on `PATH`; the plugin surfaces a clear actionable error if either is missing.

Supports `azure-cli = "latest"` in `.prototools` (auto-set via `LoadVersionsOutput::from`) and asdf-style `.tool-versions` files via `detect_version_files` / `parse_version_file`. Verified end-to-end with proto 0.56.4 on Windows x64 and proto 0.57.3 on WSL Ubuntu 24.04. Latest release: [v0.1.2](https://github.com/BarretoTech/proto-azure-cli-plugin/releases/tag/v0.1.2).

## Test plan

- [x] JSON syntactically valid (`jq` parse)
- [x] All 7 required `PluginEntry` fields present (`author`, `bins`, `description`, `format`, `id`, `locator`, `name`)
- [x] Alphabetically positioned between `atlas` and `bazel`
- [x] Plugin install verified from `github://BarretoTech/proto-azure-cli-plugin@v0.1.2` on Windows x64 (download_prebuilt path) and Linux x64 (native_install path)