### PR TITLE
fix: Recurse into cache subdirectories when cleaning

### DIFF
--- a/crates/cli/src/commands/clean.rs
+++ b/crates/cli/src/commands/clean.rs
@@ -13,6 +13,7 @@ use starbase_console::ui::*;
 use starbase_console::utils::formats::format_bytes_binary;
 use starbase_styles::color;
 use starbase_utils::fs;
+use std::io;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 use tracing::{debug, instrument};
@@ -269,23 +270,26 @@ pub async fn clean_proto_tool(session: &ProtoSession, days: u64) -> miette::Resu
 }
 
 #[instrument]
-pub async fn clean_dir(dir: &Path, days: u64) -> miette::Result<Vec<StaleFile>> {
+pub fn clean_dir(dir: &Path, days: u64, recurse: bool) -> miette::Result<Vec<StaleFile>> {
     let duration = Duration::from_secs(86400 * days);
     let mut cleaned = vec![];
 
-    for file in fs::read_dir(dir)? {
-        let path = file.path();
+    for entry in fs::read_dir(dir)? {
+        let path = entry.path();
 
         // Don't delete dot files/folders
         if path
             .file_name()
-            .and_then(|name| name.to_str())
-            .is_some_and(|name| name.starts_with('.'))
+            .is_some_and(|name| name.as_encoded_bytes().starts_with(b"."))
         {
             continue;
         }
 
-        if path.is_file() {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+
+        if file_type.is_file() {
             let bytes = fs::remove_file_if_stale(&path, duration)?;
 
             if bytes > 0 {
@@ -299,6 +303,27 @@ pub async fn clean_dir(dir: &Path, days: u64) -> miette::Result<Vec<StaleFile>> 
                     file: path,
                     size: bytes,
                 })
+            }
+        } else if recurse && file_type.is_dir() {
+            cleaned.extend(clean_dir(&path, days, recurse)?);
+
+            // Prune the subdirectory if empty; a concurrent clean or write is not an error
+            match std::fs::remove_dir(&path) {
+                Ok(_) => {
+                    debug!("Directory {} is now empty, removing", color::path(&path));
+                }
+                Err(error)
+                    if matches!(
+                        error.kind(),
+                        io::ErrorKind::NotFound | io::ErrorKind::DirectoryNotEmpty
+                    ) => {}
+                Err(error) => {
+                    return Err(fs::FsError::Remove {
+                        path,
+                        error: Box::new(error),
+                    }
+                    .into());
+                }
             }
         }
     }
@@ -335,19 +360,24 @@ pub async fn internal_clean(
     if matches!(args.target, CleanTarget::All | CleanTarget::Plugins) {
         debug!("Cleaning downloaded plugins...");
 
-        result.plugins = clean_dir(&session.env.store.plugins_dir, days).await?;
+        // Plugins are stored as flat files, so no recursion is needed
+        result.plugins = clean_dir(&session.env.store.plugins_dir, days, false)?;
     }
 
     if matches!(args.target, CleanTarget::All | CleanTarget::Temp) {
         debug!("Cleaning temporary directory...");
 
-        result.temp = clean_dir(&session.env.store.temp_dir, days).await?;
+        // Temp contents are coordinated through the install and plugin download
+        // locks, and both flows remove their own directories when they finish;
+        // recursive cleanup would have to participate in those lock protocols,
+        // so keep the previous top-level behavior here
+        result.temp = clean_dir(&session.env.store.temp_dir, days, false)?;
     }
 
     if matches!(args.target, CleanTarget::All | CleanTarget::Cache) {
         debug!("Cleaning cache directory...");
 
-        result.cache = clean_dir(&session.env.store.cache_dir, days).await?;
+        result.cache = clean_dir(&session.env.store.cache_dir, days, true)?;
     }
 
     Ok(result)

--- a/crates/cli/tests/clean_test.rs
+++ b/crates/cli/tests/clean_test.rs
@@ -4,6 +4,34 @@ use std::time::{Duration, SystemTime};
 
 mod clean {
     use super::*;
+    use std::path::Path;
+
+    fn make_stale(path: impl AsRef<Path>) {
+        fs::File::options()
+            .write(true)
+            .open(path)
+            .unwrap()
+            .set_times(
+                fs::FileTimes::new().set_accessed(
+                    SystemTime::now()
+                        .checked_sub(Duration::from_secs(86400 * 2))
+                        .unwrap(),
+                ),
+            )
+            .unwrap();
+    }
+
+    fn run_clean(sandbox: &ProtoSandbox, target: &str) {
+        sandbox
+            .run_bin(|cmd| {
+                cmd.arg("clean")
+                    .arg("--yes")
+                    .arg(target)
+                    .arg("--days")
+                    .arg("1");
+            })
+            .success();
+    }
 
     #[test]
     fn cleans_without_issue() {
@@ -24,31 +52,109 @@ mod clean {
         sandbox.create_file(".proto/plugins/a_plugin.wasm", "{}");
         sandbox.create_file(".proto/plugins/b_plugin.wasm", "{}");
 
-        fs::File::options()
-            .write(true)
-            .open(sandbox.path().join(".proto/plugins/a_plugin.wasm"))
-            .unwrap()
-            .set_times(
-                fs::FileTimes::new().set_accessed(
-                    SystemTime::now()
-                        .checked_sub(Duration::from_secs(86400 * 2))
-                        .unwrap(),
-                ),
-            )
-            .unwrap();
+        make_stale(sandbox.path().join(".proto/plugins/a_plugin.wasm"));
 
-        sandbox
-            .run_bin(|cmd| {
-                cmd.arg("clean")
-                    .arg("--yes")
-                    .arg("plugins")
-                    .arg("--days")
-                    .arg("1");
-            })
-            .success();
+        run_clean(&sandbox, "plugins");
 
         assert!(!sandbox.path().join(".proto/plugins/a_plugin.wasm").exists());
         assert!(sandbox.path().join(".proto/plugins/b_plugin.wasm").exists());
+    }
+
+    #[test]
+    fn cleans_cache_subdirectories() {
+        let sandbox = create_empty_proto_sandbox();
+        sandbox.create_file(".proto/cache/requests-v2/nested/stale.json", "{}");
+
+        make_stale(
+            sandbox
+                .path()
+                .join(".proto/cache/requests-v2/nested/stale.json"),
+        );
+
+        run_clean(&sandbox, "cache");
+
+        assert!(!sandbox.path().join(".proto/cache/requests-v2").exists());
+
+        // But never the cache directory itself
+        assert!(sandbox.path().join(".proto/cache").exists());
+    }
+
+    #[test]
+    fn keeps_fresh_files_in_cache_subdirectories() {
+        let sandbox = create_empty_proto_sandbox();
+        sandbox.create_file(".proto/cache/registry/fresh.json", "{}");
+
+        run_clean(&sandbox, "cache");
+
+        assert!(
+            sandbox
+                .path()
+                .join(".proto/cache/registry/fresh.json")
+                .exists()
+        );
+    }
+
+    #[test]
+    fn doesnt_clean_dot_directories_in_cache() {
+        let sandbox = create_empty_proto_sandbox();
+        sandbox.create_file(".proto/cache/.internal/stale.json", "{}");
+
+        make_stale(sandbox.path().join(".proto/cache/.internal/stale.json"));
+
+        run_clean(&sandbox, "cache");
+
+        assert!(
+            sandbox
+                .path()
+                .join(".proto/cache/.internal/stale.json")
+                .exists()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn doesnt_follow_or_delete_symlinks_in_cache() {
+        let sandbox = create_empty_proto_sandbox();
+        sandbox.create_file("external/stale.json", "{}");
+
+        make_stale(sandbox.path().join("external/stale.json"));
+
+        fs::create_dir_all(sandbox.path().join(".proto/cache")).unwrap();
+
+        std::os::unix::fs::symlink(
+            sandbox.path().join("external"),
+            sandbox.path().join(".proto/cache/linked"),
+        )
+        .unwrap();
+
+        std::os::unix::fs::symlink(
+            sandbox.path().join("external/stale.json"),
+            sandbox.path().join(".proto/cache/linked.json"),
+        )
+        .unwrap();
+
+        run_clean(&sandbox, "cache");
+
+        assert!(sandbox.path().join("external/stale.json").exists());
+        assert!(sandbox.path().join(".proto/cache/linked").is_symlink());
+        assert!(sandbox.path().join(".proto/cache/linked.json").is_symlink());
+    }
+
+    #[test]
+    fn doesnt_recurse_into_temp() {
+        let sandbox = create_empty_proto_sandbox();
+        sandbox.create_file(".proto/temp/tool/hash/leftover.bin", "");
+
+        make_stale(sandbox.path().join(".proto/temp/tool/hash/leftover.bin"));
+
+        run_clean(&sandbox, "temp");
+
+        assert!(
+            sandbox
+                .path()
+                .join(".proto/temp/tool/hash/leftover.bin")
+                .exists()
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #1047

`clean_dir()` only iterated immediate children and only processed regular files, so `proto clean cache` never removed anything under `~/.proto/cache`: every entry there is a directory (`requests-v2`, `registry`), and the HTTP request cache inside `requests-v2` has no eviction of its own, so it grows without bound.

`clean_dir` now takes a `recurse` flag. For the cache target it recurses into subdirectories, removes stale files at any depth, and prunes a subdirectory once it becomes empty (tolerating `NotFound`/`DirectoryNotEmpty` from concurrent writers). The cache root itself is never removed and dot-prefixed entries keep being skipped. Entries are classified via `DirEntry::file_type()`, so symlinks are neither followed nor deleted.

The other two targets keep their previous top-level behavior deliberately:

- **plugins** stays shallow because the plugin cache layout is flat (`create_cache_path` writes `<plugins>/<id>-<hash>.<ext>`); there is nothing nested to clean.
- **temp** stays shallow because it is the one store directory with concurrent writers: installs hold a directory lock on `<temp>/<tool>/<hash>` (`fs::lock_directory`) and plugin downloads hold companion `<id>-<hash>.lock` files, and both flows already remove their own directories when they finish. A recursive cleaner would need to participate in those lock protocols non-blockingly, which `starbase_utils` has no primitive for today. Happy to follow up on that separately (e.g. a try-lock variant in `starbase_utils` plus layout-aware temp cleanup) if there's interest.

Two small behavior corrections that fall out of the rewrite:

- The dot-entry check now compares bytes instead of going through `to_str()`, which returned `None` for non-UTF-8 names and caused such dot entries to be deleted rather than skipped.
- Stale file symlinks at the top level were previously deleted (`Path::is_file()` follows links); symlinks are now always left alone.

Why not `starbase_utils::fs::remove_dir_stale_contents()`: it returns aggregate counts rather than the per-file results the CLI reports, and has no dot-entry or pruning policy.

Tests cover nested stale cache cleanup with pruning, fresh nested files surviving, dot directories untouched, directory and file symlinks preserved, and temp remaining top-level only. Also verified manually against a 10 GB real-world `~/.proto/cache`.
