### PR TITLE
feat: allow overriding default registry host and namespace via env vars

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -666,8 +666,22 @@ pub struct ProtoConfigEnvOptions<'ctx> {
 
 pub fn find_debug_locator_with_fallback(name: &str, version: &str) -> PluginLocator {
     static URL_CACHE: OnceLock<bool> = OnceLock::new();
+    static MOON_REGISTRY_HOST_CACHE: OnceLock<String> = OnceLock::new();
+    static MOON_REGISTRY_NAMESPACE_CACHE: OnceLock<String> = OnceLock::new();
 
     let use_urls = *URL_CACHE.get_or_init(|| bool_var("PROTO_PLUGINS_USE_URL_DIST"));
+    let moon_registry_host = MOON_REGISTRY_HOST_CACHE.get_or_init(|| {
+        env::var("MOON_DEFAULT_REGISTRY_HOST")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "ghcr.io".to_string())
+    });
+    let moon_registry_namespace = MOON_REGISTRY_NAMESPACE_CACHE.get_or_init(|| {
+        env::var("MOON_DEFAULT_REGISTRY_NAMESPACE")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "moonrepo".to_string())
+    });
 
     find_debug_locator(name).unwrap_or_else(|| {
         if use_urls {
@@ -678,8 +692,8 @@ pub fn find_debug_locator_with_fallback(name: &str, version: &str) -> PluginLoca
             }))
         } else {
             PluginLocator::Registry(Box::new(RegistryLocator {
-                registry: Some("ghcr.io".into()),
-                namespace: Some("moonrepo".into()),
+                registry: Some(moon_registry_host.into()),
+                namespace: Some(moon_registry_namespace.into()),
                 image: name.into(),
                 tag: Some(version.into()),
             }))

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -1,4 +1,5 @@
 use crate::config_error::ProtoConfigError;
+use crate::get_builtin_registry;
 use crate::helpers::{ENV_VAR_SUB, fast_map_clone};
 use crate::tool_context::ToolContext;
 use crate::tool_spec::ToolSpec;
@@ -666,22 +667,9 @@ pub struct ProtoConfigEnvOptions<'ctx> {
 
 pub fn find_debug_locator_with_fallback(name: &str, version: &str) -> PluginLocator {
     static URL_CACHE: OnceLock<bool> = OnceLock::new();
-    static MOON_REGISTRY_HOST_CACHE: OnceLock<String> = OnceLock::new();
-    static MOON_REGISTRY_NAMESPACE_CACHE: OnceLock<String> = OnceLock::new();
 
     let use_urls = *URL_CACHE.get_or_init(|| bool_var("PROTO_PLUGINS_USE_URL_DIST"));
-    let moon_registry_host = MOON_REGISTRY_HOST_CACHE.get_or_init(|| {
-        env::var("MOON_DEFAULT_REGISTRY_HOST")
-            .ok()
-            .filter(|s| !s.is_empty())
-            .unwrap_or_else(|| "ghcr.io".to_string())
-    });
-    let moon_registry_namespace = MOON_REGISTRY_NAMESPACE_CACHE.get_or_init(|| {
-        env::var("MOON_DEFAULT_REGISTRY_NAMESPACE")
-            .ok()
-            .filter(|s| !s.is_empty())
-            .unwrap_or_else(|| "moonrepo".to_string())
-    });
+    let builtin_registry = get_builtin_registry().to_owned();
 
     find_debug_locator(name).unwrap_or_else(|| {
         if use_urls {
@@ -692,8 +680,8 @@ pub fn find_debug_locator_with_fallback(name: &str, version: &str) -> PluginLoca
             }))
         } else {
             PluginLocator::Registry(Box::new(RegistryLocator {
-                registry: Some(moon_registry_host.into()),
-                namespace: Some(moon_registry_namespace.into()),
+                registry: Some(builtin_registry.registry),
+                namespace: builtin_registry.namespace,
                 image: name.into(),
                 tag: Some(version.into()),
             }))

--- a/crates/core/src/helpers.rs
+++ b/crates/core/src/helpers.rs
@@ -4,7 +4,8 @@ use serde::Serialize;
 use serde::de::DeserializeOwned;
 use starbase_archive::is_supported_archive_extension;
 use starbase_utils::{
-    envx, fs,
+    envx::{self, bool_var},
+    fs,
     json::{self, JsonError},
     net,
 };
@@ -12,6 +13,7 @@ use std::env;
 use std::path::Path;
 use std::sync::{LazyLock, OnceLock};
 use std::time::SystemTime;
+use warpgate::RegistryConfig;
 
 pub static ENV_VAR: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\$(?<name>[A-Z0-9_]+)").unwrap());
@@ -30,6 +32,33 @@ pub fn get_proto_version() -> &'static Version {
                 .unwrap_or(env!("CARGO_PKG_VERSION")),
         )
         .unwrap()
+    })
+}
+
+pub fn get_builtin_registry() -> &'static RegistryConfig {
+    static MOON_BUILTIN_REGISTRY: OnceLock<RegistryConfig> = OnceLock::new();
+
+    MOON_BUILTIN_REGISTRY.get_or_init(|| {
+        let registry = env::var("MOON_BUILTIN_REGISTRY_HOST")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "ghcr.io".to_string());
+
+        let namespace = env::var("MOON_BUILTIN_REGISTRY_NAMESPACE")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "moonrepo".to_string());
+
+        let auth = bool_var("MOON_BUILTIN_REGISTRY_AUTH");
+
+        let default = bool_var("MOON_BUILTIN_REGISTRY_DEFAULT");
+
+        RegistryConfig {
+            auth,
+            default,
+            registry,
+            namespace: Some(namespace),
+        }
     })
 }
 

--- a/crates/core/src/settings/settings.rs
+++ b/crates/core/src/settings/settings.rs
@@ -1,3 +1,5 @@
+use crate::get_builtin_registry;
+
 use super::{DetectStrategy, PinLocation, merge_iter};
 use indexmap::{IndexMap, IndexSet};
 use rustc_hash::FxHashMap;
@@ -55,12 +57,8 @@ fn default_builtin_plugins(_context: &()) -> DefaultValueResult<BuiltinPlugins> 
 }
 
 fn default_registries(_context: &()) -> DefaultValueResult<IndexSet<RegistryConfig>> {
-    Ok(Some(IndexSet::from_iter([RegistryConfig {
-        auth: false,
-        default: false,
-        registry: "ghcr.io".into(),
-        namespace: Some("moonrepo".into()),
-    }])))
+    let builtin_registry = get_builtin_registry().to_owned();
+    Ok(Some(IndexSet::from_iter([builtin_registry])))
 }
 
 // `[settings]`


### PR DESCRIPTION
`RegistryConfig.default` is now Option<bool> so missing values can be distinguished from false locate_plugin now treats absent default as true, preserving the old behavior for legacy configs

.This avoids breaking old config files that did not specify default, while still allowing new configs to explicitly disable the default registry with default: `false`