### PR TITLE
Update OCaml plugin locator

### DIFF
--- a/registry/data/third-party.json
+++ b/registry/data/third-party.json
@@ -1027,13 +1027,13 @@
     },
     {
       "id": "ocaml",
-      "locator": "github://Hebilicious/proto-ocaml",
+      "locator": "github://Hebilicious/proto-plugins/ocaml",
       "format": "wasm",
       "name": "OCaml",
       "description": "The OCaml compiler toolchain, powered by opam and dune.",
       "author": "Hebilicious",
       "homepageUrl": "https://ocaml.org/",
-      "repositoryUrl": "https://github.com/Hebilicious/proto-ocaml",
+      "repositoryUrl": "https://github.com/Hebilicious/proto-plugins",
       "bins": [
         "dune",
         "ocaml",


### PR DESCRIPTION
Updates the OCaml third-party plugin entry to point at the new Hebilicious/proto-plugins monorepo locator.