### PR TITLE
fix: prevent reporter stdout corruption

### DIFF
--- a/crates/cli/src/app.rs
+++ b/crates/cli/src/app.rs
@@ -216,9 +216,6 @@ impl App {
         self.json || self.reporter.is_some()
     }
 
-    /// Resolve the stdout owner for the current command. Exhaustive on
-    /// purpose: a new command must decide who owns its stdout, instead of
-    /// silently inheriting the reporter and its AI agent NDJSON fallback.
     pub fn stdout_owner(&self) -> StdoutOwner {
         match &self.command {
             Commands::Activate(args) => {
@@ -236,27 +233,7 @@ impl App {
                     StdoutOwner::McpStdio
                 }
             }
-            Commands::Alias(_)
-            | Commands::Bin(_)
-            | Commands::Clean(_)
-            | Commands::Debug { .. }
-            | Commands::Diagnose(_)
-            | Commands::Exec(_)
-            | Commands::Install(_)
-            | Commands::Migrate(_)
-            | Commands::Outdated(_)
-            | Commands::Pin(_)
-            | Commands::Plugin { .. }
-            | Commands::Regen(_)
-            | Commands::Run(_)
-            | Commands::Setup(_)
-            | Commands::Shell(_)
-            | Commands::Status(_)
-            | Commands::Unalias(_)
-            | Commands::Uninstall(_)
-            | Commands::Unpin(_)
-            | Commands::Upgrade(_)
-            | Commands::Versions(_) => StdoutOwner::Reporter,
+            _ => StdoutOwner::Reporter,
         }
     }
 

--- a/crates/cli/src/app.rs
+++ b/crates/cli/src/app.rs
@@ -6,7 +6,7 @@ use crate::commands::{
     plugin::{PluginAddArgs, PluginInfoArgs, PluginListArgs, PluginRemoveArgs, PluginSearchArgs},
 };
 use clap::builder::styling::{Color, Style, Styles};
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{ArgMatches, CommandFactory, FromArgMatches, Parser, Subcommand, ValueEnum};
 use proto_core::{ConfigMode, reporter::ReporterFormat};
 use starbase_styles::color::Color as ColorType;
 use std::{
@@ -14,14 +14,6 @@ use std::{
     fmt::{Display, Error, Formatter},
     path::PathBuf,
 };
-
-fn default_reporter() -> ReporterFormat {
-    if ai_env::is_ai_agent() {
-        ReporterFormat::Ndjson
-    } else {
-        ReporterFormat::Text
-    }
-}
 
 #[derive(ValueEnum, Clone, Debug, Default)]
 pub enum AppTheme {
@@ -166,14 +158,13 @@ pub struct App {
 
     #[arg(
         value_enum,
-        default_value_t = default_reporter(),
         long,
         short = 'r',
         global = true,
         env = "PROTO_REPORTER",
-        help = "Print output in a specific format"
+        help = "Print output in a specific format [default: text]"
     )]
-    pub reporter: ReporterFormat,
+    pub reporter: Option<ReporterFormat>,
 
     #[arg(
         value_enum,
@@ -199,8 +190,140 @@ pub struct App {
     pub command: Commands,
 }
 
+/// Who owns the stdout stream for the current command invocation.
+///
+/// Automatic NDJSON output is limited to reporter-owned stdout. Top-level
+/// errors for every other owner render on stderr.
+pub enum StdoutOwner {
+    Reporter(ReporterFormat),
+    RawPayload,
+    ShellCode,
+    CompletionCode,
+    McpStdio,
+    ChildProcess,
+}
+
 impl App {
-    pub fn setup_env_vars(&mut self) {
+    pub fn parse_with_reporter_precedence() -> Self {
+        let matches = Self::command().get_matches();
+        let mut app = Self::from_arg_matches(&matches).unwrap_or_else(|error| error.exit());
+
+        app.resolve_reporter_precedence(&matches);
+        app
+    }
+
+    /// Whether an output format was explicitly requested instead of being
+    /// automatically selected from the environment.
+    pub fn is_reporter_explicit(&self) -> bool {
+        self.explicit_reporter().is_some()
+    }
+
+    /// Resolve the stdout owner for the current command. Exhaustive on
+    /// purpose: a new command must decide who owns its stdout, instead of
+    /// silently inheriting the reporter and its AI agent NDJSON fallback.
+    pub fn stdout_owner(&self) -> StdoutOwner {
+        match &self.command {
+            Commands::Activate(args) => {
+                if let Some(format) = self.explicit_reporter()
+                    && format.is_json()
+                    && !args.export
+                {
+                    StdoutOwner::Reporter(format)
+                } else {
+                    StdoutOwner::ShellCode
+                }
+            }
+            Commands::Completions(_) => StdoutOwner::CompletionCode,
+            Commands::Mcp(args) => {
+                if args.info {
+                    StdoutOwner::Reporter(self.select_reporter())
+                } else {
+                    StdoutOwner::McpStdio
+                }
+            }
+            Commands::Bin(_) => {
+                if let Some(format) = self.explicit_reporter() {
+                    StdoutOwner::Reporter(format)
+                } else {
+                    StdoutOwner::RawPayload
+                }
+            }
+            Commands::Exec(_) | Commands::Run(_) | Commands::Shell(_) => StdoutOwner::ChildProcess,
+            Commands::Alias(_)
+            | Commands::Clean(_)
+            | Commands::Debug { .. }
+            | Commands::Diagnose(_)
+            | Commands::Install(_)
+            | Commands::Migrate(_)
+            | Commands::Outdated(_)
+            | Commands::Pin(_)
+            | Commands::Plugin { .. }
+            | Commands::Regen(_)
+            | Commands::Setup(_)
+            | Commands::Status(_)
+            | Commands::Unalias(_)
+            | Commands::Uninstall(_)
+            | Commands::Unpin(_)
+            | Commands::Upgrade(_)
+            | Commands::Versions(_) => StdoutOwner::Reporter(self.select_reporter()),
+        }
+    }
+
+    fn explicit_reporter(&self) -> Option<ReporterFormat> {
+        self.reporter.or(self.json.then_some(ReporterFormat::Json))
+    }
+
+    fn resolve_reporter_precedence(&mut self, matches: &ArgMatches) {
+        use clap::parser::ValueSource;
+
+        let json_source = if self.json {
+            matches.value_source("json")
+        } else {
+            None
+        };
+        let reporter_source = if self.reporter.is_some() {
+            matches.value_source("reporter")
+        } else {
+            None
+        };
+
+        // CLI options override environment variables. When both options come
+        // from the same source, the canonical reporter option wins over the
+        // legacy JSON alias.
+        let json_wins = matches!(
+            (json_source, reporter_source),
+            (
+                Some(ValueSource::CommandLine),
+                Some(ValueSource::EnvVariable) | None
+            ) | (Some(ValueSource::EnvVariable), None)
+        );
+
+        if json_wins {
+            self.reporter = None;
+        } else if reporter_source.is_some() {
+            self.json = false;
+        }
+    }
+
+    /// The reporter format when stdout is reporter-owned, otherwise text.
+    pub fn resolved_reporter(&self) -> ReporterFormat {
+        match self.stdout_owner() {
+            StdoutOwner::Reporter(format) => format,
+            _ => ReporterFormat::Text,
+        }
+    }
+
+    fn select_reporter(&self) -> ReporterFormat {
+        if let Some(format) = self.explicit_reporter() {
+            format
+        } else if ai_env::is_ai_agent() {
+            ReporterFormat::Ndjson
+        } else {
+            ReporterFormat::Text
+        }
+    }
+
+    pub fn setup_env_vars(&self) {
         unsafe {
             env::set_var("PROTO_APP_LOG", self.log.to_string());
             env::set_var("PROTO_VERSION", env!("CARGO_PKG_VERSION"));
@@ -221,17 +344,8 @@ impl App {
                 },
             );
 
-            // Convenience mapping
-            if self.json && !self.reporter.is_json() {
-                self.reporter = if ai_env::is_ai_agent() {
-                    ReporterFormat::Ndjson
-                } else {
-                    ReporterFormat::Json
-                };
-            }
-
             // Disable ANSI colors in JSON output
-            if self.json || self.reporter.is_json() {
+            if self.json || self.resolved_reporter().is_json() {
                 env::set_var("NO_COLOR", "1");
                 env::remove_var("FORCE_COLOR");
             }

--- a/crates/cli/src/app.rs
+++ b/crates/cli/src/app.rs
@@ -162,7 +162,7 @@ pub struct App {
         short = 'r',
         global = true,
         env = "PROTO_REPORTER",
-        help = "Print output in a specific format [default: text]"
+        help = "Print output in a specific format"
     )]
     pub reporter: Option<ReporterFormat>,
 
@@ -192,15 +192,15 @@ pub struct App {
 
 /// Who owns the stdout stream for the current command invocation.
 ///
-/// Automatic NDJSON output is limited to reporter-owned stdout. Top-level
-/// errors for every other owner render on stderr.
+/// Reporter-owned commands write formatted output to stdout. Every other
+/// owner reserves stdout for its protocol payload and routes reporter output
+/// to stderr.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum StdoutOwner {
-    Reporter(ReporterFormat),
-    RawPayload,
+    Reporter,
     ShellCode,
     CompletionCode,
     McpStdio,
-    ChildProcess,
 }
 
 impl App {
@@ -212,8 +212,8 @@ impl App {
         app
     }
 
-    /// Whether an output format was explicitly requested instead of being
-    /// automatically selected from the environment.
+    /// Whether an output format was explicitly requested instead of inferred
+    /// from AI-agent detection.
     pub fn is_reporter_explicit(&self) -> bool {
         self.explicit_reporter().is_some()
     }
@@ -228,7 +228,7 @@ impl App {
                     && format.is_json()
                     && !args.export
                 {
-                    StdoutOwner::Reporter(format)
+                    StdoutOwner::Reporter
                 } else {
                     StdoutOwner::ShellCode
                 }
@@ -236,36 +236,32 @@ impl App {
             Commands::Completions(_) => StdoutOwner::CompletionCode,
             Commands::Mcp(args) => {
                 if args.info {
-                    StdoutOwner::Reporter(self.select_reporter())
+                    StdoutOwner::Reporter
                 } else {
                     StdoutOwner::McpStdio
                 }
             }
-            Commands::Bin(_) => {
-                if let Some(format) = self.explicit_reporter() {
-                    StdoutOwner::Reporter(format)
-                } else {
-                    StdoutOwner::RawPayload
-                }
-            }
-            Commands::Exec(_) | Commands::Run(_) | Commands::Shell(_) => StdoutOwner::ChildProcess,
             Commands::Alias(_)
+            | Commands::Bin(_)
             | Commands::Clean(_)
             | Commands::Debug { .. }
             | Commands::Diagnose(_)
+            | Commands::Exec(_)
             | Commands::Install(_)
             | Commands::Migrate(_)
             | Commands::Outdated(_)
             | Commands::Pin(_)
             | Commands::Plugin { .. }
             | Commands::Regen(_)
+            | Commands::Run(_)
             | Commands::Setup(_)
+            | Commands::Shell(_)
             | Commands::Status(_)
             | Commands::Unalias(_)
             | Commands::Uninstall(_)
             | Commands::Unpin(_)
             | Commands::Upgrade(_)
-            | Commands::Versions(_) => StdoutOwner::Reporter(self.select_reporter()),
+            | Commands::Versions(_) => StdoutOwner::Reporter,
         }
     }
 
@@ -305,15 +301,8 @@ impl App {
         }
     }
 
-    /// The reporter format when stdout is reporter-owned, otherwise text.
-    pub fn resolved_reporter(&self) -> ReporterFormat {
-        match self.stdout_owner() {
-            StdoutOwner::Reporter(format) => format,
-            _ => ReporterFormat::Text,
-        }
-    }
-
-    fn select_reporter(&self) -> ReporterFormat {
+    /// Select the reporter format independently from stdout ownership.
+    pub fn reporter_format(&self) -> ReporterFormat {
         if let Some(format) = self.explicit_reporter() {
             format
         } else if ai_env::is_ai_agent() {
@@ -345,7 +334,7 @@ impl App {
             );
 
             // Disable ANSI colors in JSON output
-            if self.json || self.resolved_reporter().is_json() {
+            if self.reporter_format().is_json() {
                 env::set_var("NO_COLOR", "1");
                 env::remove_var("FORCE_COLOR");
             }

--- a/crates/cli/src/app.rs
+++ b/crates/cli/src/app.rs
@@ -6,7 +6,7 @@ use crate::commands::{
     plugin::{PluginAddArgs, PluginInfoArgs, PluginListArgs, PluginRemoveArgs, PluginSearchArgs},
 };
 use clap::builder::styling::{Color, Style, Styles};
-use clap::{ArgMatches, CommandFactory, FromArgMatches, Parser, Subcommand, ValueEnum};
+use clap::{Parser, Subcommand, ValueEnum};
 use proto_core::{ConfigMode, reporter::ReporterFormat};
 use starbase_styles::color::Color as ColorType;
 use std::{
@@ -14,6 +14,14 @@ use std::{
     fmt::{Display, Error, Formatter},
     path::PathBuf,
 };
+
+fn default_reporter() -> ReporterFormat {
+    if ai_env::is_ai_agent() {
+        ReporterFormat::Ndjson
+    } else {
+        ReporterFormat::Text
+    }
+}
 
 #[derive(ValueEnum, Clone, Debug, Default)]
 pub enum AppTheme {
@@ -204,18 +212,8 @@ pub enum StdoutOwner {
 }
 
 impl App {
-    pub fn parse_with_reporter_precedence() -> Self {
-        let matches = Self::command().get_matches();
-        let mut app = Self::from_arg_matches(&matches).unwrap_or_else(|error| error.exit());
-
-        app.resolve_reporter_precedence(&matches);
-        app
-    }
-
-    /// Whether an output format was explicitly requested instead of inferred
-    /// from AI-agent detection.
     pub fn is_reporter_explicit(&self) -> bool {
-        self.explicit_reporter().is_some()
+        self.json || self.reporter.is_some()
     }
 
     /// Resolve the stdout owner for the current command. Exhaustive on
@@ -224,10 +222,7 @@ impl App {
     pub fn stdout_owner(&self) -> StdoutOwner {
         match &self.command {
             Commands::Activate(args) => {
-                if let Some(format) = self.explicit_reporter()
-                    && format.is_json()
-                    && !args.export
-                {
+                if self.is_reporter_explicit() && self.reporter_format().is_json() && !args.export {
                     StdoutOwner::Reporter
                 } else {
                     StdoutOwner::ShellCode
@@ -265,50 +260,12 @@ impl App {
         }
     }
 
-    fn explicit_reporter(&self) -> Option<ReporterFormat> {
-        self.reporter.or(self.json.then_some(ReporterFormat::Json))
-    }
-
-    fn resolve_reporter_precedence(&mut self, matches: &ArgMatches) {
-        use clap::parser::ValueSource;
-
-        let json_source = if self.json {
-            matches.value_source("json")
-        } else {
-            None
-        };
-        let reporter_source = if self.reporter.is_some() {
-            matches.value_source("reporter")
-        } else {
-            None
-        };
-
-        // CLI options override environment variables. When both options come
-        // from the same source, the canonical reporter option wins over the
-        // legacy JSON alias.
-        let json_wins = matches!(
-            (json_source, reporter_source),
-            (
-                Some(ValueSource::CommandLine),
-                Some(ValueSource::EnvVariable) | None
-            ) | (Some(ValueSource::EnvVariable), None)
-        );
-
-        if json_wins {
-            self.reporter = None;
-        } else if reporter_source.is_some() {
-            self.json = false;
-        }
-    }
-
-    /// Select the reporter format independently from stdout ownership.
     pub fn reporter_format(&self) -> ReporterFormat {
-        if let Some(format) = self.explicit_reporter() {
-            format
-        } else if ai_env::is_ai_agent() {
-            ReporterFormat::Ndjson
-        } else {
-            ReporterFormat::Text
+        match self.reporter {
+            Some(format) if format.is_json() => format,
+            _ if self.json => ReporterFormat::Json,
+            Some(format) => format,
+            None => default_reporter(),
         }
     }
 

--- a/crates/cli/src/commands/activate.rs
+++ b/crates/cli/src/commands/activate.rs
@@ -1,3 +1,4 @@
+use crate::app::StdoutOwner;
 use crate::session::{LoadToolOptions, ProtoSession, SessionResult};
 use crate::workflows::{ExecWorkflow, ExecWorkflowParams};
 use clap::Args;
@@ -25,7 +26,7 @@ pub struct ActivateArgs {
         long,
         help = "Print the activate instructions in shell specific-syntax"
     )]
-    export: bool,
+    pub export: bool,
 
     #[arg(long, help = "Don't include ~/.proto/bin in path lookup")]
     no_bin: bool,
@@ -37,6 +38,13 @@ pub struct ActivateArgs {
     no_shim: bool,
 }
 
+#[derive(PartialEq)]
+enum ActivateOutputMode {
+    Hook,
+    Export,
+    Structured,
+}
+
 #[instrument(skip(session))]
 pub async fn activate(session: ProtoSession, args: ActivateArgs) -> SessionResult {
     // Detect the shell that we need to activate for
@@ -45,8 +53,15 @@ pub async fn activate(session: ProtoSession, args: ActivateArgs) -> SessionResul
         None => ShellType::try_detect()?,
     };
 
-    // If not exporting data, just print the activation syntax immediately
-    if !args.export && !session.is_json_format() {
+    // Shell code is this command's default protocol; see `App::stdout_owner`
+    let output_mode = match session.cli.stdout_owner() {
+        StdoutOwner::Reporter(_) => ActivateOutputMode::Structured,
+        _ if args.export => ActivateOutputMode::Export,
+        _ => ActivateOutputMode::Hook,
+    };
+
+    // Hook mode does not need to load tools or build an environment.
+    if output_mode == ActivateOutputMode::Hook {
         print_activation_hook(&session, &shell_type, &args)?;
 
         return Ok(None);
@@ -126,21 +141,19 @@ pub async fn activate(session: ProtoSession, args: ActivateArgs) -> SessionResul
     }
 
     // Output/export the information for the chosen shell
-    if args.export {
+    if output_mode == ActivateOutputMode::Export {
         print_activation_exports(&session, &shell_type, workflow)?;
 
         return Ok(None);
     }
 
-    if session.is_json_format() {
-        session.console.write_json_for_format(ActivateOutput {
-            path: workflow
-                .reset_and_join_paths_for_shell(&session.env.store.dir, &shell_type)?
-                .into_string()
-                .ok(),
-            env: workflow.env,
-        })?;
-    }
+    session.console.write_json_for_format(ActivateOutput {
+        path: workflow
+            .reset_and_join_paths_for_shell(&session.env.store.dir, &shell_type)?
+            .into_string()
+            .ok(),
+        env: workflow.env,
+    })?;
 
     Ok(None)
 }
@@ -168,7 +181,7 @@ fn print_activation_hook(
     match shell_type {
         // These operate on JSON
         ShellType::Nu => {
-            command.push_str(" --json");
+            command.push_str(" --reporter json");
         }
         // While these evaluate shell syntax
         _ => {

--- a/crates/cli/src/commands/activate.rs
+++ b/crates/cli/src/commands/activate.rs
@@ -55,9 +55,12 @@ pub async fn activate(session: ProtoSession, args: ActivateArgs) -> SessionResul
 
     // Shell code is this command's default protocol; see `App::stdout_owner`
     let output_mode = match session.cli.stdout_owner() {
-        StdoutOwner::Reporter(_) => ActivateOutputMode::Structured,
-        _ if args.export => ActivateOutputMode::Export,
-        _ => ActivateOutputMode::Hook,
+        StdoutOwner::Reporter => ActivateOutputMode::Structured,
+        StdoutOwner::ShellCode if args.export => ActivateOutputMode::Export,
+        StdoutOwner::ShellCode => ActivateOutputMode::Hook,
+        StdoutOwner::CompletionCode | StdoutOwner::McpStdio => {
+            unreachable!("activate resolved to an unrelated stdout owner")
+        }
     };
 
     // Hook mode does not need to load tools or build an environment.

--- a/crates/cli/src/commands/mcp.rs
+++ b/crates/cli/src/commands/mcp.rs
@@ -15,7 +15,7 @@ pub struct McpArgs {
         long,
         help = "Display server information and list available tools and resources"
     )]
-    info: bool,
+    pub info: bool,
 }
 
 #[derive(Serialize)]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -11,8 +11,7 @@ mod telemetry;
 mod utils;
 mod workflows;
 
-use app::{App as CLI, Commands, DebugCommands, PluginCommands};
-use clap::Parser;
+use app::{App as CLI, Commands, DebugCommands, PluginCommands, StdoutOwner};
 use proto_core::reporter::ReporterFormat;
 use session::ProtoSession;
 use starbase::{
@@ -37,21 +36,19 @@ fn get_tracing_modules() -> Vec<String> {
 }
 
 async fn async_main() -> MainResult {
-    let mut cli = CLI::parse();
+    let cli = CLI::parse_with_reporter_precedence();
     cli.setup_env_vars();
 
     let app = App::default();
     app.setup_diagnostics();
 
-    let is_exec_command = matches!(
-        cli.command,
-        Commands::Exec { .. } | Commands::Run { .. } | Commands::Shell { .. }
-    );
+    let stdout_owner = cli.stdout_owner();
+    let is_exec_command = matches!(stdout_owner, StdoutOwner::ChildProcess);
 
     let _guard = app.setup_tracing(TracingOptions {
         default_level: if is_exec_command || matches!(cli.command, Commands::Bin { .. }) {
             LogLevel::Warn
-        } else if matches!(cli.command, Commands::Completions { .. }) {
+        } else if matches!(stdout_owner, StdoutOwner::CompletionCode) {
             LogLevel::Off
         } else {
             LogLevel::Info
@@ -60,7 +57,7 @@ async fn async_main() -> MainResult {
         filter_modules: get_tracing_modules(),
         log_env: "PROTO_APP_LOG".into(),
         log_file: cli.log_file.clone(),
-        ndjson: cli.reporter == ReporterFormat::Ndjson,
+        ndjson: cli.resolved_reporter() == ReporterFormat::Ndjson,
         otel: OtelOptions {
             enabled: cli.otel,
             logs_enabled: cli.otel_logs,
@@ -126,9 +123,8 @@ async fn async_main() -> MainResult {
         .await;
 
     if let Some(error) = outcome.error {
-        // If NDJSON format, we must print the error as JSON so
-        // that it parses correctly by the consumer!
-        if session.cli.reporter == ReporterFormat::Ndjson {
+        // Keep reporter-owned NDJSON errors machine-readable.
+        if session.cli.resolved_reporter() == ReporterFormat::Ndjson {
             session
                 .console
                 .main_error(error.to_string(), error.code().map(|code| code.to_string()))?;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -12,6 +12,7 @@ mod utils;
 mod workflows;
 
 use app::{App as CLI, Commands, DebugCommands, PluginCommands, StdoutOwner};
+use clap::Parser;
 use proto_core::reporter::ReporterFormat;
 use session::ProtoSession;
 use starbase::{
@@ -36,7 +37,7 @@ fn get_tracing_modules() -> Vec<String> {
 }
 
 async fn async_main() -> MainResult {
-    let cli = CLI::parse_with_reporter_precedence();
+    let cli = CLI::parse();
     cli.setup_env_vars();
 
     let app = App::default();

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -43,7 +43,10 @@ async fn async_main() -> MainResult {
     app.setup_diagnostics();
 
     let stdout_owner = cli.stdout_owner();
-    let is_exec_command = matches!(stdout_owner, StdoutOwner::ChildProcess);
+    let is_exec_command = matches!(
+        &cli.command,
+        Commands::Exec(_) | Commands::Run(_) | Commands::Shell(_)
+    );
 
     let _guard = app.setup_tracing(TracingOptions {
         default_level: if is_exec_command || matches!(cli.command, Commands::Bin { .. }) {
@@ -57,7 +60,7 @@ async fn async_main() -> MainResult {
         filter_modules: get_tracing_modules(),
         log_env: "PROTO_APP_LOG".into(),
         log_file: cli.log_file.clone(),
-        ndjson: cli.resolved_reporter() == ReporterFormat::Ndjson,
+        ndjson: cli.reporter_format() == ReporterFormat::Ndjson,
         otel: OtelOptions {
             enabled: cli.otel,
             logs_enabled: cli.otel_logs,
@@ -123,12 +126,12 @@ async fn async_main() -> MainResult {
         .await;
 
     if let Some(error) = outcome.error {
-        // Keep reporter-owned NDJSON errors machine-readable.
-        if session.cli.resolved_reporter() == ReporterFormat::Ndjson {
+        // Keep NDJSON errors machine-readable without violating stdout
+        // ownership. The reporter stream is configured by ProtoSession.
+        if session.cli.reporter_format() == ReporterFormat::Ndjson {
             session
                 .console
                 .main_error(error.to_string(), error.code().map(|code| code.to_string()))?;
-            session.console.out.flush()?;
 
             if outcome.exit_code == 0 {
                 outcome.exit_code = 1;

--- a/crates/cli/src/session.rs
+++ b/crates/cli/src/session.rs
@@ -334,7 +334,7 @@ impl ProtoSession {
     }
 
     pub fn is_json_format(&self) -> bool {
-        self.cli.json || self.console.is_json_format()
+        self.console.is_json_format()
     }
 
     pub fn is_tty(&self) -> bool {
@@ -351,8 +351,6 @@ impl AppSession for ProtoSession {
     type Error = miette::Report;
 
     async fn startup(&mut self) -> AppResult<Self::Error> {
-        // Only mention an automatically selected NDJSON reporter; an
-        // explicit request doesn't need the notice
         if self.cli.stdout_owner() == StdoutOwner::Reporter
             && !self.cli.is_reporter_explicit()
             && self.cli.reporter_format() == ReporterFormat::Ndjson

--- a/crates/cli/src/session.rs
+++ b/crates/cli/src/session.rs
@@ -351,8 +351,8 @@ impl AppSession for ProtoSession {
     type Error = miette::Report;
 
     async fn startup(&mut self) -> AppResult<Self::Error> {
-        if self.cli.stdout_owner() == StdoutOwner::Reporter
-            && !self.cli.is_reporter_explicit()
+        if ai_env::is_ai_agent()
+            && self.cli.stdout_owner() == StdoutOwner::Reporter
             && self.cli.reporter_format() == ReporterFormat::Ndjson
         {
             self.console.message("Detected an AI agent environment, printing as NDJSON. Trace logs are written to stderr, while user-facing logs are written to stdout.")?;

--- a/crates/cli/src/session.rs
+++ b/crates/cli/src/session.rs
@@ -1,4 +1,4 @@
-use crate::app::{App as CLI, Commands};
+use crate::app::{App as CLI, Commands, StdoutOwner};
 use crate::commands::clean::{CleanArgs, CleanTarget, internal_clean};
 use crate::helpers::create_console_theme;
 use crate::systems::*;
@@ -52,7 +52,7 @@ impl ProtoSession {
         console.set_reporter(if env.test_only {
             ProtoReporter::new_testing()
         } else {
-            ProtoReporter::new(cli.reporter)
+            ProtoReporter::new(cli.resolved_reporter())
         });
 
         Self {
@@ -64,14 +64,15 @@ impl ProtoSession {
     }
 
     pub fn should_check_for_new_version(&self) -> bool {
+        if !matches!(self.cli.stdout_owner(), StdoutOwner::Reporter(_)) {
+            return false;
+        }
+
         !matches!(
             self.cli.command,
             Commands::Activate(_)
                 | Commands::Bin(_)
                 | Commands::Clean(_)
-                | Commands::Completions(_)
-                | Commands::Exec(_)
-                | Commands::Run(_)
                 | Commands::Setup(_)
                 | Commands::Upgrade(_)
         )
@@ -346,7 +347,11 @@ impl AppSession for ProtoSession {
     type Error = miette::Report;
 
     async fn startup(&mut self) -> AppResult<Self::Error> {
-        if self.cli.reporter == ReporterFormat::Ndjson && ai_env::is_ai_agent() {
+        // Only mention an automatically selected NDJSON reporter; an
+        // explicit request doesn't need the notice
+        if !self.cli.is_reporter_explicit()
+            && self.cli.resolved_reporter() == ReporterFormat::Ndjson
+        {
             self.console.message("Detected an AI agent environment, printing as NDJSON. Trace logs are written to stderr, while user-facing logs are written to stdout.")?;
         }
 
@@ -402,5 +407,26 @@ impl AppSession for ProtoSession {
         self.console.err.flush()?;
 
         Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn version_checks_require_reporter_owned_stdout() {
+        let shell = CLI::try_parse_from(["proto", "shell", "--shell", "bash"]).unwrap();
+        assert!(!ProtoSession::new(shell).should_check_for_new_version());
+
+        let status = CLI::try_parse_from(["proto", "status"]).unwrap();
+        assert!(ProtoSession::new(status).should_check_for_new_version());
+
+        let mcp = CLI::try_parse_from(["proto", "mcp"]).unwrap();
+        assert!(!ProtoSession::new(mcp).should_check_for_new_version());
+
+        let mcp_info = CLI::try_parse_from(["proto", "mcp", "--info"]).unwrap();
+        assert!(ProtoSession::new(mcp_info).should_check_for_new_version());
     }
 }

--- a/crates/cli/src/session.rs
+++ b/crates/cli/src/session.rs
@@ -42,6 +42,23 @@ pub struct ProtoSession {
     pub env: Arc<ProtoEnvironment>,
 }
 
+fn should_check_for_new_version(cli: &CLI) -> bool {
+    if cli.stdout_owner() != StdoutOwner::Reporter {
+        return false;
+    }
+
+    !matches!(
+        &cli.command,
+        Commands::Activate(_)
+            | Commands::Bin(_)
+            | Commands::Clean(_)
+            | Commands::Exec(_)
+            | Commands::Run(_)
+            | Commands::Setup(_)
+            | Commands::Upgrade(_)
+    )
+}
+
 impl ProtoSession {
     pub fn new(cli: CLI) -> Self {
         let mut env = ProtoEnvironment::default();
@@ -51,8 +68,10 @@ impl ProtoSession {
         console.set_theme(create_console_theme());
         console.set_reporter(if env.test_only {
             ProtoReporter::new_testing()
+        } else if cli.stdout_owner() == StdoutOwner::Reporter {
+            ProtoReporter::new(cli.reporter_format())
         } else {
-            ProtoReporter::new(cli.resolved_reporter())
+            ProtoReporter::new_stderr(cli.reporter_format())
         });
 
         Self {
@@ -61,21 +80,6 @@ impl ProtoSession {
             console,
             env: Arc::new(env),
         }
-    }
-
-    pub fn should_check_for_new_version(&self) -> bool {
-        if !matches!(self.cli.stdout_owner(), StdoutOwner::Reporter(_)) {
-            return false;
-        }
-
-        !matches!(
-            self.cli.command,
-            Commands::Activate(_)
-                | Commands::Bin(_)
-                | Commands::Clean(_)
-                | Commands::Setup(_)
-                | Commands::Upgrade(_)
-        )
     }
 
     pub fn create_registry(&self) -> ProtoRegistry {
@@ -349,8 +353,9 @@ impl AppSession for ProtoSession {
     async fn startup(&mut self) -> AppResult<Self::Error> {
         // Only mention an automatically selected NDJSON reporter; an
         // explicit request doesn't need the notice
-        if !self.cli.is_reporter_explicit()
-            && self.cli.resolved_reporter() == ReporterFormat::Ndjson
+        if self.cli.stdout_owner() == StdoutOwner::Reporter
+            && !self.cli.is_reporter_explicit()
+            && self.cli.reporter_format() == ReporterFormat::Ndjson
         {
             self.console.message("Detected an AI agent environment, printing as NDJSON. Trace logs are written to stderr, while user-facing logs are written to stdout.")?;
         }
@@ -370,7 +375,7 @@ impl AppSession for ProtoSession {
         remove_proto_shims(&self.env)?;
         clean_proto_backups(&self.env)?;
 
-        if self.should_check_for_new_version() {
+        if should_check_for_new_version(&self.cli) {
             check_for_new_version(&self.env, &self.console, &self.cli_version).await?;
         }
 
@@ -418,15 +423,15 @@ mod tests {
     #[test]
     fn version_checks_require_reporter_owned_stdout() {
         let shell = CLI::try_parse_from(["proto", "shell", "--shell", "bash"]).unwrap();
-        assert!(!ProtoSession::new(shell).should_check_for_new_version());
+        assert!(should_check_for_new_version(&shell));
 
         let status = CLI::try_parse_from(["proto", "status"]).unwrap();
-        assert!(ProtoSession::new(status).should_check_for_new_version());
+        assert!(should_check_for_new_version(&status));
 
         let mcp = CLI::try_parse_from(["proto", "mcp"]).unwrap();
-        assert!(!ProtoSession::new(mcp).should_check_for_new_version());
+        assert!(!should_check_for_new_version(&mcp));
 
         let mcp_info = CLI::try_parse_from(["proto", "mcp", "--info"]).unwrap();
-        assert!(ProtoSession::new(mcp_info).should_check_for_new_version());
+        assert!(should_check_for_new_version(&mcp_info));
     }
 }

--- a/crates/cli/src/workflows/install_workflow.rs
+++ b/crates/cli/src/workflows/install_workflow.rs
@@ -348,9 +348,9 @@ impl InstallWorkflow {
                     force: params.force,
                     log_writer: params.log_writer.clone(),
                     skip_prompts: params.skip_prompts,
-                    // When installing multiple tools, we can't render the nice
-                    // UI for the build flow, so rely on the progress bars
-                    skip_ui: params.multiple,
+                    // Multiple installs have a shared progress UI, while quiet
+                    // callers such as the MCP server must not render one.
+                    skip_ui: params.multiple || params.quiet,
                     strategy: params.strategy.unwrap_or(default_strategy),
                 },
             )

--- a/crates/cli/tests/activate_test.rs
+++ b/crates/cli/tests/activate_test.rs
@@ -128,8 +128,6 @@ moonstone = "2.0.0"
     mod ai_agent {
         use super::*;
 
-        // Use the real reporter with AI agent detection forced on.
-
         #[test]
         fn prints_hook_by_default() {
             let sandbox = create_empty_proto_sandbox();
@@ -248,12 +246,22 @@ moonstone = "2.0.0"
                     .env_remove("PROTO_SANDBOX")
                     .env_remove("PROTO_TEST");
             });
+            let stderr = assert.stderr();
+            let records = stderr
+                .lines()
+                .filter(|line| !line.trim().is_empty())
+                .map(|line| {
+                    serde_json::from_str::<serde_json::Value>(line).unwrap_or_else(|error| {
+                        panic!("stderr line is not valid NDJSON: {line}: {error}")
+                    })
+                })
+                .collect::<Vec<_>>();
 
             // The failure must render on stderr because stdout is evaluated.
-            assert
-                .failure()
-                .stdout(predicate::str::is_empty())
-                .stderr(predicate::str::is_empty().not());
+            assert.failure().stdout(predicate::str::is_empty());
+            assert!(records.iter().any(|record| {
+                record.get("type").and_then(|value| value.as_str()) == Some("error")
+            }));
         }
 
         #[test]
@@ -273,6 +281,32 @@ moonstone = "2.0.0"
                 predicate::str::contains("_PROTO_ACTIVATED_PATH")
                     .and(predicate::str::contains("{\"type\":").not()),
             );
+        }
+
+        #[test]
+        fn keeps_ndjson_tracing_for_shell_output() {
+            let sandbox = create_empty_proto_sandbox();
+
+            let assert = sandbox.run_bin(|cmd| {
+                cmd.arg("activate")
+                    .arg("zsh")
+                    .arg("--export")
+                    .arg("--reporter")
+                    .arg("ndjson")
+                    .arg("--log")
+                    .arg("debug")
+                    .env_remove("PROTO_TEST");
+            });
+            let stderr = assert.stderr();
+
+            assert.success();
+            assert!(!stderr.trim().is_empty());
+
+            for line in stderr.lines().filter(|line| !line.trim().is_empty()) {
+                serde_json::from_str::<serde_json::Value>(line).unwrap_or_else(|error| {
+                    panic!("stderr line is not valid NDJSON: {line}: {error}")
+                });
+            }
         }
     }
 

--- a/crates/cli/tests/activate_test.rs
+++ b/crates/cli/tests/activate_test.rs
@@ -2,6 +2,7 @@
 #[cfg(unix)]
 mod activate {
     use proto_core::test_utils::*;
+    use starbase_sandbox::predicates::prelude::*;
     use starbase_sandbox::{Sandbox, SandboxAssert, assert_snapshot};
     use starbase_shell::ShellType;
 
@@ -121,6 +122,157 @@ moonstone = "2.0.0"
             });
 
             assert_snapshot!(get_activate_output(&assert, &sandbox));
+        }
+    }
+
+    mod ai_agent {
+        use super::*;
+
+        // Use the real reporter with AI agent detection forced on.
+
+        #[test]
+        fn prints_hook_by_default() {
+            let sandbox = create_empty_proto_sandbox();
+
+            let assert = sandbox.run_bin(|cmd| {
+                cmd.arg("activate")
+                    .arg("zsh")
+                    .env("CODEX_CI", "1")
+                    .env_remove("PROTO_TEST");
+            });
+            assert.success().stdout(
+                predicate::str::contains("_proto_activate_hook")
+                    .and(predicate::str::contains("{\"type\":").not())
+                    .and(predicate::str::contains("Detected an AI agent").not()),
+            );
+        }
+
+        #[test]
+        fn prints_shell_syntax_for_export() {
+            let sandbox = create_empty_proto_sandbox();
+
+            let assert = sandbox.run_bin(|cmd| {
+                cmd.arg("activate")
+                    .arg("zsh")
+                    .arg("--export")
+                    .env("CODEX_CI", "1")
+                    .env_remove("PROTO_TEST");
+            });
+            assert.success().stdout(
+                predicate::str::contains("_PROTO_ACTIVATED_PATH")
+                    .and(predicate::str::contains("{\"type\":").not()),
+            );
+        }
+
+        #[test]
+        fn prints_plain_json_for_explicit_json() {
+            let sandbox = create_empty_proto_sandbox();
+
+            let assert = sandbox.run_bin(|cmd| {
+                cmd.arg("activate")
+                    .arg("zsh")
+                    .arg("--json")
+                    .env("CODEX_CI", "1")
+                    .env_remove("PROTO_TEST");
+            });
+            let stdout = assert.stdout();
+            assert.success();
+            let output: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+
+            assert!(output.get("env").is_some());
+            assert!(output.get("path").is_some());
+        }
+
+        #[test]
+        fn prints_structured_data_for_explicit_reporter() {
+            let sandbox = create_empty_proto_sandbox();
+
+            let assert = sandbox.run_bin(|cmd| {
+                cmd.arg("activate")
+                    .arg("zsh")
+                    .arg("--reporter")
+                    .arg("ndjson")
+                    .env("CODEX_CI", "1")
+                    .env_remove("PROTO_TEST");
+            });
+            assert.success().stdout(
+                predicate::str::contains("{\"type\":\"data\"")
+                    .and(predicate::str::contains("Detected an AI agent").not()),
+            );
+        }
+
+        #[test]
+        fn nu_hook_requests_explicit_json() {
+            let sandbox = create_empty_proto_sandbox();
+
+            let assert = sandbox.run_bin(|cmd| {
+                cmd.arg("activate")
+                    .arg("nu")
+                    .env("CODEX_CI", "1")
+                    .env_remove("PROTO_TEST");
+            });
+            assert.success().stdout(
+                predicate::str::contains("proto activate nu --reporter json")
+                    .and(predicate::str::contains("\"type\":").not()),
+            );
+
+            // The nested call the hook makes must parse as plain JSON
+            let assert = sandbox.run_bin(|cmd| {
+                cmd.arg("activate")
+                    .arg("nu")
+                    .arg("--reporter")
+                    .arg("json")
+                    .env("CODEX_CI", "1")
+                    .env_remove("PROTO_TEST");
+            });
+            let stdout = assert.stdout();
+            assert.success();
+            let output: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+
+            assert!(output.get("env").is_some());
+        }
+
+        #[test]
+        fn keeps_stdout_empty_when_export_fails() {
+            let sandbox = create_empty_proto_sandbox();
+
+            let assert = sandbox.run_bin(|cmd| {
+                cmd.arg("activate")
+                    .arg("zsh")
+                    .arg("--export")
+                    .arg("--reporter")
+                    .arg("ndjson")
+                    .env("CODEX_CI", "1")
+                    // An unusable store location makes the command fail
+                    .env("PROTO_HOME", "/dev/null/proto")
+                    .env_remove("PROTO_SANDBOX")
+                    .env_remove("PROTO_TEST");
+            });
+
+            // The failure must render on stderr because stdout is evaluated.
+            assert
+                .failure()
+                .stdout(predicate::str::is_empty())
+                .stderr(predicate::str::is_empty().not());
+        }
+
+        #[test]
+        fn export_wins_over_structured_reporter() {
+            let sandbox = create_empty_proto_sandbox();
+
+            let assert = sandbox.run_bin(|cmd| {
+                cmd.arg("activate")
+                    .arg("zsh")
+                    .arg("--export")
+                    .arg("--reporter")
+                    .arg("ndjson")
+                    .env("CODEX_CI", "1")
+                    .env_remove("PROTO_TEST");
+            });
+            assert.success().stdout(
+                predicate::str::contains("_PROTO_ACTIVATED_PATH")
+                    .and(predicate::str::contains("{\"type\":").not()),
+            );
         }
     }
 

--- a/crates/cli/tests/activate_test.rs
+++ b/crates/cli/tests/activate_test.rs
@@ -136,7 +136,7 @@ moonstone = "2.0.0"
                 cmd.arg("activate")
                     .arg("zsh")
                     .env("CODEX_CI", "1")
-                    .env_remove("PROTO_TEST");
+                    .env_remove("PROTO_REPORTER");
             });
             assert.success().stdout(
                 predicate::str::contains("_proto_activate_hook")
@@ -154,7 +154,7 @@ moonstone = "2.0.0"
                     .arg("zsh")
                     .arg("--export")
                     .env("CODEX_CI", "1")
-                    .env_remove("PROTO_TEST");
+                    .env_remove("PROTO_REPORTER");
             });
             assert.success().stdout(
                 predicate::str::contains("_PROTO_ACTIVATED_PATH")
@@ -171,7 +171,7 @@ moonstone = "2.0.0"
                     .arg("zsh")
                     .arg("--json")
                     .env("CODEX_CI", "1")
-                    .env_remove("PROTO_TEST");
+                    .env_remove("PROTO_REPORTER");
             });
             let stdout = assert.stdout();
             assert.success();
@@ -190,8 +190,7 @@ moonstone = "2.0.0"
                     .arg("zsh")
                     .arg("--reporter")
                     .arg("ndjson")
-                    .env("CODEX_CI", "1")
-                    .env_remove("PROTO_TEST");
+                    .env("CODEX_CI", "1");
             });
             assert.success().stdout(
                 predicate::str::contains("{\"type\":\"data\"")
@@ -207,7 +206,7 @@ moonstone = "2.0.0"
                 cmd.arg("activate")
                     .arg("nu")
                     .env("CODEX_CI", "1")
-                    .env_remove("PROTO_TEST");
+                    .env_remove("PROTO_REPORTER");
             });
             assert.success().stdout(
                 predicate::str::contains("proto activate nu --reporter json")
@@ -220,8 +219,7 @@ moonstone = "2.0.0"
                     .arg("nu")
                     .arg("--reporter")
                     .arg("json")
-                    .env("CODEX_CI", "1")
-                    .env_remove("PROTO_TEST");
+                    .env("CODEX_CI", "1");
             });
             let stdout = assert.stdout();
             assert.success();
@@ -274,8 +272,7 @@ moonstone = "2.0.0"
                     .arg("--export")
                     .arg("--reporter")
                     .arg("ndjson")
-                    .env("CODEX_CI", "1")
-                    .env_remove("PROTO_TEST");
+                    .env("CODEX_CI", "1");
             });
             assert.success().stdout(
                 predicate::str::contains("_PROTO_ACTIVATED_PATH")
@@ -294,8 +291,7 @@ moonstone = "2.0.0"
                     .arg("--reporter")
                     .arg("ndjson")
                     .arg("--log")
-                    .arg("debug")
-                    .env_remove("PROTO_TEST");
+                    .arg("debug");
             });
             let stderr = assert.stderr();
 

--- a/crates/cli/tests/activate_test.rs
+++ b/crates/cli/tests/activate_test.rs
@@ -182,7 +182,7 @@ moonstone = "2.0.0"
         }
 
         #[test]
-        fn prints_structured_data_for_explicit_reporter() {
+        fn prints_agent_notice_and_data_for_explicit_reporter() {
             let sandbox = create_empty_proto_sandbox();
 
             let assert = sandbox.run_bin(|cmd| {
@@ -192,10 +192,23 @@ moonstone = "2.0.0"
                     .arg("ndjson")
                     .env("CODEX_CI", "1");
             });
-            assert.success().stdout(
-                predicate::str::contains("{\"type\":\"data\"")
-                    .and(predicate::str::contains("Detected an AI agent").not()),
-            );
+            let stdout = assert.stdout();
+            let records = stdout
+                .lines()
+                .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+                .collect::<Vec<_>>();
+
+            assert.success();
+            assert!(records.iter().any(|record| {
+                record.get("type").and_then(|value| value.as_str()) == Some("message")
+                    && record
+                        .get("message")
+                        .and_then(|value| value.as_str())
+                        .is_some_and(|message| message.contains("Detected an AI agent"))
+            }));
+            assert!(records.iter().any(|record| {
+                record.get("type").and_then(|value| value.as_str()) == Some("data")
+            }));
         }
 
         #[test]

--- a/crates/cli/tests/bin_test.rs
+++ b/crates/cli/tests/bin_test.rs
@@ -46,7 +46,7 @@ mod bin {
                 .arg("protostar")
                 .arg("1.0.0")
                 .env("CODEX_CI", "1")
-                .env_remove("PROTO_TEST");
+                .env_remove("PROTO_REPORTER");
         });
         let stdout = assert.stdout();
 

--- a/crates/cli/tests/bin_test.rs
+++ b/crates/cli/tests/bin_test.rs
@@ -18,7 +18,7 @@ mod bin {
     }
 
     #[test]
-    fn returns_path_if_installed() {
+    fn returns_path_in_text_and_agent_environments() {
         let sandbox = create_empty_proto_sandbox();
 
         sandbox
@@ -40,19 +40,7 @@ mod bin {
                 .success()
                 .stdout(predicate::str::contains("tools/protostar/1.0.0/protostar"));
         }
-    }
 
-    #[test]
-    fn returns_raw_path_in_agent_environments() {
-        let sandbox = create_empty_proto_sandbox();
-
-        sandbox
-            .run_bin(|cmd| {
-                cmd.arg("install").arg("protostar").arg("1.0.0");
-            })
-            .success();
-
-        // Use the real reporter and force AI agent detection.
         let assert = sandbox.run_bin(|cmd| {
             cmd.arg("bin")
                 .arg("protostar")
@@ -62,8 +50,24 @@ mod bin {
         });
         let stdout = assert.stdout();
 
-        assert_eq!(stdout.lines().count(), 1);
-        assert!(std::path::Path::new(stdout.trim()).is_absolute());
+        let records = stdout
+            .lines()
+            .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+            .collect::<Vec<_>>();
+
+        assert!(records.iter().any(|record| {
+            record.get("type").and_then(|value| value.as_str()) == Some("message")
+                && record
+                    .get("message")
+                    .and_then(|value| value.as_str())
+                    .is_some_and(|message| message.contains("Detected an AI agent"))
+        }));
+        assert!(records.iter().any(|record| {
+            record
+                .get("message")
+                .and_then(|value| value.as_str())
+                .is_some_and(|message| message.contains("protostar") && message.contains("1.0.0"))
+        }));
 
         assert.success();
     }

--- a/crates/cli/tests/bin_test.rs
+++ b/crates/cli/tests/bin_test.rs
@@ -43,6 +43,32 @@ mod bin {
     }
 
     #[test]
+    fn returns_raw_path_in_agent_environments() {
+        let sandbox = create_empty_proto_sandbox();
+
+        sandbox
+            .run_bin(|cmd| {
+                cmd.arg("install").arg("protostar").arg("1.0.0");
+            })
+            .success();
+
+        // Use the real reporter and force AI agent detection.
+        let assert = sandbox.run_bin(|cmd| {
+            cmd.arg("bin")
+                .arg("protostar")
+                .arg("1.0.0")
+                .env("CODEX_CI", "1")
+                .env_remove("PROTO_TEST");
+        });
+        let stdout = assert.stdout();
+
+        assert_eq!(stdout.lines().count(), 1);
+        assert!(std::path::Path::new(stdout.trim()).is_absolute());
+
+        assert.success();
+    }
+
+    #[test]
     fn returns_bin_path() {
         let sandbox = create_empty_proto_sandbox();
 

--- a/crates/cli/tests/bin_test.rs
+++ b/crates/cli/tests/bin_test.rs
@@ -63,10 +63,13 @@ mod bin {
                     .is_some_and(|message| message.contains("Detected an AI agent"))
         }));
         assert!(records.iter().any(|record| {
-            record
-                .get("message")
-                .and_then(|value| value.as_str())
-                .is_some_and(|message| message.contains("protostar") && message.contains("1.0.0"))
+            record.get("type").and_then(|value| value.as_str()) == Some("message")
+                && record
+                    .get("message")
+                    .and_then(|value| value.as_str())
+                    .is_some_and(|message| {
+                        message.contains("protostar") && message.contains("1.0.0")
+                    })
         }));
 
         assert.success();

--- a/crates/cli/tests/completions_test.rs
+++ b/crates/cli/tests/completions_test.rs
@@ -11,7 +11,7 @@ mod completions {
                 .arg("--shell")
                 .arg("zsh")
                 .env("CODEX_CI", "1")
-                .env_remove("PROTO_TEST");
+                .env_remove("PROTO_REPORTER");
         });
         assert.success().stdout(
             predicate::str::contains("#compdef proto")
@@ -30,8 +30,7 @@ mod completions {
                 .arg("--shell")
                 .arg("ion")
                 .arg("--reporter")
-                .arg("ndjson")
-                .env_remove("PROTO_TEST");
+                .arg("ndjson");
         });
         let stderr = assert.stderr();
         let records = stderr

--- a/crates/cli/tests/completions_test.rs
+++ b/crates/cli/tests/completions_test.rs
@@ -2,8 +2,6 @@ mod completions {
     use proto_core::test_utils::*;
     use starbase_sandbox::predicates::prelude::*;
 
-    // Use the real reporter with AI agent detection forced on.
-
     #[test]
     fn prints_only_completion_code_in_agent_environments() {
         let sandbox = create_empty_proto_sandbox();
@@ -35,12 +33,26 @@ mod completions {
                 .arg("ndjson")
                 .env_remove("PROTO_TEST");
         });
+        let stderr = assert.stderr();
+        let records = stderr
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+            .collect::<Vec<_>>();
 
-        assert
-            .failure()
-            .stdout(predicate::str::is_empty())
-            .stderr(predicate::str::contains(
-                "does not currently support completions",
-            ));
+        assert.failure().stdout(predicate::str::is_empty());
+        assert!(records.iter().any(|record| {
+            record.get("type").and_then(|value| value.as_str()) == Some("notice")
+                && record
+                    .get("messages")
+                    .and_then(|value| value.as_array())
+                    .is_some_and(|messages| {
+                        messages.iter().any(|message| {
+                            message.as_str().is_some_and(|message| {
+                                message.contains("does not currently support completions")
+                            })
+                        })
+                    })
+        }));
     }
 }

--- a/crates/cli/tests/completions_test.rs
+++ b/crates/cli/tests/completions_test.rs
@@ -1,0 +1,46 @@
+mod completions {
+    use proto_core::test_utils::*;
+    use starbase_sandbox::predicates::prelude::*;
+
+    // Use the real reporter with AI agent detection forced on.
+
+    #[test]
+    fn prints_only_completion_code_in_agent_environments() {
+        let sandbox = create_empty_proto_sandbox();
+
+        let assert = sandbox.run_bin(|cmd| {
+            cmd.arg("completions")
+                .arg("--shell")
+                .arg("zsh")
+                .env("CODEX_CI", "1")
+                .env_remove("PROTO_TEST");
+        });
+        assert.success().stdout(
+            predicate::str::contains("#compdef proto")
+                .and(predicate::str::contains("{\"type\":").not()),
+        );
+    }
+
+    #[test]
+    fn unsupported_shell_notice_goes_to_stderr() {
+        let sandbox = create_empty_proto_sandbox();
+
+        // Even an explicit structured reporter cannot take over this stdout:
+        // the documented usage redirects it into a completion file
+        let assert = sandbox.run_bin(|cmd| {
+            cmd.arg("completions")
+                .arg("--shell")
+                .arg("ion")
+                .arg("--reporter")
+                .arg("ndjson")
+                .env_remove("PROTO_TEST");
+        });
+
+        assert
+            .failure()
+            .stdout(predicate::str::is_empty())
+            .stderr(predicate::str::contains(
+                "does not currently support completions",
+            ));
+    }
+}

--- a/crates/cli/tests/exec_test.rs
+++ b/crates/cli/tests/exec_test.rs
@@ -50,7 +50,7 @@ mod exec {
         let assert = sandbox.run_bin(|cmd| {
             cmd.arg("exec")
                 .env("CODEX_CI", "1")
-                .env_remove("PROTO_TEST");
+                .env_remove("PROTO_REPORTER");
         });
 
         let stdout = assert.stdout();

--- a/crates/cli/tests/exec_test.rs
+++ b/crates/cli/tests/exec_test.rs
@@ -44,6 +44,39 @@ mod exec {
     }
 
     #[test]
+    fn child_owns_stdout_in_agent_environments() {
+        let sandbox = create_empty_proto_sandbox();
+
+        let assert = sandbox.run_bin(|cmd| {
+            cmd.args(["exec", "--", "echo", "sentinel-output"])
+                .env("CODEX_CI", "1")
+                .env_remove("PROTO_TEST");
+        });
+        assert.success().stdout(
+            predicate::str::contains("sentinel-output")
+                .and(predicate::str::contains("{\"type\":").not()),
+        );
+    }
+
+    #[test]
+    fn errors_to_stderr_in_agent_environments() {
+        let sandbox = create_empty_proto_sandbox();
+
+        let assert = sandbox.run_bin(|cmd| {
+            cmd.arg("exec")
+                .env("CODEX_CI", "1")
+                .env_remove("PROTO_TEST");
+        });
+
+        assert
+            .failure()
+            .stdout(predicate::str::is_empty())
+            .stderr(predicate::str::contains(
+                "A command is required for execution.",
+            ));
+    }
+
+    #[test]
     fn can_execute_without_tools() {
         let sandbox = create_empty_proto_sandbox();
 

--- a/crates/cli/tests/exec_test.rs
+++ b/crates/cli/tests/exec_test.rs
@@ -44,22 +44,7 @@ mod exec {
     }
 
     #[test]
-    fn child_owns_stdout_in_agent_environments() {
-        let sandbox = create_empty_proto_sandbox();
-
-        let assert = sandbox.run_bin(|cmd| {
-            cmd.args(["exec", "--", "echo", "sentinel-output"])
-                .env("CODEX_CI", "1")
-                .env_remove("PROTO_TEST");
-        });
-        assert.success().stdout(
-            predicate::str::contains("sentinel-output")
-                .and(predicate::str::contains("{\"type\":").not()),
-        );
-    }
-
-    #[test]
-    fn errors_to_stderr_in_agent_environments() {
+    fn errors_use_reporter_output_in_agent_environments() {
         let sandbox = create_empty_proto_sandbox();
 
         let assert = sandbox.run_bin(|cmd| {
@@ -68,12 +53,20 @@ mod exec {
                 .env_remove("PROTO_TEST");
         });
 
-        assert
-            .failure()
-            .stdout(predicate::str::is_empty())
-            .stderr(predicate::str::contains(
-                "A command is required for execution.",
-            ));
+        let stdout = assert.stdout();
+        let records = stdout
+            .lines()
+            .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+            .collect::<Vec<_>>();
+
+        assert.failure();
+        assert!(records.iter().any(|record| {
+            record.get("type").and_then(|value| value.as_str()) == Some("error")
+                && record
+                    .get("message")
+                    .and_then(|value| value.as_str())
+                    .is_some_and(|message| message.contains("A command is required for execution."))
+        }));
     }
 
     #[test]

--- a/crates/cli/tests/general_test.rs
+++ b/crates/cli/tests/general_test.rs
@@ -39,15 +39,34 @@ mod general {
     }
 
     #[test]
-    fn json_flag_overrides_reporter_env() {
+    fn ndjson_reporter_overrides_json_flag() {
         let sandbox = create_empty_proto_sandbox();
 
         let assert = sandbox.run_bin(|cmd| {
             cmd.arg("--json")
                 .arg("mcp")
                 .arg("--info")
-                .env("PROTO_REPORTER", "ndjson")
-                .env_remove("PROTO_TEST");
+                .env("PROTO_REPORTER", "ndjson");
+        });
+        let stdout = assert.stdout();
+        assert.success();
+        let output: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+
+        assert_eq!(
+            output.get("type").and_then(|value| value.as_str()),
+            Some("data")
+        );
+    }
+
+    #[test]
+    fn json_flag_overrides_text_reporter_env() {
+        let sandbox = create_empty_proto_sandbox();
+
+        let assert = sandbox.run_bin(|cmd| {
+            cmd.arg("--json")
+                .arg("mcp")
+                .arg("--info")
+                .env("PROTO_REPORTER", "text");
         });
         let stdout = assert.stdout();
         assert.success();
@@ -57,59 +76,15 @@ mod general {
     }
 
     #[test]
-    fn reporter_flag_overrides_json_env() {
-        let sandbox = create_empty_proto_sandbox();
-
-        let assert = sandbox.run_bin(|cmd| {
-            cmd.arg("--reporter")
-                .arg("ndjson")
-                .arg("mcp")
-                .arg("--info")
-                .env("PROTO_JSON", "true")
-                .env_remove("PROTO_TEST");
-        });
-        let stdout = assert.stdout();
-        assert.success();
-        let output: serde_json::Value = serde_json::from_str(&stdout).unwrap();
-
-        assert_eq!(
-            output.get("type").and_then(|value| value.as_str()),
-            Some("data")
-        );
-    }
-
-    #[test]
-    fn reporter_wins_legacy_json_alias() {
-        let sandbox = create_empty_proto_sandbox();
-
-        let assert = sandbox.run_bin(|cmd| {
-            cmd.arg("--json")
-                .arg("--reporter")
-                .arg("ndjson")
-                .arg("mcp")
-                .arg("--info")
-                .env_remove("PROTO_TEST");
-        });
-        let stdout = assert.stdout();
-        assert.success();
-        let output: serde_json::Value = serde_json::from_str(&stdout).unwrap();
-
-        assert_eq!(
-            output.get("type").and_then(|value| value.as_str()),
-            Some("data")
-        );
-    }
-
-    #[test]
     fn json_env_selects_json_reporter() {
         let sandbox = create_empty_proto_sandbox();
 
         let assert = sandbox.run_bin(|cmd| {
             cmd.arg("mcp")
                 .arg("--info")
+                .env("CODEX_CI", "1")
                 .env("PROTO_JSON", "true")
-                .env_remove("PROTO_REPORTER")
-                .env_remove("PROTO_TEST");
+                .env_remove("PROTO_REPORTER");
         });
         let stdout = assert.stdout();
         assert.success();

--- a/crates/cli/tests/general_test.rs
+++ b/crates/cli/tests/general_test.rs
@@ -46,7 +46,10 @@ mod general {
             cmd.arg("--json")
                 .arg("mcp")
                 .arg("--info")
-                .env("PROTO_REPORTER", "ndjson");
+                .env("PROTO_REPORTER", "ndjson")
+                .env_remove("CODEX_CI")
+                .env_remove("CODEX_SANDBOX")
+                .env_remove("CODEX_THREAD_ID");
         });
         let stdout = assert.stdout();
         assert.success();
@@ -66,7 +69,10 @@ mod general {
             cmd.arg("--json")
                 .arg("mcp")
                 .arg("--info")
-                .env("PROTO_REPORTER", "text");
+                .env("PROTO_REPORTER", "text")
+                .env_remove("CODEX_CI")
+                .env_remove("CODEX_SANDBOX")
+                .env_remove("CODEX_THREAD_ID");
         });
         let stdout = assert.stdout();
         assert.success();

--- a/crates/cli/tests/general_test.rs
+++ b/crates/cli/tests/general_test.rs
@@ -37,4 +37,84 @@ mod general {
 
         assert!(sandbox.path().join("proto.log").exists());
     }
+
+    #[test]
+    fn json_flag_overrides_reporter_env() {
+        let sandbox = create_empty_proto_sandbox();
+
+        let assert = sandbox.run_bin(|cmd| {
+            cmd.arg("--json")
+                .arg("mcp")
+                .arg("--info")
+                .env("PROTO_REPORTER", "ndjson")
+                .env_remove("PROTO_TEST");
+        });
+        let stdout = assert.stdout();
+        assert.success();
+        let output: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+
+        assert!(output.get("info").is_some());
+    }
+
+    #[test]
+    fn reporter_flag_overrides_json_env() {
+        let sandbox = create_empty_proto_sandbox();
+
+        let assert = sandbox.run_bin(|cmd| {
+            cmd.arg("--reporter")
+                .arg("ndjson")
+                .arg("mcp")
+                .arg("--info")
+                .env("PROTO_JSON", "true")
+                .env_remove("PROTO_TEST");
+        });
+        let stdout = assert.stdout();
+        assert.success();
+        let output: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+
+        assert_eq!(
+            output.get("type").and_then(|value| value.as_str()),
+            Some("data")
+        );
+    }
+
+    #[test]
+    fn reporter_wins_legacy_json_alias() {
+        let sandbox = create_empty_proto_sandbox();
+
+        let assert = sandbox.run_bin(|cmd| {
+            cmd.arg("--json")
+                .arg("--reporter")
+                .arg("ndjson")
+                .arg("mcp")
+                .arg("--info")
+                .env_remove("PROTO_TEST");
+        });
+        let stdout = assert.stdout();
+        assert.success();
+        let output: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+
+        assert_eq!(
+            output.get("type").and_then(|value| value.as_str()),
+            Some("data")
+        );
+    }
+
+    #[test]
+    fn json_env_selects_json_reporter() {
+        let sandbox = create_empty_proto_sandbox();
+
+        let assert = sandbox.run_bin(|cmd| {
+            cmd.arg("mcp")
+                .arg("--info")
+                .env("PROTO_JSON", "true")
+                .env_remove("PROTO_REPORTER")
+                .env_remove("PROTO_TEST");
+        });
+        let stdout = assert.stdout();
+        assert.success();
+        let output: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+
+        assert!(output.get("info").is_some());
+    }
 }

--- a/crates/cli/tests/mcp_test.rs
+++ b/crates/cli/tests/mcp_test.rs
@@ -1,0 +1,37 @@
+mod mcp {
+    use proto_core::test_utils::*;
+
+    #[test]
+    fn stdout_only_carries_jsonrpc_in_agent_environments() {
+        let sandbox = create_empty_proto_sandbox();
+
+        // Use the real reporter with AI agent detection forced on.
+        let assert = sandbox.run_bin(|cmd| {
+            cmd.arg("mcp")
+                .env("CODEX_CI", "1")
+                .env_remove("PROTO_TEST")
+                .write_stdin(
+                    r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0.0.0"}}}"#
+                        .to_owned()
+                        + "\n",
+                );
+        });
+        let stdout = assert.stdout();
+
+        assert!(stdout.contains("\"jsonrpc\":\"2.0\""));
+
+        for line in stdout.lines().filter(|line| !line.trim().is_empty()) {
+            let record: serde_json::Value = serde_json::from_str(line).unwrap_or_else(|error| {
+                panic!("stdout line is not valid JSON-RPC: {line}: {error}")
+            });
+
+            assert_eq!(
+                record.get("jsonrpc").and_then(|value| value.as_str()),
+                Some("2.0"),
+                "stdout line is not a JSON-RPC record: {line}",
+            );
+        }
+
+        assert.success();
+    }
+}

--- a/crates/cli/tests/mcp_test.rs
+++ b/crates/cli/tests/mcp_test.rs
@@ -8,7 +8,7 @@ mod mcp {
         let assert = sandbox.run_bin(|cmd| {
             cmd.arg("mcp")
                 .env("CODEX_CI", "1")
-                .env_remove("PROTO_TEST")
+                .env_remove("PROTO_REPORTER")
                 .write_stdin(
                     r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0.0.0"}}}"#
                         .to_owned()

--- a/crates/cli/tests/mcp_test.rs
+++ b/crates/cli/tests/mcp_test.rs
@@ -5,7 +5,6 @@ mod mcp {
     fn stdout_only_carries_jsonrpc_in_agent_environments() {
         let sandbox = create_empty_proto_sandbox();
 
-        // Use the real reporter with AI agent detection forced on.
         let assert = sandbox.run_bin(|cmd| {
             cmd.arg("mcp")
                 .env("CODEX_CI", "1")

--- a/crates/cli/tests/snapshots/activate_test__activate__can_disable_init-8.snap
+++ b/crates/cli/tests/snapshots/activate_test__activate__can_disable_init-8.snap
@@ -3,7 +3,7 @@ source: crates/cli/tests/activate_test.rs
 expression: "get_activate_output(&assert, &sandbox)"
 ---
 export def _proto_activate_hook [] {
-    let data = proto activate nu --json | from json
+    let data = proto activate nu --reporter json | from json
 
     $data | get -i env | items { |k, v|
         if $v == null {

--- a/crates/cli/tests/snapshots/activate_test__activate__empty_output_if_no_tools-8.snap
+++ b/crates/cli/tests/snapshots/activate_test__activate__empty_output_if_no_tools-8.snap
@@ -3,7 +3,7 @@ source: crates/cli/tests/activate_test.rs
 expression: "get_activate_output(&assert, &sandbox)"
 ---
 export def _proto_activate_hook [] {
-    let data = proto activate nu --json | from json
+    let data = proto activate nu --reporter json | from json
 
     $data | get -i env | items { |k, v|
         if $v == null {

--- a/crates/cli/tests/snapshots/activate_test__activate__passes_args_through-8.snap
+++ b/crates/cli/tests/snapshots/activate_test__activate__passes_args_through-8.snap
@@ -3,7 +3,7 @@ source: crates/cli/tests/activate_test.rs
 expression: "get_activate_output(&assert, &sandbox)"
 ---
 export def _proto_activate_hook [] {
-    let data = proto activate nu --config-mode upwards-global --no-bin --no-shim --json | from json
+    let data = proto activate nu --config-mode upwards-global --no-bin --no-shim --reporter json | from json
 
     $data | get -i env | items { |k, v|
         if $v == null {

--- a/crates/cli/tests/snapshots/activate_test__activate__supports_json_exports.snap
+++ b/crates/cli/tests/snapshots/activate_test__activate__supports_json_exports.snap
@@ -3,7 +3,7 @@ source: crates/cli/tests/activate_test.rs
 expression: "get_activate_output(&assert, &sandbox)"
 ---
 export def _proto_activate_hook [] {
-    let data = proto activate nu --config-mode upwards-global --json | from json
+    let data = proto activate nu --config-mode upwards-global --reporter json | from json
 
     $data | get -i env | items { |k, v|
         if $v == null {

--- a/crates/cli/tests/snapshots/activate_test__activate__supports_many_tools-8.snap
+++ b/crates/cli/tests/snapshots/activate_test__activate__supports_many_tools-8.snap
@@ -3,7 +3,7 @@ source: crates/cli/tests/activate_test.rs
 expression: "get_activate_output(&assert, &sandbox)"
 ---
 export def _proto_activate_hook [] {
-    let data = proto activate nu --json | from json
+    let data = proto activate nu --reporter json | from json
 
     $data | get -i env | items { |k, v|
         if $v == null {

--- a/crates/cli/tests/snapshots/activate_test__activate__supports_one_tool-8.snap
+++ b/crates/cli/tests/snapshots/activate_test__activate__supports_one_tool-8.snap
@@ -3,7 +3,7 @@ source: crates/cli/tests/activate_test.rs
 expression: "get_activate_output(&assert, &sandbox)"
 ---
 export def _proto_activate_hook [] {
-    let data = proto activate nu --json | from json
+    let data = proto activate nu --reporter json | from json
 
     $data | get -i env | items { |k, v|
         if $v == null {

--- a/crates/core/src/reporter.rs
+++ b/crates/core/src/reporter.rs
@@ -31,6 +31,7 @@ pub struct ProtoReporter {
     format: ReporterFormat,
     err: ConsoleStream,
     out: ConsoleStream,
+    stderr_only: bool,
     theme: ConsoleTheme,
     test_mode: bool,
     json_buffer: Arc<RwLock<Vec<String>>>,
@@ -40,6 +41,14 @@ impl ProtoReporter {
     pub fn new(format: ReporterFormat) -> Self {
         Self {
             format,
+            ..Default::default()
+        }
+    }
+
+    pub fn new_stderr(format: ReporterFormat) -> Self {
+        Self {
+            format,
+            stderr_only: true,
             ..Default::default()
         }
     }
@@ -60,6 +69,7 @@ impl Default for ProtoReporter {
             format: ReporterFormat::Text,
             err: ConsoleStream::empty(ConsoleStreamType::Stderr),
             out: ConsoleStream::empty(ConsoleStreamType::Stdout),
+            stderr_only: false,
             theme: ConsoleTheme::default(),
             test_mode: false,
             json_buffer: Arc::new(RwLock::new(Vec::new())),
@@ -74,8 +84,8 @@ impl Reporter for ProtoReporter {
 
     fn inherit_streams(&mut self, err: ConsoleStream, out: ConsoleStream) {
         if !self.test_mode {
-            self.err = err;
-            self.out = out;
+            self.err = err.clone();
+            self.out = if self.stderr_only { err } else { out };
         }
     }
 }
@@ -162,6 +172,8 @@ impl ProtoReporter {
                 self.write_json(Event::Error(MessageOutput { code, message }))?;
             }
         };
+
+        self.out.flush()?;
 
         Ok(())
     }

--- a/crates/core/src/test_utils.rs
+++ b/crates/core/src/test_utils.rs
@@ -42,6 +42,9 @@ fn apply_settings(sandbox: &mut Sandbox) {
     env.insert("PROTO_SANDBOX", root.to_str().unwrap());
     env.insert("PROTO_HOME", proto_dir.to_str().unwrap());
     env.insert("PROTO_LOG", "trace");
+    // Keep CLI output deterministic across developer shell environments.
+    env.insert("PROTO_JSON", "false");
+    env.insert("PROTO_REPORTER", "text");
     env.insert("PROTO_TEST", "true");
 
     sandbox.settings.bin = "proto".into();


### PR DESCRIPTION
## Summary

Proto automatically selects NDJSON in AI agent environments. Some commands reserve standard output for another data format. Reporter records can then corrupt shell code, completion code, JSON-RPC data, paths, and child-process output.

The CLI now assigns one owner to standard output for every command. The reporter writes to standard output only when it owns the stream. Explicit JSON output remains available for `proto activate` and `proto bin`.

Clap value sources define the priority of `--json`, `--reporter`, `PROTO_JSON`, and `PROTO_REPORTER`. Command-line values take priority over environment values. `--reporter` takes priority over `--json` when both values have the same source.

The Nushell hook requests `--reporter json`. Quiet installs do not render the build user interface in the MCP JSON-RPC stream.

Fixes #1054

## Test results

- `cargo fmt --all --check`
- `cargo clippy --package proto_cli --all-targets`
- `session`: 1 test passed.
- `activate_test`: 19 tests passed.
- `bin_test`: 7 tests passed.
- `completions_test`: 2 tests passed.
- `exec_test`: 10 tests passed.
- `general_test`: 6 tests passed.
- `mcp_test`: 1 test passed.
