### PR TITLE
registry: add Hunk plugin

### DIFF
--- a/registry/data/third-party.json
+++ b/registry/data/third-party.json
@@ -775,6 +775,19 @@
       ]
     },
     {
+      "id": "hunk",
+      "locator": "https://raw.githubusercontent.com/IgnisDa/proto-plugins/main/hunk/plugin.toml",
+      "format": "toml",
+      "name": "Hunk",
+      "description": "Review-first terminal diff viewer for agent-authored changesets.",
+      "author": "IgnisDa",
+      "homepageUrl": "https://hunk.dev/",
+      "repositoryUrl": "https://github.com/IgnisDa/proto-plugins/tree/main/hunk",
+      "bins": [
+        "hunk"
+      ]
+    },
+    {
       "id": "hurl",
       "locator": "https://raw.githubusercontent.com/Phault/proto-toml-plugins/main/hurl/plugin.toml",
       "format": "toml",


### PR DESCRIPTION
## Summary

- add the community TOML plugin for Hunk to the proto registry
- expose the `hunk` binary in plugin search metadata

## Testing

- `cargo run -p proto_codegen`
- `cargo test -p proto_codegen`
- installed Hunk 0.17.3 through proto and verified `hunk --version` on macOS arm64 using an isolated `PROTO_HOME`