### PR TITLE
fix(nix, aarch64-darwin): set --max-jobs 1

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -37,7 +37,7 @@ jobs:
           - system: aarch64-linux
             runner: depot-ubuntu-22.04-arm-8
           - system: aarch64-darwin
-            runner: depot-macos-15
+            runner: macos-15
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
ensure auto-concurrency does not try to set max jobs > 1