### PR TITLE
fix: Prevent run fallback guard from leaking into child processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@
 
 #### 🐞 Fixes
 
+- Fixed an issue where the internal fallback loop guard (`PROTO_INTERNAL_RUN_FALLBACK`) would leak into child processes and abort unrelated, nested invocations of the same tool (like npm scripts that spawn `node`) with a false `fallback_loop` error. The guard is now scoped to the process that performed the fallback, so only a genuine same-process re-entry is treated as a loop.
+  - Proto now also skips any directory on `PATH` that contains a shims `registry.json`, so a foreign proto store (from a mismatched `PROTO_HOME`) is never selected as the global fallback and can't trigger a loop.
+  - Reworded the `fallback_loop` error to describe the actual cause instead of incorrectly claiming the resolved binary is a proto shim.
 - Fixed an issue where `proto uninstall` would fail when `PROTO_ENV` is set and an environment scoped `.prototools.<env>` config exists, as it would attempt to unpin the version from an invalid path.
 
 ## 0.60.2

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -156,18 +156,39 @@ async fn get_tool_executable(
 }
 
 // Set when falling back to a global executable, so that we can detect
-// when the "global" executable re-enters proto (an execution loop)
+// when the "global" executable re-enters proto (an execution loop).
+//
+// Each entry is scoped to the process that performed the fallback
+// (`id:pid`), because this variable is inherited by the *entire* process
+// tree, not just the immediate child. A genuine loop re-enters proto
+// through `execvp`, which replaces the process in place and preserves the
+// PID, so the re-entry reports our own PID. An unrelated, legitimate
+// invocation of the same tool deeper in the tree (e.g. an npm script that
+// runs `node`) is reached through a real `fork` and carries a different
+// PID, so it must not be treated as a loop.
+// https://github.com/moonrepo/proto/issues/1086
 const FALLBACK_GUARD_VAR: &str = "PROTO_INTERNAL_RUN_FALLBACK";
 
-fn has_fallen_back(guard: &str, id: &str) -> bool {
-    guard.split(',').any(|prev| prev == id)
+fn has_fallen_back(guard: &str, id: &str, pid: u32) -> bool {
+    guard.split(',').any(|entry| match entry.split_once(':') {
+        // Scoped to a PID: only a loop when it names *this* process.
+        Some((entry_id, entry_pid)) => {
+            entry_id == id && entry_pid.parse::<u32>().is_ok_and(|prev| prev == pid)
+        }
+        // proto always writes a PID, so a bare id can only be stale (e.g.
+        // written by an older proto and inherited across a fork) or set by
+        // hand. Either way it isn't this process looping, so ignore it.
+        None => false,
+    })
 }
 
-fn append_fallback(guard: &str, id: &str) -> String {
+fn append_fallback(guard: &str, id: &str, pid: u32) -> String {
+    let entry = format!("{id}:{pid}");
+
     if guard.is_empty() {
-        id.to_owned()
+        entry
     } else {
-        format!("{guard},{id}")
+        format!("{guard},{entry}")
     }
 }
 
@@ -208,6 +229,16 @@ fn find_global_executable(
             continue;
         }
 
+        // The store above may also live under a directory that isn't named
+        // `.proto` (a custom `PROTO_HOME`), so the name checks won't catch
+        // it. Every proto shims directory contains a `registry.json`, so use
+        // that as a reliable marker and skip such a directory regardless of
+        // its name -- executing one of its shims would re-enter proto and
+        // loop. https://github.com/moonrepo/proto/issues/1086
+        if path_dir.join("registry.json").is_file() {
+            continue;
+        }
+
         // Local development may have ~/.proto on PATH, so ignore!
         #[cfg(debug_assertions)]
         if path_dir.to_string_lossy().contains(".proto") {
@@ -242,11 +273,13 @@ fn run_global_tool(
     if let Some(global_exe) = get_global_executable(&session.env, args.context.id.as_str()) {
         let id = args.context.id.to_string();
         let guard = env::var(FALLBACK_GUARD_VAR).unwrap_or_default();
+        let pid = std::process::id();
 
-        // If we've already fallen back for this tool once in this execution
-        // chain, then the "global" executable is actually a proto shim,
-        // and executing it would recurse forever!
-        if has_fallen_back(&guard, &id) {
+        // If this same process has already fallen back for this tool, then
+        // the "global" executable resolves back into proto (a shim on PATH,
+        // or a wrapper that re-resolves through it), and executing it would
+        // recurse forever!
+        if has_fallen_back(&guard, &id, pid) {
             return Err(ProtoCliError::RunFallbackLoop {
                 tool: id,
                 path: global_exe,
@@ -262,7 +295,7 @@ fn run_global_tool(
 
         let mut command = Command::new(global_exe);
         command.args(args.passthrough);
-        command.env(FALLBACK_GUARD_VAR, append_fallback(&guard, &id));
+        command.env(FALLBACK_GUARD_VAR, append_fallback(&guard, &id, pid));
 
         return exec_command_and_replace(command).into_diagnostic();
     }
@@ -564,18 +597,37 @@ mod tests {
         use super::*;
 
         #[test]
-        fn matches_exact_ids_only() {
-            assert!(has_fallen_back("node", "node"));
-            assert!(has_fallen_back("node,npm", "npm"));
-            assert!(!has_fallen_back("", "node"));
-            assert!(!has_fallen_back("node", "npm"));
-            assert!(!has_fallen_back("nodejs", "node"));
+        fn pid_scoped_entries_match_only_this_process() {
+            // Same tool, same process (an `execvp` re-entry) is a loop.
+            assert!(has_fallen_back("node:100", "node", 100));
+            assert!(has_fallen_back("npm:5,node:100", "node", 100));
+
+            // Same tool, but a different process (reached via a `fork`, like
+            // an npm script running `node`) is NOT a loop. This is the leak
+            // that #1086 was about.
+            assert!(!has_fallen_back("node:100", "node", 200));
+            assert!(!has_fallen_back("npm:5,node:100", "node", 200));
+
+            // Different tool never matches, regardless of process.
+            assert!(!has_fallen_back("node:100", "npm", 100));
+            assert!(!has_fallen_back("nodejs:100", "node", 100));
         }
 
         #[test]
-        fn appends_ids() {
-            assert_eq!(append_fallback("", "node"), "node");
-            assert_eq!(append_fallback("node", "npm"), "node,npm");
+        fn bare_ids_are_ignored() {
+            // proto always writes `id:pid`, so a bare id is stale/foreign
+            // (e.g. left by an older proto) and must never trip the guard.
+            assert!(!has_fallen_back("node", "node", 100));
+            assert!(!has_fallen_back("node,npm", "npm", 100));
+            assert!(!has_fallen_back("", "node", 100));
+            // A bare id mixed with a matching pid-scoped entry still trips.
+            assert!(has_fallen_back("node,npm:100", "npm", 100));
+        }
+
+        #[test]
+        fn appends_pid_scoped_entries() {
+            assert_eq!(append_fallback("", "node", 100), "node:100");
+            assert_eq!(append_fallback("node:100", "npm", 200), "node:100,npm:200");
         }
     }
 
@@ -648,6 +700,26 @@ mod tests {
                     sandbox.path().join("other-home/.proto/shims"),
                     sandbox.path().join("other-home/.proto/bin"),
                 ]),
+            );
+
+            assert_eq!(result, None);
+        }
+
+        #[test]
+        fn skips_foreign_store_shims_dir_by_registry_marker() {
+            let sandbox = create_empty_sandbox();
+            let env = create_env(sandbox.path());
+
+            // A proto store whose home isn't named `.proto` (a custom
+            // `PROTO_HOME`), so the name-based checks can't catch it. The
+            // `registry.json` marks the directory as a proto shims dir.
+            sandbox.create_file(format!("custom/shims/{}", path::exe_name("tool")), "");
+            sandbox.create_file("custom/shims/registry.json", "{}");
+
+            let result = find_global_executable(
+                &env,
+                "tool",
+                &join_dirs(&[sandbox.path().join("custom/shims")]),
             );
 
             assert_eq!(result, None);

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -113,13 +113,16 @@ pub enum ProtoCliError {
     MigrateUnknownOperation { op: String },
 
     // RUN
-    #[diagnostic(code(proto::commands::run::fallback_loop))]
+    #[diagnostic(
+        code(proto::commands::run::fallback_loop),
+        help(
+            "This typically means the executable resolves back to a proto shim -- for example a version manager shim on PATH, or another proto store on PATH whose HOME or PROTO_HOME differs from the current one."
+        )
+    )]
     #[error(
-        "Unable to run {tool}, as the global executable found at {} is a proto shim, which would trigger a recursive execution loop.\nThis can happen when a proto store exists on {} that does not match the current store, typically caused by {} or {} changing.",
+        "Unable to run {tool}, as the global executable at {} re-entered proto for the same tool, which would loop indefinitely.\nDetected via the inherited {} environment variable.",
         .path.style(Style::Path),
-        "PATH".style(Style::Property),
-        "HOME".style(Style::Property),
-        "PROTO_HOME".style(Style::Property),
+        "PROTO_INTERNAL_RUN_FALLBACK".style(Style::Property),
     )]
     RunFallbackLoop { tool: String, path: PathBuf },
 

--- a/crates/cli/tests/run_test.rs
+++ b/crates/cli/tests/run_test.rs
@@ -27,18 +27,42 @@ mod run {
         assert.stdout(predicate::str::contains("usage: git"));
     }
 
+    // A genuine execution loop: a "global" executable that re-invokes proto
+    // for the same tool through `exec`, which preserves the PID (as a proto
+    // shim, or a PATH wrapper that resolves back into proto, would). proto
+    // must detect its own re-entry and error rather than recurse forever.
+    // On a correct build this errors after a single re-entry; only a broken
+    // guard would spin until the sandbox timeout.
+    #[cfg(unix)]
     #[test]
     fn errors_instead_of_looping_when_fallback_reenters_proto() {
+        use std::os::unix::fs::PermissionsExt;
+
         let sandbox = create_empty_proto_sandbox();
+
+        sandbox.create_file(
+            "globals/loopy",
+            format!(
+                "#!/bin/sh\nexec '{}' run loopy\n",
+                env!("CARGO_BIN_EXE_proto")
+            ),
+        );
+
+        let globals_dir = sandbox.path().join("globals");
+
+        fs::set_permissions(globals_dir.join("loopy"), fs::Permissions::from_mode(0o755)).unwrap();
+
+        // Minimal PATH so only our fake `loopy` is discoverable.
+        let path_env = env::join_paths([globals_dir, "/usr/bin".into(), "/bin".into()]).unwrap();
 
         let assert = sandbox
             .run_bin(|cmd| {
-                cmd.arg("run").arg("git");
-                cmd.env("PROTO_INTERNAL_RUN_FALLBACK", "git");
+                cmd.arg("run").arg("loopy");
+                cmd.env("PATH", &path_env);
             })
             .failure();
 
-        assert.stderr(predicate::str::contains("recursive execution loop"));
+        assert.stderr(predicate::str::contains("would loop indefinitely"));
     }
 
     #[test]
@@ -54,6 +78,31 @@ mod run {
             .failure();
 
         assert.stdout(predicate::str::contains("usage: git"));
+    }
+
+    // A fallback guard inherited from an unrelated ancestor process (a
+    // different PID) must not abort the current invocation. This is the leak
+    // that broke nested npm tooling. https://github.com/moonrepo/proto/issues/1086
+    #[test]
+    fn fallback_guard_ignores_other_processes() {
+        let sandbox = create_empty_proto_sandbox();
+
+        // The test runner's PID is guaranteed to differ from the spawned
+        // proto process's PID, so this entry stands in for a leaked guard
+        // set by some earlier, unrelated fallback.
+        let foreign_pid = std::process::id();
+
+        let assert = sandbox
+            .run_bin(|cmd| {
+                cmd.arg("run").arg("git");
+                cmd.env("PROTO_INTERNAL_RUN_FALLBACK", format!("git:{foreign_pid}"));
+            })
+            // Falls through to the global `git`; no args is exit 1.
+            .failure();
+
+        assert
+            .stdout(predicate::str::contains("usage: git"))
+            .stderr(predicate::str::contains("would loop indefinitely").not());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #1086. The `PROTO_INTERNAL_RUN_FALLBACK` fallback-loop guard was a process-tree-wide environment variable used as a **single-hop** guard, so it leaked into the descendants of any real fallback executable and aborted unrelated, nested invocations of the same tool with a false `proto::commands::run::fallback_loop` error — breaking essentially all npm-based tooling in directories proto doesn't manage.

## Root cause

When proto has no pinned version, it falls back to the global executable and sets `PROTO_INTERNAL_RUN_FALLBACK=<tool>`, which is inherited by the **entire** process tree. A real fallback (e.g. Homebrew `node`) keeps running and spawns children; any descendant that later invokes the same tool through a shim (an npm script's `#!/usr/bin/env node`) sees the stale flag and aborts. The error message then blamed the resolved binary as a proto shim without ever verifying it.

## Fix

- **PID-scope the guard** (`id:pid`). A genuine loop re-enters proto via `execvp`, which replaces the process and preserves the PID; a real tool that spawns children forks (new PID), so a leaked guard now carries a foreign PID and is ignored. Bare ids (no PID) are ignored — this satisfies the issue's `PROTO_INTERNAL_RUN_FALLBACK=node node --version` litmus test and keeps cross-version upgrades safe (an older proto writes bare ids).
- **Skip foreign proto-shim dirs at selection** — `find_global_executable` now skips any `PATH` dir containing a shims `registry.json`, so a foreign store from a mismatched `PROTO_HOME` is never chosen as the global fallback. This preserves loop protection on Windows, where the spawn-based exec model makes the PID signal unavailable.
- **Reword the error** to describe the actual cause (the inherited guard variable) and stop asserting the resolved binary is a proto shim.

## Testing

- **Unit**: `has_fallen_back` PID-matching / bare-id-ignored / append behaviour, plus a `find_global_executable` test for the `registry.json` skip.
- **Integration** (`run_test.rs`): a real same-PID exec loop still errors (no hang), a leaked guard from a different PID is ignored and falls through to the global tool, and the other-tool / foreign-shim cases behave.
- Manually reproduced the issue's exact console session against the built binary: the leaked-guard command now runs `node`; a genuine loop errors cleanly; a foreign shim dir on `PATH` is skipped in favour of a real binary.

### Windows note / tradeoff

On Windows the PID guard is inert (spawn assigns a fresh PID each hop), so genuine-loop protection there rests on the new `registry.json` shim-dir skip — which also fixes the npm false-positive on Windows. The one uncovered case is an exotic non-`exec` wrapper that re-resolves back into a proto shim, which the spawn model can't distinguish from legitimate nesting anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
