### PR TITLE
Add Nushell plugin

### DIFF
--- a/registry/data/third-party.json
+++ b/registry/data/third-party.json
@@ -1026,6 +1026,35 @@
       ]
     },
     {
+      "id": "nu",
+      "locator": "github://Hebilicious/proto-nu",
+      "format": "wasm",
+      "name": "Nushell",
+      "description": "A modern shell written in Rust with structured data pipelines.",
+      "author": "Hebilicious",
+      "homepageUrl": "https://www.nushell.sh/",
+      "repositoryUrl": "https://github.com/Hebilicious/proto-nu",
+      "bins": [
+        "nu",
+        "nu_plugin_custom_values",
+        "nu_plugin_example",
+        "nu_plugin_formats",
+        "nu_plugin_gstat",
+        "nu_plugin_inc",
+        "nu_plugin_polars",
+        "nu_plugin_query",
+        "nu_plugin_stress_internals"
+      ],
+      "detectionSources": [
+        {
+          "file": ".nu-version"
+        },
+        {
+          "file": ".nushell-version"
+        }
+      ]
+    },
+    {
       "id": "ocaml",
       "locator": "github://Hebilicious/proto-ocaml",
       "format": "wasm",

--- a/registry/data/third-party.json
+++ b/registry/data/third-party.json
@@ -1027,13 +1027,13 @@
     },
     {
       "id": "nu",
-      "locator": "github://Hebilicious/proto-nu",
+      "locator": "github://Hebilicious/proto-plugins/nu",
       "format": "wasm",
       "name": "Nushell",
       "description": "A modern shell written in Rust with structured data pipelines.",
       "author": "Hebilicious",
       "homepageUrl": "https://www.nushell.sh/",
-      "repositoryUrl": "https://github.com/Hebilicious/proto-nu",
+      "repositoryUrl": "https://github.com/Hebilicious/proto-plugins",
       "bins": [
         "nu",
         "nu_plugin_custom_values",
@@ -1056,13 +1056,13 @@
     },
     {
       "id": "ocaml",
-      "locator": "github://Hebilicious/proto-ocaml",
+      "locator": "github://Hebilicious/proto-plugins/ocaml",
       "format": "wasm",
       "name": "OCaml",
       "description": "The OCaml compiler toolchain, powered by opam and dune.",
       "author": "Hebilicious",
       "homepageUrl": "https://ocaml.org/",
-      "repositoryUrl": "https://github.com/Hebilicious/proto-ocaml",
+      "repositoryUrl": "https://github.com/Hebilicious/proto-plugins",
       "bins": [
         "dune",
         "ocaml",


### PR DESCRIPTION
Adds the Nushell third-party WASM plugin entry and points it at the new Hebilicious/proto-plugins monorepo locator.