### PR TITLE
fix: re-check the install state after acquiring the install lock

### DIFF
--- a/crates/core/src/flow/install.rs
+++ b/crates/core/src/flow/install.rs
@@ -7,6 +7,7 @@ use crate::helpers::{is_archive_file, is_offline};
 use crate::lockfile::*;
 use crate::reporter::ProtoConsole;
 use crate::tool::Tool;
+use crate::tool_manifest::ToolManifest;
 use crate::tool_spec::ToolSpec;
 use crate::utils::log::LogWriter;
 use crate::utils::{archive, process};
@@ -79,7 +80,7 @@ impl<'tool> Installer<'tool> {
     pub async fn install(
         &self,
         options: InstallOptions,
-    ) -> Result<Option<LockRecord>, ProtoInstallError> {
+    ) -> Result<Option<(LockRecord, fs::DirLock)>, ProtoInstallError> {
         if self.tool.is_installed(self.spec) && !options.force {
             debug!(
                 tool = self.tool.context.as_str(),
@@ -97,6 +98,12 @@ impl<'tool> Installer<'tool> {
         // because the latter needs to be clean for "build from source",
         // and the `.lock` file breaks that contract
         let mut install_lock = fs::lock_directory(&self.temp_dir)?;
+
+        if !options.force && self.was_installed_while_locked() {
+            install_lock.unlock()?;
+
+            return Ok(None);
+        }
 
         // If this function is defined, it acts like an escape hatch and
         // takes precedence over all other install strategies
@@ -141,7 +148,7 @@ impl<'tool> Installer<'tool> {
                 // Verify against lockfile
                 Locker::new(self.tool).verify_locked_record(self.spec, &record)?;
 
-                return Ok(Some(record));
+                return Ok(Some((record, install_lock)));
             }
 
             if !output.skip_install {
@@ -182,11 +189,7 @@ impl<'tool> Installer<'tool> {
                     "Successfully installed tool",
                 );
 
-                install_lock.unlock()?;
-
-                let _ = fs::remove_dir_all(&self.temp_dir);
-
-                Ok(Some(record))
+                Ok(Some((record, install_lock)))
             }
 
             // Clean up if the install failed
@@ -205,6 +208,19 @@ impl<'tool> Installer<'tool> {
                 Err(error)
             }
         }
+    }
+
+    fn was_installed_while_locked(&self) -> bool {
+        let Some(version) = self.spec.version.as_ref() else {
+            return false;
+        };
+
+        if version.is_latest() || !self.product_dir.exists() {
+            return false;
+        }
+
+        ToolManifest::load_from(self.tool.get_inventory_dir())
+            .is_ok_and(|manifest| manifest.installed_versions.contains(version))
     }
 
     /// Build the tool from source using a set of requirements and instructions

--- a/crates/core/src/flow/manage.rs
+++ b/crates/core/src/flow/manage.rs
@@ -40,22 +40,24 @@ impl<'tool> Manager<'tool> {
             let cache_hit = self.tool.is_installed(spec) && !options.force;
             cache = cache_status(cache_hit);
 
-            let record = match Installer::new(self.tool, spec).install(options).await? {
-                // Update lock record with resolved spec information
-                Some(mut record) => {
-                    record.version = Some(version.clone());
-                    record.spec = Some(spec.req.clone());
-                    record
-                }
-                // Return an existing lock record if already installed
-                None => {
-                    self.post_install(spec, false).await?;
+            let (record, mut install_lock) =
+                match Installer::new(self.tool, spec).install(options).await? {
+                    // Update lock record with resolved spec information
+                    Some((mut record, install_lock)) => {
+                        record.version = Some(version.clone());
+                        record.spec = Some(spec.req.clone());
 
-                    return Ok(Locker::new(self.tool)
-                        .get_resolved_locked_record(spec)
-                        .cloned());
-                }
-            };
+                        (record, install_lock)
+                    }
+                    // Return an existing lock record if already installed
+                    None => {
+                        self.post_install(spec, false).await?;
+
+                        return Ok(Locker::new(self.tool)
+                            .get_resolved_locked_record(spec)
+                            .cloned());
+                    }
+                };
 
             // Add record to lockfile
             if spec.update_lockfile {
@@ -71,6 +73,9 @@ impl<'tool> Manager<'tool> {
                     ..Default::default()
                 },
             );
+            self.tool.inventory.manifest.save()?;
+
+            install_lock.unlock().map_err(ProtoInstallError::from)?;
 
             self.post_install(spec, true).await?;
 

--- a/crates/core/src/flow/manage.rs
+++ b/crates/core/src/flow/manage.rs
@@ -6,7 +6,7 @@ use crate::flow::resolve::Resolver;
 use crate::lockfile::LockRecord;
 use crate::telemetry::cache_status;
 use crate::tool::Tool;
-use crate::tool_manifest::ToolManifestVersion;
+use crate::tool_manifest::{ToolManifest, ToolManifestVersion};
 use crate::tool_spec::ToolSpec;
 use proto_pdk_api::{InstallStrategy, PluginFunction, SyncManifestInput, SyncManifestOutput};
 use starbase_utils::fs;
@@ -51,6 +51,9 @@ impl<'tool> Manager<'tool> {
                     }
                     // Return an existing lock record if already installed
                     None => {
+                        self.tool.inventory.manifest =
+                            ToolManifest::load_from(self.tool.get_inventory_dir())?;
+
                         self.post_install(spec, false).await?;
 
                         return Ok(Locker::new(self.tool)

--- a/crates/core/src/tool.rs
+++ b/crates/core/src/tool.rs
@@ -15,7 +15,7 @@ use proto_pdk_api::{
 use rustc_hash::FxHashMap;
 use starbase_styles::color;
 use starbase_utils::net::DownloadOptions;
-use starbase_utils::{fs, path};
+use starbase_utils::{fs, hash, path};
 use std::fmt::{self, Debug};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -218,7 +218,10 @@ impl Tool {
         let installed = spec.version.as_ref().is_some_and(|v| {
             !v.is_latest() && self.inventory.manifest.installed_versions.contains(v)
         }) && dir.exists()
-            && !fs::is_dir_locked(&dir);
+            && !fs::is_dir_locked(
+                self.get_temp_dir()
+                    .join(hash::base64::from_bytes(spec.req.to_string())),
+            );
 
         if installed {
             debug!(


### PR DESCRIPTION
Fixes #1063.

Concurrent auto-installs of the same missing version all pass the `is_installed` check before any of them finishes. They then queue on the install lock and unpack again on top of a directory another process already installed into, which leaves the binary truncated and non-executable for a moment. Anything that execs the resolved path during that window fails with exit code 126.

This re-checks the install state after acquiring the lock. Reusing `Tool::is_installed` is not enough on its own, because the tool's manifest is loaded into memory before the wait, so `installed_versions` is still the copy from before the other process wrote to it. The check reads `manifest.json` from disk instead.

The re-check alone still left a race: the installing process released the lock inside `Installer::install`, but the manifest only reached disk later, inside `Linker::link`. A waiting process could acquire the lock in that gap, read the old manifest, and reinstall anyway. When I ran the repro from the issue with only the re-check applied, one of the four queued processes still got through. `Installer::install` now returns the lock guard along with the record, and `Manager::install` releases it only after the manifest is written to disk.

With both changes, the victim loop from the issue drops from 368 failed execs to zero once the initial extraction finishes, and only one of the five concurrent installers unpacks the archive.
