### PR TITLE
registry: add dekit and gitui plugins

### DIFF
--- a/registry/data/third-party.json
+++ b/registry/data/third-party.json
@@ -389,6 +389,19 @@
       ]
     },
     {
+      "id": "dekit",
+      "locator": "https://raw.githubusercontent.com/IgnisDa/proto-plugins/main/dekit/plugin.toml",
+      "format": "toml",
+      "name": "dekit",
+      "description": "A scriptable process manager you drive from a CLI, TUI, API, or script.",
+      "author": "IgnisDa",
+      "homepageUrl": "https://github.com/pvolok/dekit",
+      "repositoryUrl": "https://github.com/IgnisDa/proto-plugins/tree/main/dekit",
+      "bins": [
+        "dekit"
+      ]
+    },
+    {
       "id": "direnv",
       "locator": "https://raw.githubusercontent.com/appthrust/proto-toml-plugins/main/direnv/plugin.toml",
       "format": "toml",
@@ -605,6 +618,20 @@
       "repositoryUrl": "https://github.com/Phault/proto-toml-plugins",
       "bins": [
         "gitleaks"
+      ]
+    },
+    {
+      "id": "gitui",
+      "locator": "https://raw.githubusercontent.com/IgnisDa/proto-plugins/main/gitui/plugin.toml",
+      "format": "toml",
+      "name": "gitui",
+      "description": "Blazing fast terminal-ui for git written in rust.",
+      "author": "IgnisDa",
+      "homepageUrl": "https://github.com/gitui-org/gitui",
+      "repositoryUrl": "https://github.com/IgnisDa/proto-plugins/tree/main/gitui",
+      "devicon": "git",
+      "bins": [
+        "gitui"
       ]
     },
     {


### PR DESCRIPTION
## Summary

Adds two new third-party TOML plugins to the registry:

- **dekit** — A scriptable process manager you drive from a CLI, TUI, API, or script ([pvolok/dekit](https://github.com/pvolok/dekit))
- **gitui** — Blazing fast terminal-ui for git written in rust ([gitui-org/gitui](https://github.com/gitui-org/gitui))

Both plugins are hosted at [IgnisDa/proto-plugins](https://github.com/IgnisDa/proto-plugins) and follow the same TOML plugin layout as [appthrust/proto-toml-plugins](https://github.com/appthrust/proto-toml-plugins).

## Plugin TOMLs

- `dekit`: https://raw.githubusercontent.com/IgnisDa/proto-plugins/main/dekit/plugin.toml
- `gitui`: https://raw.githubusercontent.com/IgnisDa/proto-plugins/main/gitui/plugin.toml

## Validation

- `cargo run -p proto_codegen` ran successfully; the diff is clean (only the two new entries, no formatting churn).
- Entries are sorted alphabetically by `id` and conform to the `PluginEntry` schema.
- The plugin repo has passing CI (installs + `--version` checks) on Linux, macOS (arm64 + x86_64), and Windows: https://github.com/IgnisDa/proto-plugins/actions

## Notes

- **dekit** is mid-rename from `mprocs`. The latest stable `v0.9.x` releases still ship assets under the legacy `mprocs-*` naming; the new `dekit-*` asset naming (with `SHA256SUMS` checksums) is available on the rolling `canary` release and will appear on the next stable release. The plugin targets the new naming, so `proto install dekit canary` works today and `proto install dekit <stable>` will work once the next stable ships.
- **gitui** does not publish checksum files, so downloads are not checksum-verified. The macOS asset naming is irregular (arm64 build has no arch suffix, x86_64 is suffixed `-x86`); this is handled with a per-platform `{arch}` mapping.