### PR TITLE
fix: Do not append trailing separators when converting virtual path prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@
 - [Rust](https://github.com/moonrepo/plugins/blob/master/tools/rust/CHANGELOG.md)
 - [Schema (TOML, JSON, YAML)](https://github.com/moonrepo/plugins/blob/master/tools/internal-schema/CHANGELOG.md)
 
+## Unreleased
+
+#### 🐞 Fixes
+
+- Fixed virtual path conversion producing a path with a trailing separator when the path being converted is a virtual/real prefix itself (`Path::join("")` appends a separator). This surfaced in moon as `$env.PWD contains trailing slashes` errors from nushell when plugin commands ran at the workspace root.
+
 ## 0.60.2
 
 #### 🚀 Updates

--- a/crates/warpgate-api/src/path_utils.rs
+++ b/crates/warpgate-api/src/path_utils.rs
@@ -34,6 +34,17 @@ pub fn sort_paths_list(paths_list: &mut [(PathBuf, PathBuf)]) {
     paths_list.sort_by(|a, d| d.0.cmp(&a.0).then(d.1.cmp(&a.1)));
 }
 
+// When the path being converted is the prefix itself, the stripped
+// relative path is empty, and `Path::join("")` would append a trailing
+// separator, so return the base prefix untouched instead.
+fn join_rel_path(base: &Path, rel_path: &Path) -> PathBuf {
+    if rel_path.as_os_str().is_empty() {
+        base.to_owned()
+    } else {
+        base.join(rel_path)
+    }
+}
+
 /// Convert the provided real host path to a virtual guest path.
 /// If the host path does not match any of the provided virtual paths,
 /// it will return `None`.
@@ -47,7 +58,7 @@ pub fn convert_to_virtual_path(
         let virtual_path = if path.starts_with(guest_path) {
             path.to_owned()
         } else if let Ok(rel_path) = path.strip_prefix(host_path) {
-            guest_path.join(rel_path)
+            join_rel_path(guest_path, rel_path)
         } else {
             continue;
         };
@@ -71,7 +82,7 @@ pub fn convert_to_real_path(
         let real_path = if path.starts_with(host_path) {
             path.to_owned()
         } else if let Ok(rel_path) = path.strip_prefix(guest_path) {
-            host_path.join(rel_path)
+            join_rel_path(host_path, rel_path)
         } else {
             continue;
         };
@@ -96,7 +107,7 @@ pub fn convert_to_real_native_path(
         let real_path = if path.starts_with(host_path) {
             path.to_owned()
         } else if let Ok(rel_path) = path.strip_prefix(guest_path) {
-            host_path.join(rel_path)
+            join_rel_path(host_path, rel_path)
         } else {
             continue;
         };

--- a/crates/warpgate-api/src/path_utils.rs
+++ b/crates/warpgate-api/src/path_utils.rs
@@ -34,17 +34,6 @@ pub fn sort_paths_list(paths_list: &mut [(PathBuf, PathBuf)]) {
     paths_list.sort_by(|a, d| d.0.cmp(&a.0).then(d.1.cmp(&a.1)));
 }
 
-// When the path being converted is the prefix itself, the stripped
-// relative path is empty, and `Path::join("")` would append a trailing
-// separator, so return the base prefix untouched instead.
-fn join_rel_path(base: &Path, rel_path: &Path) -> PathBuf {
-    if rel_path.as_os_str().is_empty() {
-        base.to_owned()
-    } else {
-        base.join(rel_path)
-    }
-}
-
 /// Convert the provided real host path to a virtual guest path.
 /// If the host path does not match any of the provided virtual paths,
 /// it will return `None`.
@@ -57,8 +46,12 @@ pub fn convert_to_virtual_path(
     for (host_path, guest_path) in paths_list {
         let virtual_path = if path.starts_with(guest_path) {
             path.to_owned()
+        } else if path == host_path {
+            // The prefix itself, otherwise `join` below would
+            // append a trailing separator
+            guest_path.to_owned()
         } else if let Ok(rel_path) = path.strip_prefix(host_path) {
-            join_rel_path(guest_path, rel_path)
+            guest_path.join(rel_path)
         } else {
             continue;
         };
@@ -81,8 +74,12 @@ pub fn convert_to_real_path(
     for (host_path, guest_path) in paths_list {
         let real_path = if path.starts_with(host_path) {
             path.to_owned()
+        } else if path == guest_path {
+            // The prefix itself, otherwise `join` below would
+            // append a trailing separator
+            host_path.to_owned()
         } else if let Ok(rel_path) = path.strip_prefix(guest_path) {
-            join_rel_path(host_path, rel_path)
+            host_path.join(rel_path)
         } else {
             continue;
         };
@@ -106,8 +103,12 @@ pub fn convert_to_real_native_path(
     for (host_path, guest_path) in paths_list {
         let real_path = if path.starts_with(host_path) {
             path.to_owned()
+        } else if path == guest_path {
+            // The prefix itself, otherwise `join` below would
+            // append a trailing separator
+            host_path.to_owned()
         } else if let Ok(rel_path) = path.strip_prefix(guest_path) {
-            join_rel_path(host_path, rel_path)
+            host_path.join(rel_path)
         } else {
             continue;
         };

--- a/crates/warpgate-api/tests/path_utils_test.rs
+++ b/crates/warpgate-api/tests/path_utils_test.rs
@@ -126,6 +126,75 @@ fn converts_the_prefixes_themselves() {
     );
 }
 
+// `PathBuf` equality ignores trailing separators, so these must compare
+// the raw string form to catch a `join("")` on the stripped prefix.
+// https://github.com/moonrepo/moon/issues/2676
+#[cfg(not(windows))]
+#[test]
+fn converts_the_prefixes_themselves_without_trailing_separators() {
+    let paths = vec![(PathBuf::from("/Users/warp"), PathBuf::from("/userhome"))];
+
+    assert_eq!(
+        convert_to_virtual_path("/Users/warp", &paths)
+            .unwrap()
+            .to_string_lossy(),
+        "/userhome"
+    );
+
+    assert_eq!(
+        convert_to_real_path("/userhome", &paths)
+            .unwrap()
+            .to_string_lossy(),
+        "/Users/warp"
+    );
+
+    assert_eq!(
+        convert_to_real_native_path("/userhome", &paths).to_string_lossy(),
+        "/Users/warp"
+    );
+
+    // Also when the input itself has a trailing separator
+    assert_eq!(
+        convert_to_real_path("/userhome/", &paths)
+            .unwrap()
+            .to_string_lossy(),
+        "/Users/warp"
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn converts_the_prefixes_themselves_without_trailing_separators() {
+    let paths = vec![(PathBuf::from("C:\\Users\\warp"), PathBuf::from("/userhome"))];
+
+    assert_eq!(
+        convert_to_virtual_path("C:\\Users\\warp", &paths)
+            .unwrap()
+            .to_string_lossy(),
+        "/userhome"
+    );
+
+    assert_eq!(
+        convert_to_real_path("/userhome", &paths)
+            .unwrap()
+            .to_string_lossy(),
+        "C:\\Users\\warp"
+    );
+
+    assert_eq!(
+        convert_to_real_native_path("/userhome", &paths).to_string_lossy(),
+        "C:\\Users\\warp"
+    );
+
+    // Also when the input itself has a trailing separator
+    assert_eq!(
+        convert_to_real_path("/userhome/", &paths)
+            .unwrap()
+            .to_string_lossy(),
+        "C:\\Users\\warp"
+    );
+}
+
 // Entries are matched in order, which is why lists should be pre-sorted
 // with `sort_paths_list` so that the longest prefix wins.
 #[test]


### PR DESCRIPTION
When the path being converted through `convert_to_virtual_path`, `convert_to_real_path`, or `convert_to_real_native_path` is exactly one of the mapped prefixes, `strip_prefix` yields an empty relative path, and `Path::join("")` appends a trailing separator:

```rust
PathBuf::from("/Users/me/repo").join("") // => "/Users/me/repo/"
```

So converting a workspace root round-trips as `/workspace/` → `/Users/me/repo/`. Downstream in moon, that slashed path is exported as `PWD` for plugin-executed commands, and shells that validate `PWD` on startup (nushell) refuse to run, failing the command. Full analysis in moonrepo/moon#2676.

This went unnoticed because `PathBuf` equality compares components and ignores trailing separators, so the existing `converts_the_prefixes_themselves` test passes even with the bug present.

### Changes

- Added a prefix equality branch to all three convert functions that returns the opposite prefix directly, so `join` only runs for strictly longer paths. Since `Path` equality is component-based, this also covers inputs that already carry a trailing separator.
- Added tests that assert on the raw string form (unix and windows variants), including inputs that themselves carry a trailing separator. Verified the new test fails without the fix.
- Added a changelog entry.
