### PR TITLE
new: Support frozen lockfiles.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@
     - Signature files may contain multiple binary signatures, multiple signatures in one armored block, or multiple concatenated armored blocks. Verification succeeds when any signature matches a trusted key.
     - GPG verification streams the artifact from disk in a blocking worker and records only the verified signer fingerprint and artifact SHA256 in lockfiles, instead of the armored public keyring.
 - **Lockfiles**
+  - Added a `--frozen-lockfile` flag to `proto install` (and a `PROTO_FROZEN_LOCKFILE` environment variable) that treats the lockfile as read-only. Versions are resolved from existing lockfile records, and the lockfile is never created, updated, or pruned.
+    - If a tool being installed has no matching record, the install fails instead of resolving a fresh version, which is useful for reproducible installs in CI.
+    - This flag cannot be combined with `--update-lockfile` or `--pin`.
   - Updated `proto pin` and `proto unpin` to always keep the lockfile of the modified config in sync, even when another config (like an environment config) takes precedence for the tool.
   - Updated `proto install --pin` to track the record of the installed version in the lockfile of the pinned config, even when another config (like an environment config) takes precedence for the tool.
   - Updated `proto uninstall` to remove records for the uninstalled version from all applicable lockfiles, as the version may be pinned in multiple configs (each of which is unpinned). When uninstalling all versions, the tool is removed from all applicable lockfiles.
@@ -53,6 +56,7 @@
   - Proto now also skips any directory on `PATH` that contains a shims `registry.json`, so a foreign proto store (from a mismatched `PROTO_HOME`) is never selected as the global fallback and can't trigger a loop.
   - Reworded the `fallback_loop` error to describe the actual cause instead of incorrectly claiming the resolved binary is a proto shim.
 - Fixed an issue where `proto uninstall` would fail when `PROTO_ENV` is set and an environment scoped `.prototools.<env>` config exists, as it would attempt to unpin the version from an invalid path.
+- Fixed an issue where an install that failed very early (before any progress output) could hang when not running in a TTY, as the non-TTY progress monitor could miss the exit signal.
 
 ## 0.60.2
 

--- a/crates/cli/src/commands/install.rs
+++ b/crates/cli/src/commands/install.rs
@@ -48,6 +48,15 @@ pub struct InstallArgs {
     #[arg(long, help = "Force reinstallation even if already installed")]
     pub force: bool,
 
+    #[arg(
+        long,
+        env = "PROTO_FROZEN_LOCKFILE",
+        group = "lockfile-mode",
+        conflicts_with = "pin",
+        help = "Error if the lockfile is missing a record or would be modified"
+    )]
+    pub frozen_lockfile: bool,
+
     #[arg(long, help = "Pin the resolved version to .prototools")]
     pub pin: Option<Option<PinLocation>>,
 
@@ -63,6 +72,7 @@ pub struct InstallArgs {
 
     #[arg(
         long,
+        group = "lockfile-mode",
         help = "Don't inherit a version from the lockfile and update the record"
     )]
     pub update_lockfile: bool,
@@ -164,7 +174,8 @@ pub async fn install_one(
 
     // Don't resolve the version from a lockfile
     spec.resolve_from_lockfile = !args.update_lockfile;
-    spec.update_lockfile = !args.internal;
+    spec.update_lockfile = !args.internal && !args.frozen_lockfile;
+    spec.frozen = args.frozen_lockfile;
 
     // Load config including global versions,
     // so that our requirements can be satisfied
@@ -214,8 +225,9 @@ pub async fn install_one(
     let outcome = result?;
     let tool = workflow.tool;
 
-    // Reconcile lockfiles by removing orphaned records
-    if !args.internal {
+    // Reconcile lockfiles by removing orphaned records, unless frozen, as
+    // pruning would modify the lockfile
+    if !args.internal && !args.frozen_lockfile {
         Locker::prune_orphaned_records(&session.env)?;
     }
 
@@ -324,7 +336,8 @@ async fn install_all(session: ProtoSession, args: InstallArgs) -> SessionResult 
 
         let mut spec = version.clone();
         spec.resolve_from_lockfile = !args.update_lockfile;
-        spec.update_lockfile = !args.internal;
+        spec.update_lockfile = !args.internal && !args.frozen_lockfile;
+        spec.frozen = args.frozen_lockfile;
 
         let tool_context = tool.context.clone();
         let topo_graph = topo_graph.clone();
@@ -435,8 +448,9 @@ async fn install_all(session: ProtoSession, args: InstallArgs) -> SessionResult 
 
     workflow_manager.stop_rendering().await?;
 
-    // Reconcile lockfiles by removing orphaned records
-    if !args.internal {
+    // Reconcile lockfiles by removing orphaned records, unless frozen, as
+    // pruning would modify the lockfile
+    if !args.internal && !args.frozen_lockfile {
         Locker::prune_orphaned_records(&session.env)?;
     }
 

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -446,6 +446,7 @@ pub async fn run(session: ProtoSession, mut args: RunArgs) -> SessionResult {
                         resolve_from_manifest: false,
                         resolve_from_lockfile: false,
                         update_lockfile: false,
+                        frozen: false,
                     }),
                     ..Default::default()
                 },

--- a/crates/cli/src/utils/progress_instance.rs
+++ b/crates/cli/src/utils/progress_instance.rs
@@ -34,9 +34,9 @@ pub fn monitor_non_tty_progress(
     reporter: ProgressReporter,
     id: Option<String>,
 ) -> JoinHandle<Result<(), ConsoleError>> {
-    tokio::spawn(Box::pin(async move {
-        let mut receiver = reporter.subscribe();
+    let mut receiver = reporter.subscribe();
 
+    tokio::spawn(Box::pin(async move {
         while let Ok(state) = receiver.recv().await {
             match state {
                 ProgressState::Exit => {

--- a/crates/cli/tests/install_all_lockfile_test.rs
+++ b/crates/cli/tests/install_all_lockfile_test.rs
@@ -319,4 +319,128 @@ version = "4.5.15"
             &UnresolvedVersionSpec::parse("5.0.0").unwrap()
         );
     }
+
+    mod frozen {
+        use super::*;
+
+        fn create_sandbox() -> ProtoSandbox {
+            let sandbox = create_empty_proto_sandbox();
+            sandbox.create_file(
+                ".prototools",
+                r#"
+protostar = "1"
+protoform = "2.1"
+
+[settings]
+unstable-lockfile = true
+builtin-backends = false
+builtin-tools = false
+"#,
+            );
+            sandbox
+        }
+
+        // protoform ignores os/arch, so its records must omit them to match
+        fn record(tool: &str, spec: &str, version: &str) -> String {
+            if tool == "protoform" {
+                format!(
+                    r#"
+[[tools.{tool}]]
+spec = "{spec}"
+version = "{version}"
+"#
+                )
+            } else {
+                format!(
+                    r#"
+[[tools.{tool}]]
+os = "{}"
+arch = "{}"
+spec = "{spec}"
+version = "{version}"
+"#,
+                    SystemOS::default(),
+                    SystemArch::default()
+                )
+            }
+        }
+
+        #[test]
+        fn installs_all_without_modifying_lockfile() {
+            let sandbox = create_sandbox();
+            sandbox.create_file(
+                ".protolock",
+                format!(
+                    "{}{}",
+                    record("protostar", "1", "1.10.15"),
+                    record("protoform", "2.1", "2.1.15"),
+                ),
+            );
+
+            sandbox
+                .run_bin(|cmd| {
+                    cmd.arg("install").arg("--frozen-lockfile");
+                })
+                .success();
+
+            // The lockfile is read-only, so no checksums were written back
+            let lockfile = ProtoLock::load(sandbox.path().join(".protolock")).unwrap();
+
+            let protostar = lockfile.tools.get("protostar").unwrap();
+
+            assert_eq!(protostar.len(), 1);
+            assert!(protostar[0].checksum.is_none());
+
+            let protoform = lockfile.tools.get("protoform").unwrap();
+
+            assert_eq!(protoform.len(), 1);
+            assert!(protoform[0].checksum.is_none());
+        }
+
+        #[test]
+        fn doesnt_prune_orphans_when_frozen() {
+            let sandbox = create_sandbox();
+            sandbox.create_file(
+                ".protolock",
+                format!(
+                    "{}{}{}",
+                    record("protostar", "1", "1.10.15"),
+                    // Orphaned: no longer matches the configured "1"
+                    record("protostar", "^4.5", "4.5.15"),
+                    record("protoform", "2.1", "2.1.15"),
+                ),
+            );
+
+            sandbox
+                .run_bin(|cmd| {
+                    cmd.arg("install").arg("--frozen-lockfile");
+                })
+                .success();
+
+            // Pruning would modify the lockfile, so the orphan is kept
+            let lockfile = ProtoLock::load(sandbox.path().join(".protolock")).unwrap();
+            let protostar = lockfile.tools.get("protostar").unwrap();
+
+            assert_eq!(protostar.len(), 2);
+        }
+
+        #[test]
+        fn errors_when_a_tool_is_missing_from_lockfile() {
+            let sandbox = create_sandbox();
+
+            // Only protostar is recorded; protoform has no record
+            sandbox.create_file(".protolock", record("protostar", "1", "1.10.15"));
+
+            sandbox
+                .run_bin(|cmd| {
+                    cmd.arg("install").arg("--frozen-lockfile");
+                })
+                .failure();
+
+            // The missing tool was never resolved or written to the lockfile
+            let lockfile = ProtoLock::load(sandbox.path().join(".protolock")).unwrap();
+
+            assert!(!lockfile.tools.contains_key("protoform"));
+        }
+    }
 }

--- a/crates/cli/tests/install_one_lockfile_test.rs
+++ b/crates/cli/tests/install_one_lockfile_test.rs
@@ -1025,4 +1025,148 @@ version = "1.0.0"
             );
         }
     }
+
+    mod frozen {
+        use super::*;
+
+        fn create_record(spec: &str, version: &str) -> String {
+            format!(
+                r#"
+[[tools.protostar]]
+os = "{}"
+arch = "{}"
+spec = "{spec}"
+version = "{version}"
+"#,
+                SystemOS::default(),
+                SystemArch::default()
+            )
+        }
+
+        #[test]
+        fn installs_from_locked_record_without_modifying_lockfile() {
+            let sandbox = create_proto_sandbox("lockfile");
+            sandbox.create_file(".protolock", create_record("5.0.0", "5.0.0"));
+
+            let assert = sandbox
+                .run_bin(|cmd| {
+                    cmd.arg("install")
+                        .arg("protostar")
+                        .arg("5.0.0")
+                        .arg("--frozen-lockfile");
+                })
+                .success();
+
+            assert.stdout(predicate::str::contains(
+                "protostar 5.0.0 has been installed",
+            ));
+
+            // The lockfile is authoritative and read-only, so no checksum
+            // was written back for the installed version
+            let lockfile = ProtoLock::load(sandbox.path().join(".protolock")).unwrap();
+            let records = lockfile.tools.get("protostar").unwrap();
+
+            assert_eq!(records.len(), 1);
+            assert_record!(records[0], "5.0.0");
+            assert!(records[0].checksum.is_none());
+        }
+
+        #[test]
+        fn inherits_locked_version_from_range() {
+            let sandbox = create_proto_sandbox("lockfile");
+            sandbox.create_file(".protolock", create_record("^5.10", "5.10.10"));
+
+            // 5.10.15 is the latest, but the frozen record pins 5.10.10
+            let assert = sandbox
+                .run_bin(|cmd| {
+                    cmd.arg("install")
+                        .arg("protostar")
+                        .arg("^5.10")
+                        .arg("--frozen-lockfile");
+                })
+                .success();
+
+            assert.stdout(predicate::str::contains(
+                "protostar 5.10.10 has been installed",
+            ));
+        }
+
+        #[test]
+        fn errors_when_record_is_missing() {
+            let sandbox = create_proto_sandbox("lockfile");
+
+            // The lockfile is enabled but has no record for the tool
+            let assert = sandbox
+                .run_bin(|cmd| {
+                    cmd.arg("install")
+                        .arg("protostar")
+                        .arg("5.0.0")
+                        .arg("--frozen-lockfile");
+                })
+                .failure();
+
+            assert.stderr(predicate::str::contains("Lockfile is frozen"));
+
+            // Nothing was written to the lockfile
+            assert!(!sandbox.path().join(".protolock").exists());
+        }
+
+        #[test]
+        fn errors_when_requested_version_isnt_locked() {
+            let sandbox = create_proto_sandbox("lockfile");
+            sandbox.create_file(".protolock", create_record("5.0.0", "5.0.0"));
+
+            // The lockfile only has 5.0.0, so installing 5.10.0 would
+            // require adding a new record
+            let assert = sandbox
+                .run_bin(|cmd| {
+                    cmd.arg("install")
+                        .arg("protostar")
+                        .arg("5.10.0")
+                        .arg("--frozen-lockfile");
+                })
+                .failure();
+
+            assert.stderr(predicate::str::contains("Lockfile is frozen"));
+
+            // And the existing record was left untouched
+            let lockfile = ProtoLock::load(sandbox.path().join(".protolock")).unwrap();
+            let records = lockfile.tools.get("protostar").unwrap();
+
+            assert_eq!(records.len(), 1);
+            assert_record!(records[0], "5.0.0");
+        }
+
+        #[test]
+        fn errors_when_combined_with_update_lockfile() {
+            let sandbox = create_proto_sandbox("lockfile");
+
+            sandbox
+                .run_bin(|cmd| {
+                    cmd.arg("install")
+                        .arg("protostar")
+                        .arg("5.0.0")
+                        .arg("--frozen-lockfile")
+                        .arg("--update-lockfile");
+                })
+                .failure()
+                .stderr(predicate::str::contains("cannot be used with"));
+        }
+
+        #[test]
+        fn errors_when_combined_with_pin() {
+            let sandbox = create_proto_sandbox("lockfile");
+
+            sandbox
+                .run_bin(|cmd| {
+                    cmd.arg("install")
+                        .arg("protostar")
+                        .arg("5.0.0")
+                        .arg("--frozen-lockfile")
+                        .arg("--pin");
+                })
+                .failure()
+                .stderr(predicate::str::contains("cannot be used with"));
+        }
+    }
 }

--- a/crates/core/src/flow/lock.rs
+++ b/crates/core/src/flow/lock.rs
@@ -14,17 +14,17 @@ use version_spec::{UnresolvedVersionSpec, VersionSpec};
 //      [x] validate lock record
 //      [x] create lockfile if it does not exist
 //      [x] error if spec/req is not found in lockfile
-//      [ ] frozen lockfiles
+//      [x] frozen lockfiles
 //      [x] orphan pruning
 // [x] install one
 //      [x] resolve version from lockfile
 //      [x] validate lock record
-//      [ ] frozen lockfiles
+//      [x] frozen lockfiles
 //      [x] orphan pruning
 // [x] install one version
 //      [x] don't resolve version from lockfile
 //      [x] validate lock record
-//      [ ] frozen lockfiles
+//      [x] frozen lockfiles
 //      [x] orphan pruning
 // [x] uninstall
 //      [x] remove from lockfile

--- a/crates/core/src/flow/lock_error.rs
+++ b/crates/core/src/flow/lock_error.rs
@@ -45,6 +45,17 @@ pub enum ProtoLockError {
         source_url: String,
     },
 
+    #[diagnostic(
+        code(proto::install::frozen_lockfile),
+        help = "Run `proto install` without `--frozen-lockfile` to populate the lockfile, then commit the changes."
+    )]
+    #[error(
+        "Lockfile is frozen, but is missing a record for {} {}. The lockfile is either not enabled or out of date.",
+        .tool.style(Style::Id),
+        .spec.style(Style::Hash),
+    )]
+    FrozenMissingRecord { tool: String, spec: String },
+
     #[diagnostic(code(proto::install::mismatched_arch))]
     #[error(
         "System architecture mismatch! Received {} but expected {}.",

--- a/crates/core/src/flow/resolve.rs
+++ b/crates/core/src/flow/resolve.rs
@@ -1,5 +1,5 @@
 pub use super::resolve_error::ProtoResolveError;
-use crate::flow::lock::Locker;
+use crate::flow::lock::{Locker, ProtoLockError};
 use crate::helpers::is_offline;
 use crate::tool::Tool;
 use crate::tool_spec::ToolSpec;
@@ -128,23 +128,34 @@ impl<'tool> Resolver<'tool> {
         let mut candidate = spec.req.clone();
 
         // If requested, resolve the version from a lockfile
-        if spec.resolve_from_lockfile
-            && let Some(record) = Locker::new(self.tool).resolve_locked_record(spec)?
-        {
-            let version = record
-                .version
-                .clone()
-                .expect("Version missing from lockfile record!");
+        if spec.resolve_from_lockfile {
+            if let Some(record) = Locker::new(self.tool).resolve_locked_record(spec)? {
+                let version = record
+                    .version
+                    .clone()
+                    .expect("Version missing from lockfile record!");
 
-            debug!(
-                tool = self.tool.context.as_str(),
-                spec = candidate.to_string(),
-                "Inherited version {} from lockfile",
-                version
-            );
+                debug!(
+                    tool = self.tool.context.as_str(),
+                    spec = candidate.to_string(),
+                    "Inherited version {} from lockfile",
+                    version
+                );
 
-            spec.version_locked = Some(record);
-            candidate = version.to_unresolved_spec();
+                spec.version_locked = Some(record);
+                candidate = version.to_unresolved_spec();
+            }
+            // When frozen, the lockfile is authoritative and must already
+            // contain a record for the requested specification. Resolving a
+            // fresh version would require writing to the lockfile, so error
+            // instead of silently falling through to remote resolution
+            else if spec.frozen {
+                return Err(ProtoLockError::FrozenMissingRecord {
+                    tool: self.tool.get_name().to_owned(),
+                    spec: spec.req.to_string(),
+                }
+                .into());
+            }
         }
 
         let version = self

--- a/crates/core/src/tool_spec.rs
+++ b/crates/core/src/tool_spec.rs
@@ -26,6 +26,12 @@ pub struct ToolSpec {
 
     /// Update the lockfile when applicable?
     pub update_lockfile: bool,
+
+    /// Treat the lockfile as frozen (read-only)? When enabled, the version
+    /// must resolve from an existing lockfile record, and the lockfile is
+    /// never created or modified. If a matching record does not exist, an
+    /// error is raised instead of resolving a fresh version.
+    pub frozen: bool,
 }
 
 impl ToolSpec {
@@ -84,6 +90,7 @@ impl Default for ToolSpec {
             resolve_from_lockfile: true,
             resolve_from_manifest: true,
             update_lockfile: true,
+            frozen: false,
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds `--frozen-lockfile` support to `proto install`, completing the remaining `frozen lockfiles` checklist items in `crates/core/src/flow/lock.rs`. Builds on the env-scoped lockfile and orphan-pruning work already in `develop-0.61`.

When frozen, the lockfile is treated as read-only and authoritative:

- Versions resolve **only** from existing lockfile records.
- If a tool being installed has no matching record, the install **errors** (`FrozenMissingRecord`) instead of resolving a fresh version — the same idea as `npm ci` / yarn `--frozen-lockfile`.
- The lockfile is never created, updated, or pruned. Checksum verification still runs.

## Surface

- `--frozen-lockfile` flag on `proto install`, plus a `PROTO_FROZEN_LOCKFILE` environment variable for CI.
- Mutually exclusive with `--update-lockfile`; conflicts with `--pin` (both would mutate the lockfile).

```bash
# Fails if the lockfile is missing/out of date, never writes to it
proto install --frozen-lockfile
```

## Changes

- `tool_spec.rs` — new `ToolSpec.frozen` field.
- `flow/lock_error.rs` — `FrozenMissingRecord { tool, spec }` (`proto::install::frozen_lockfile`).
- `flow/resolve.rs` — error when frozen and no locked record is found, instead of falling through to remote resolution.
- `commands/install.rs` — the flag, spec wiring, and skipping orphan pruning when frozen (both `install_one` and `install_all`).
- `commands/run.rs` — updated the `ToolSpec` literal.

## Drive-by fix

The first test runs hung for 300s. A frozen missing-record error fails so fast (no network or version load) that `stop_rendering` calls `reporter.exit()` before the non-TTY progress monitor — which subscribed *inside* its spawned task — had subscribed, so the exit signal was missed and the `await` hung forever. This is a latent race that **any** fast-failing install would hit in non-TTY mode (i.e. CI). Fixed by subscribing before spawning the task (`utils/progress_instance.rs`).

## Notes

- In `install_all`, a missing record fails that tool (non-zero exit) while other locked tools still install — consistent with how proto reports per-tool install failures, rather than failing before anything installs. Happy to tighten to fail-fast if preferred.

## Testing

- 6 new tests in `install_one_lockfile_test.rs`, 3 in `install_all_lockfile_test.rs` (`mod frozen`).
- All 41 lockfile tests pass; `errors_when_record_is_missing` now completes in ~1.2s.
- All 34 `install_one`/`install_all` tests pass (regression check for the progress fix).
- `cargo fmt` and `cargo clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
