### PR TITLE
fix: Respect `detect-strategy` when installing a single tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 #### 🐞 Fixes
 
+- Fixed `proto install <tool>` not respecting the `detect-strategy` setting. It resolved a version by scanning the working directory for the tool's own version file before consulting `.prototools`, unlike `proto run`, `proto status` and a bare `proto install`, which all honour the setting. A repo pinning `go = "1.26.7"` with `detect-strategy = "prefer-prototools"` beside a `go.work` would install whatever the `go` directive's range resolved to, and `proto run go` would then fail with `missing_tool`. As a consequence, `install` now also detects ecosystem files by traversing the config file chain rather than only the working directory, and honours `PROTO_<TOOL>_VERSION`.
 - Fixed virtual path conversion producing a path with a trailing separator when the path being converted is a virtual/real prefix itself (`Path::join("")` appends a separator). This surfaced in moon as `$env.PWD contains trailing slashes` errors from nushell when plugin commands ran at the workspace root.
 
 ## 0.60.2

--- a/crates/cli/src/commands/install.rs
+++ b/crates/cli/src/commands/install.rs
@@ -5,7 +5,7 @@ use crate::utils::install_graph::*;
 use crate::utils::tool_record::ToolRecord;
 use crate::workflows::{InstallOutcome, InstallWorkflowManager, InstallWorkflowParams};
 use clap::Args;
-use proto_core::flow::detect::Detector;
+use proto_core::flow::detect::{Detector, ProtoDetectError};
 use proto_core::{
     ConfigMode, Id, PinLocation, Tool, ToolContext, ToolSpec, reporter::NoticeOutput,
 };
@@ -147,15 +147,12 @@ pub async fn install_one(
     // otherwise fallback to "latest"
     let mut spec = if let Some(spec) = &args.spec {
         spec.to_owned()
-    } else if let Some((spec, _)) = Detector::new(&tool)
-        .detect_version_from(&session.env.working_dir)
-        .await?
-    {
-        spec.into()
-    } else if let Some(spec) = session.load_config()?.versions.get(&context) {
-        spec.to_owned()
     } else {
-        ToolSpec::default()
+        match Detector::detect(&tool).await {
+            Ok((spec, _)) => spec,
+            Err(ProtoDetectError::FailedVersionDetect { .. }) => ToolSpec::default(),
+            Err(error) => return Err(error.into()),
+        }
     };
 
     // Don't resolve the version from the manifest

--- a/crates/cli/tests/install_one_test.rs
+++ b/crates/cli/tests/install_one_test.rs
@@ -91,6 +91,71 @@ mod install_one {
     }
 
     #[test]
+    fn prefers_prototools_over_ecosystem_file() {
+        let sandbox = create_empty_proto_sandbox();
+        sandbox.create_file(
+            ".prototools",
+            "protostar = \"1.2.3\"\n\n[settings]\ndetect-strategy = \"prefer-prototools\"\n",
+        );
+        sandbox.create_file(".protostarrc", "^1.2.3");
+
+        sandbox
+            .run_bin(|cmd| {
+                cmd.arg("install").arg("protostar");
+            })
+            .success();
+
+        assert!(sandbox.path().join(".proto/tools/protostar/1.2.3").exists());
+        assert!(
+            !sandbox
+                .path()
+                .join(".proto/tools/protostar/1.10.15")
+                .exists()
+        );
+    }
+
+    #[test]
+    fn only_prototools_ignores_ecosystem_file() {
+        let sandbox = create_empty_proto_sandbox();
+        sandbox.create_file(
+            ".prototools",
+            "protostar = \"1.2.3\"\n\n[settings]\ndetect-strategy = \"only-prototools\"\n",
+        );
+        sandbox.create_file(".protostarrc", "^1.2.3");
+
+        sandbox
+            .run_bin(|cmd| {
+                cmd.arg("install").arg("protostar");
+            })
+            .success();
+
+        assert!(sandbox.path().join(".proto/tools/protostar/1.2.3").exists());
+        assert!(
+            !sandbox
+                .path()
+                .join(".proto/tools/protostar/1.10.15")
+                .exists()
+        );
+    }
+
+    #[test]
+    fn detects_ecosystem_file_from_parent_dir() {
+        let sandbox = create_empty_proto_sandbox();
+        sandbox.create_file(".protostarrc", "1.2.3");
+        sandbox.create_file("nested/.gitkeep", "");
+
+        sandbox
+            .run_bin(|cmd| {
+                cmd.arg("install")
+                    .arg("protostar")
+                    .current_dir(sandbox.path().join("nested"));
+            })
+            .success();
+
+        assert!(sandbox.path().join(".proto/tools/protostar/1.2.3").exists());
+    }
+
+    #[test]
     fn installs_latest_if_no_version() {
         let sandbox = create_empty_proto_sandbox();
 


### PR DESCRIPTION
Closes #1091.

`proto install <tool>` resolved its version by scanning the working directory for the
tool's own version files *before* consulting `.prototools`, and without ever reading
`settings.detect_strategy`. It was the only caller of the low-level
`Detector::detect_version_from` outside `detect.rs`; `run`, `status`, `activate` and
`install_all` all go through `Detector::detect`, which is where the strategy is read.

So a repo that set `detect-strategy = "prefer-prototools"` (or even `"only-prototools"`)
still had the ecosystem file win for `install` — and then `run`, which honoured the
setting, asked for the pinned version that was never installed and failed with
`missing_tool`. Details and a repro in the issue.

## The change

`install_one` now uses `Detector::detect`, the same entry point `install_all` uses a
few lines below it, mapping `FailedVersionDetect` onto the existing "fall back to
latest" behaviour. The `session.load_config()` branch it replaces is redundant —
`Detector::detect` already reads `.prototools` through `detect_from_proto_config`.

Three behaviour changes fall out of that, all of them in the direction of matching
what the other commands already do:

1. **`detect-strategy` is honoured.** The fix.
2. **Ecosystem files are found by walking the config-file chain**, not just the cwd.
   Previously `.prototools` was read all the way up while `go.mod`/`package.json`/…
   was only read in the working directory, so under the default `first-available` a
   parent directory's version file was invisible to `install` alone.
3. **`PROTO_<TOOL>_VERSION` now applies to `proto install <tool>`**, as it already
   does to `run`, `status` and bare `install`. Called out because it is a real change
   in what `install` reads; it is also what makes `proto install node` agree with the
   `proto run node` that follows it.

No information is lost by routing through the detector: `.prototools` entries
deserialize from a plain string, so a config `ToolSpec` carries only `req`, and
`install_one` overwrites `resolve_from_manifest` / `resolve_from_lockfile` /
`update_lockfile` immediately afterwards.

## Tests

The existing `installs_via_detection` and `installs_via_prototools` each put a single
source in the sandbox, so neither could see the ordering. Three tests added to
`install_one`:

- `prefers_prototools_over_ecosystem_file` — `.prototools` pinning `1.2.3` with
  `prefer-prototools`, beside a `.protostarrc` of `^1.2.3`. Asserts 1.2.3 is installed
  and 1.10.15 is not. **Fails on master.**
- `only_prototools_ignores_ecosystem_file` — the same with `only-prototools`.
- `detects_ecosystem_file_from_parent_dir` — covers change 2.

`installs_via_detection` is deliberately unchanged: under the default
`first-available`, an ecosystem file in the cwd must still win when no `.prototools`
sits beside it.

## Verified

- The three new tests fail on `master` and pass with the change; the two existing
  detection tests pass either way (before: 2 passed / 3 failed, after: 5 passed).
- End to end with the real Go plugin, in a throwaway directory holding a `.prototools`
  of `go = "1.26.7"` + `prefer-prototools` beside a `go.work` of `go 1.26.7`:
  `proto install go` now logs `[go] Go 1.26.7 installed`, where a release build
  installs 1.27.0 in the same directory.
- `cargo fmt --all --check` and `cargo clippy --workspace --all-targets` are clean.

One note for anyone reproducing locally rather than in CI: outside the nix devshell
the CLI tests need `WARPGATE_PLUGINS_DIR=$PWD/plugins`, since `just build-wasm`
writes to `plugins/target/` and `find_wasm_file_with_name`'s traversal from
`CARGO_MANIFEST_DIR` doesn't reach it. Without it every CLI test fails with
"Test plugins not available", unrelated to this change.
