### PR TITLE
test(e2e): Never let a failing command hide its output

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -21,9 +21,39 @@ bash ./e2e/run.sh install
 bash ./e2e/run.sh node
 ```
 
-Per-test stdout/stderr is captured under `e2e/.logs/<name>.log`. The shared `PROTO_HOME` lives at `e2e/.proto-home` and is wiped at the start of each run.
+Per-test stdout/stderr is captured under `e2e/.logs/<name>.log`. The shared `PROTO_HOME` lives at `e2e/.proto-home`, so a run never touches your own `~/.proto` — the suite installs 20+ tools into the store, uninstalls one, and runs `proto clean` over it.
 
-Override the binary location with `PROTO_BIN_DIR=/some/dir bash ./e2e/run.sh` if you want to test a binary other than `target/release/proto`.
+State is kept between runs (`bootstrap.sh` puts the binary under test into the store, so the harness can't wipe it). To start clean:
+
+```bash
+rm -rf e2e/.proto-home && ./e2e/bootstrap.sh
+```
+
+## Env knobs
+
+| Variable              | Effect                                                                                  |
+| --------------------- | --------------------------------------------------------------------------------------- |
+| `E2E_SERIAL=1`        | Never run a `# group:` in parallel. First thing to try when a failure smells like a race |
+| `E2E_TAIL=200`        | How many lines of a failing test's log to print inline (default 40)                      |
+| `E2E_KEEP_SCRATCH=1`  | Keep the shared work dir instead of deleting it on exit, and print its path              |
+| `E2E_USE_REAL_HOME=1` | Use `~/.proto` as the store instead of `e2e/.proto-home`                                 |
+
+## Debugging a failure
+
+A failing test prints, in order: the `ASSERT FAIL` / `COMMAND FAILED` lines from its log, the tail of the log, and the path to a post-mortem file. The post-mortem (`e2e/.logs/<name>.postmortem.txt`) captures the state the test left behind — the shared `.prototools`, the shim registry, the shims directory, and `proto status` — none of which is visible in the test's own log. CI uploads both as the `e2e-logs-<os>` artifact.
+
+Helpers never swallow a command's output. Use `run_probe` for anything whose exit code you want to assert on:
+
+```bash
+run_probe proto bin node
+echo_probe path                       # exit=, path=, stderr= into the log
+
+if [[ $RUN_RC -ne 0 ]]; then
+  fail "proto bin node exited $RUN_RC"
+fi
+```
+
+A bare `out=$(cmd)` aborts the test under `set -e` before anything can be printed, which is how a failing shim once produced a log that just stopped mid-sentence.
 
 ## Layout
 
@@ -67,7 +97,7 @@ source "$(dirname "$0")/../lib/assert.sh"
 
 - **`# requires:`** — if any named test FAILED or was SKIPPED, this test is also SKIPPED. Used for tool dependencies (`npm` requires `node`).
 - **`# os:`** — allow-list of OSes. Default = all 3. Used for `30-asdf-backend` (`linux,macos`) since the asdf backend doesn't run on Windows.
-- **`# group:`** — consecutive tests sharing this value run as background jobs in parallel. The harness waits for the whole group to finish before moving on to the next test. Used to fan out the install phase: `10–18` share `install-base`, `20–23` share `install-deps`. Members of the same group must be independent of each other — `# requires:` should only point to tests in earlier groups or earlier sequential tests, not peers in the same group (peer status isn't recorded until the batch completes).
+- **`# group:`** — consecutive tests sharing this value run as background jobs in parallel. The harness waits for the whole group to finish before moving on to the next test. Used to fan out the install phase: `10–18` share `tools`, `20–25` share `tools-secondary`, `30–32` share `backends`. Members of the same group must be independent of each other — `# requires:` should only point to tests in earlier groups or earlier sequential tests, not peers in the same group (peer status isn't recorded until the batch completes).
 
 ## Adding a test
 

--- a/e2e/lib/assert.sh
+++ b/e2e/lib/assert.sh
@@ -10,6 +10,33 @@ fail() {
   return 1
 }
 
+# Report what died and where, for any failure the caller does not handle.
+# Without this, `set -e` aborts the test silently and its log just stops
+# mid-way, with no exit code and no message.
+#
+# Failures inside a command substitution are skipped: they are either handled
+# by the caller (`out=$(cmd) || rc=$?`) or reported again by the assignment
+# that surrounds them, and reporting both is just noise.
+_report_failure() {
+  local rc=$?
+
+  if [[ ${BASH_SUBSHELL:-0} -ne 0 ]]; then
+    return 0
+  fi
+
+  echo "COMMAND FAILED (exit=$rc) at ${BASH_SOURCE[1]}:${BASH_LINENO[0]}: $BASH_COMMAND" >&2
+
+  local i
+  for ((i = 1; i < ${#FUNCNAME[@]} - 1; i++)); do
+    echo "  called from ${FUNCNAME[$i]} (${BASH_SOURCE[$i + 1]}:${BASH_LINENO[$i]})" >&2
+  done
+}
+
+# `errtrace` so the trap also covers failures inside functions, which is where
+# every assertion and helper lives
+set -o errtrace
+trap _report_failure ERR
+
 assert_eq() {
   [[ "$1" == "$2" ]] || fail "expected '$2', got '$1'"
 }
@@ -45,6 +72,50 @@ assert_dir() {
 assert_executable() {
   [[ -n "$1" ]] || fail "empty path passed to assert_executable"
   [[ -x "$1" || -f "$1.exe" || "$1" == *.cmd ]] || fail "not executable: $1"
+}
+
+# Run a command and record its result in RUN_RC / RUN_OUT / RUN_ERR, keeping
+# stdout and stderr separate. Never aborts the caller, so the result can be
+# logged before it is asserted on.
+#
+# This exists because `out=$(cmd)` under `set -e` aborts the test the moment
+# the command fails, before any diagnostic can be printed, which turns a
+# failing tool into a log that simply stops.
+run_probe() {
+  local err_file
+  err_file=$(mktemp)
+
+  RUN_CMD="$*"
+  RUN_RC=0
+  RUN_OUT=$("$@" 2>"$err_file") || RUN_RC=$?
+  RUN_ERR=$(cat "$err_file")
+
+  rm -f "$err_file"
+
+  # Tools are inconsistent about which stream they report on, so most
+  # assertions want both
+  if [[ -n "$RUN_ERR" ]]; then
+    RUN_ALL="$RUN_OUT
+$RUN_ERR"
+  else
+    RUN_ALL="$RUN_OUT"
+  fi
+}
+
+# Echo what a `run_probe` saw, for the test log.
+echo_probe() {
+  echo "\$ $RUN_CMD"
+  echo "  exit=$RUN_RC"
+  echo "  ${1:-output}=$RUN_OUT"
+
+  if [[ -n "$RUN_ERR" ]]; then
+    echo "  stderr=$RUN_ERR"
+  fi
+}
+
+# Assert the last `run_probe` succeeded, naming the command that didn't.
+assert_probe_ok() {
+  [[ $RUN_RC -eq 0 ]] || fail "\`$RUN_CMD\` exited $RUN_RC"
 }
 
 # Retry a command with backoff. Use only for network-bound install commands.

--- a/e2e/lib/env.sh
+++ b/e2e/lib/env.sh
@@ -32,8 +32,17 @@ mkdir -p "$E2E_LOGS"
 # Shared PROTO_HOME for the whole run. Tests accumulate state here.
 # Keep an internal POSIX form for bash builtins / PATH composition,
 # and export PROTO_HOME in the form proto's binary expects.
+#
+# This lives inside the repo (and is gitignored) so that a local run cannot
+# touch the developer's own store: the suite installs 20+ tools, uninstalls
+# one, and runs `proto clean` over whatever it finds. Set E2E_USE_REAL_HOME=1
+# to point it back at ~/.proto.
 if [[ -z "${_PROTO_HOME_POSIX:-}" ]]; then
-  _PROTO_HOME_POSIX="$HOME/.proto"
+  if [[ -n "${E2E_USE_REAL_HOME:-}" ]]; then
+    _PROTO_HOME_POSIX="$HOME/.proto"
+  else
+    _PROTO_HOME_POSIX="$E2E_DIR/.proto-home"
+  fi
 fi
 
 if [[ "$E2E_OS" == "windows" ]]; then
@@ -54,6 +63,24 @@ export PATH="$_PROTO_HOME_POSIX/shims:$_PROTO_HOME_POSIX/bin:$PATH"
 # Stable locale across runners (stderr matching shouldn't depend on it)
 export LANG="${LANG:-C.UTF-8}"
 export LC_ALL="${LC_ALL:-C.UTF-8}"
+
+# proto detects AI agents and switches its output to NDJSON, which breaks every
+# assertion in the suite — `just test-e2e` run from inside an agent fails on
+# output no human ever sees. Neutralize the detection (an empty value counts as
+# not set) and pin the reporter, the same way the Rust tests do in
+# crates/core/src/test_utils.rs.
+for _ai_var in \
+  AI_AGENT ANTIGRAVITY_AGENT AUGMENT_AGENT CLAUDECODE CLAUDE_CODE \
+  CLAUDE_CODE_IS_COWORK CODEX_CI CODEX_SANDBOX CODEX_THREAD_ID \
+  COPILOT_ALLOW_ALL COPILOT_CLI COPILOT_GITHUB_TOKEN COPILOT_MODEL \
+  CURSOR_AGENT CURSOR_EXTENSION_HOST_ROLE CURSOR_TRACE_ID GEMINI_CLI \
+  OPENCODE OPENCODE_CLIENT REPL_ID; do
+  export "$_ai_var="
+done
+unset _ai_var
+
+export PROTO_JSON=false
+export PROTO_REPORTER=text
 
 # Match existing CI diagnostics
 export PROTO_DEBUG_COMMAND=1

--- a/e2e/lib/utils.sh
+++ b/e2e/lib/utils.sh
@@ -48,36 +48,23 @@ test_bin() {
 
   echo "Verifying bin is executable..."
 
-  local bin="" bin_rc=0
-  bin=$(proto bin "$context")
-  bin_rc=$?
+  run_probe proto bin "$context"
+  echo_probe path
+  assert_probe_ok
 
-  echo "  exit=$bin_rc"
-  echo "  path=$bin"
-
-  if [[ $bin_rc -ne 0 ]]; then
-    fail "bin '$bin' exited $bin_rc"
-  fi
-
+  local bin="$RUN_OUT"
   assert_executable "$bin"
 
   echo "Verifying bin version..."
 
-  local ver="" bin_rc=0
-  ver=$("$bin" "$version_arg" 2>&1)
-  bin_rc=$?
-
-  echo "  exit=$bin_rc"
-  echo "  output=$ver"
-
-  if [[ $bin_rc -ne 0 ]]; then
-    fail "bin '$bin' exited $bin_rc"
-  fi
+  run_probe "$bin" "$version_arg"
+  echo_probe
+  assert_probe_ok
 
   # Ignore versions that contain a scope,
   # as the scope is typically not included in the outputs
   if [[ $version =~ ^[0-9] ]]; then
-    assert_contains "$ver" "$version"
+    assert_contains "$RUN_ALL" "$version"
   fi
 }
 
@@ -94,33 +81,22 @@ test_shim() {
 
   echo "Verifying shim is executable..."
 
-  local shim="" shim_rc=0
-  shim=$(command -v "$exe_name")
-  shim_rc=$?
+  run_probe command -v "$exe_name"
+  echo_probe path
 
-  echo "  exit=$shim_rc"
-  echo "  path=$shim"
-
-  if [[ $shim_rc -ne 0 ]]; then
-    fail "shim '$shim' exited $shim_rc"
+  if [[ $RUN_RC -ne 0 ]]; then
+    fail "no shim named '$exe_name' found on PATH"
   fi
 
+  local shim="$RUN_OUT"
   assert_executable "$shim"
 
   echo "Verifying shim version..."
 
-  local ver="" shim_rc=0
-  ver=$("$shim" "$version_arg" 2>&1)
-  shim_rc=$?
-
-  echo "  exit=$shim_rc"
-  echo "  output=$ver"
-
-  if [[ $shim_rc -ne 0 ]]; then
-    fail "shim '$shim' exited $shim_rc"
-  fi
-
-  assert_contains "$ver" "$version"
+  run_probe "$shim" "$version_arg"
+  echo_probe
+  assert_probe_ok
+  assert_contains "$RUN_ALL" "$version"
 
   unset PROTO_DEBUG_SHIM
 }
@@ -132,20 +108,13 @@ install_tool() {
 
   echo "Installing tool $tool $version..."
 
-  retry 3 proto install "$tool" "$version" --pin local --log trace
-  local exit_code=$?
-
-  if [[ $exit_code -ne 0 ]]; then
-    return $exit_code
-  fi
+  retry 3 proto install "$tool" "$version" --pin local --log trace || return $?
 
   test_bin "$tool" "$version" "$version_arg"
 
   if [[ "$tool" != "rust" && "$tool" != "jdk" && "$tool" != "jre" ]]; then
     test_shim "$tool" "$version" "$version_arg"
   fi
-
-  return $exit_code
 }
 
 install_backend() {
@@ -158,15 +127,8 @@ install_backend() {
 
   echo "Installing backend tool $context $version..."
 
-  retry 3 proto install "$context" "$version" --pin local --log trace
-  local exit_code=$?
-
-  if [[ $exit_code -ne 0 ]]; then
-    return $exit_code
-  fi
+  retry 3 proto install "$context" "$version" --pin local --log trace || return $?
 
   test_bin "$id" "$version" "$version_arg"
   test_shim "$id" "$version" "$version_arg"
-
-  return $exit_code
 }

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -10,6 +10,11 @@
 # Usage:
 #   ./e2e/run.sh             # run all tests
 #   ./e2e/run.sh install     # only tests whose name contains "install"
+#
+# Env knobs:
+#   E2E_SERIAL=1        # never run a group in parallel, one test at a time
+#   E2E_TAIL=200        # lines of a failing test's log to print inline
+#   E2E_KEEP_SCRATCH=1  # keep the shared work dir for post-mortem poking
 set -euo pipefail
 
 source "$(dirname "$0")/lib/env.sh"
@@ -24,6 +29,25 @@ if ! command -v proto >/dev/null 2>&1 || ! proto --version >/dev/null 2>&1; then
   exit 1
 fi
 
+# State is intentionally kept between runs: bootstrap.sh puts the binary under
+# test into the store, so wiping it here would delete what we are testing. To
+# start from scratch, remove the store and re-bootstrap:
+#   rm -rf e2e/.proto-home && ./e2e/bootstrap.sh
+
+# Neutral cwd for tests that don't need a specific work dir. Lives outside
+# the repo so the repo's own .prototools doesn't get picked up as ancestry.
+E2E_SCRATCH="$(mktemp -d)"
+export E2E_SCRATCH
+
+if [[ -z "${E2E_KEEP_SCRATCH:-}" ]]; then
+  trap 'rm -rf "$E2E_SCRATCH"' EXIT
+fi
+
+E2E_TAIL="${E2E_TAIL:-40}"
+
+# Stale post-mortems from an earlier run would be read as belonging to this one
+rm -f "$E2E_LOGS"/*.postmortem.txt
+
 echo "Using proto at: $(command -v proto)"
 echo "With version: $(proto --version)"
 echo ""
@@ -32,18 +56,9 @@ echo "PROTO_HOME: $PROTO_HOME"
 echo "E2E_DIR:    $E2E_DIR"
 echo "E2E_LOGS:   $E2E_LOGS"
 echo "REPO_ROOT:  $REPO_ROOT"
+echo "SCRATCH:    $E2E_SCRATCH"
 echo "PATH:       $PATH"
 echo ""
-
-# Wipe state from any previous run
-# rm -rf "$_PROTO_HOME_POSIX" "$E2E_LOGS"
-# mkdir -p "$_PROTO_HOME_POSIX" "$E2E_LOGS"
-
-# Neutral cwd for tests that don't need a specific work dir. Lives outside
-# the repo so the repo's own .prototools doesn't get picked up as ancestry.
-E2E_SCRATCH="$(mktemp -d)"
-trap 'rm -rf "$E2E_SCRATCH"' EXIT
-export E2E_SCRATCH
 
 filter="${1:-}"
 
@@ -125,6 +140,50 @@ should_skip() {
   echo ""
 }
 
+# Dump the state a failing test left behind, while it still exists. The shared
+# config and the shim registry are behind most cross-test failures, and neither
+# shows up in the test's own log.
+write_postmortem() {
+  local name="$1"
+  local file="$E2E_LOGS/$name.postmortem.txt"
+
+  {
+    echo "===== $name post-mortem ====="
+    echo ""
+    echo "--- $E2E_SCRATCH/.prototools"
+    cat "$E2E_SCRATCH/.prototools" 2>/dev/null || echo "(missing)"
+    echo ""
+    echo "--- $_PROTO_HOME_POSIX/shims/registry.json"
+    cat "$_PROTO_HOME_POSIX/shims/registry.json" 2>/dev/null || echo "(missing)"
+    echo ""
+    echo "--- shims dir"
+    ls -l "$_PROTO_HOME_POSIX/shims" 2>/dev/null || echo "(missing)"
+    echo ""
+    echo "--- proto status"
+    (cd "$E2E_SCRATCH" && proto status 2>&1) || true
+  } >"$file"
+
+  echo "$file"
+}
+
+# Lead with what actually died, then the tail, then where to find the state.
+# A bare tail buries the cause under whatever trace logging came after it.
+report_failure() {
+  local name="$1" log="$2" indent="${3:-}"
+  local cause
+  cause=$(grep -nE "ASSERT FAIL|COMMAND FAILED|FATAL" "$log" 2>/dev/null | tail -5 || true)
+
+  if [[ -n "$cause" ]]; then
+    echo "${indent}----- cause $name -----"
+    echo "$cause" | sed "s/^/${indent}/"
+  fi
+
+  echo "${indent}----- tail $name (last $E2E_TAIL lines) -----"
+  tail -"$E2E_TAIL" "$log" 2>/dev/null | sed "s/^/${indent}/" || true
+  echo "${indent}----- end -----"
+  echo "${indent}post-mortem: $(write_postmortem "$name")"
+}
+
 run_one() {
   local file="$1"
   local name; name=$(basename "$file" .sh)
@@ -148,9 +207,7 @@ run_one() {
   else
     record "$name" "FAIL" "exit=$rc"
     printf "[FAIL] %-32s  %ds exit=%d  log=%s\n" "$name" "$dur" "$rc" "$log"
-    echo "----- tail $name -----"
-    tail -40 "$log" || true
-    echo "----- end -----"
+    report_failure "$name" "$log"
   fi
 }
 
@@ -200,9 +257,7 @@ run_batch() {
     else
       record "$name" "FAIL" "exit=$rc"
       printf "  [FAIL] %-30s  %ds exit=%d  log=%s\n" "$name" "$dur" "$rc" "$log"
-      echo "  ----- tail $name -----"
-      tail -40 "$log" 2>/dev/null | sed 's/^/  /' || true
-      echo "  ----- end -----"
+      report_failure "$name" "$log" "  "
     fi
   done
 }
@@ -226,6 +281,13 @@ flush_batch() {
 
 for f in "${tests[@]}"; do
   group=$(parse_directive "$f" "group" || true)
+
+  # Every test becomes its own batch, so nothing runs concurrently. Use this to
+  # tell a real failure apart from one test interfering with its group peers.
+  if [[ -n "${E2E_SERIAL:-}" ]]; then
+    group=""
+  fi
+
   if [[ -n "$group" && "$group" == "$batch_group" ]]; then
     batch+=("$f")
   else
@@ -235,6 +297,52 @@ for f in "${tests[@]}"; do
   fi
 done
 flush_batch
+
+# The GitHub Actions run page showed nothing beyond "Process completed with exit
+# code 1" — not even which test failed. Annotations put the cause on the page,
+# and the step summary lists what failed or was skipped without downloading the
+# log artifact.
+write_ci_report() {
+  local i name status reason log cause
+
+  for ((i = 0; i < ${#test_names[@]}; i++)); do
+    if [[ "${test_status[$i]}" != "FAIL" ]]; then
+      continue
+    fi
+
+    name="${test_names[$i]}"
+    log="$E2E_LOGS/$name.log"
+    cause=$(grep -hE "ASSERT FAIL|COMMAND FAILED|FATAL" "$log" 2>/dev/null | head -1 || true)
+
+    echo "::error title=E2E ($E2E_OS) $name::${cause:-no assertion message, see $name.log}"
+  done
+
+  if [[ -z "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    return 0
+  fi
+
+  {
+    echo "### E2E ($E2E_OS): $pass passed, $fail failed, $skip skipped"
+    echo ""
+
+    for ((i = 0; i < ${#test_names[@]}; i++)); do
+      name="${test_names[$i]}"
+      status="${test_status[$i]}"
+      reason="${test_reason[$i]}"
+
+      case "$status" in
+        FAIL)
+          log="$E2E_LOGS/$name.log"
+          cause=$(grep -hE "ASSERT FAIL|COMMAND FAILED|FATAL" "$log" 2>/dev/null | head -1 || true)
+          echo "- ❌ \`$name\` ($reason) — ${cause:-no assertion message}"
+          ;;
+        SKIP)
+          echo "- ⏭️ \`$name\` ($reason)"
+          ;;
+      esac
+    done
+  } >>"$GITHUB_STEP_SUMMARY"
+}
 
 # Summary
 pass=0; fail=0; skip=0
@@ -252,6 +360,10 @@ printf "  Passed:  %d\n" "$pass"
 printf "  Failed:  %d\n" "$fail"
 printf "  Skipped: %d\n" "$skip"
 printf "  Total:   %d\n" "${#test_names[@]}"
+
+if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+  write_ci_report
+fi
 
 echo ""
 echo "Log files:"

--- a/e2e/tests/00-help.sh
+++ b/e2e/tests/00-help.sh
@@ -3,11 +3,15 @@ set -euo pipefail
 source "$(dirname "$0")/../lib/env.sh"
 source "$(dirname "$0")/../lib/assert.sh"
 
-ver=$(proto --version 2>&1)
-assert_contains "$ver" "proto"
+run_probe proto --version
+echo_probe
+assert_probe_ok
+assert_contains "$RUN_ALL" "proto"
 
-help=$(proto --help 2>&1)
-assert_contains "$help" "install"
-assert_contains "$help" "run"
-assert_contains "$help" "pin"
-assert_contains "$help" "bin"
+run_probe proto --help
+echo_probe
+assert_probe_ok
+assert_contains "$RUN_ALL" "install"
+assert_contains "$RUN_ALL" "run"
+assert_contains "$RUN_ALL" "pin"
+assert_contains "$RUN_ALL" "bin"

--- a/e2e/tests/01-versions.sh
+++ b/e2e/tests/01-versions.sh
@@ -7,7 +7,9 @@ source "$(dirname "$0")/../lib/assert.sh"
 # not cached) and the upstream registry call. Sample a few tools rather than
 # all 13 — exhaustive coverage happens during install tests.
 for tool in node bun python go; do
-  out=$(retry 3 proto versions "$tool" 2>&1)
+  run_probe retry 3 proto versions "$tool"
+  echo_probe
+  assert_probe_ok
   # Output should contain at least one version-shaped string with a dot
-  assert_contains "$out" "."
+  assert_contains "$RUN_ALL" "."
 done

--- a/e2e/tests/40-status.sh
+++ b/e2e/tests/40-status.sh
@@ -4,7 +4,9 @@ set -euo pipefail
 source "$(dirname "$0")/../lib/env.sh"
 source "$(dirname "$0")/../lib/assert.sh"
 
-out=$(proto status 2>&1)
+run_probe proto status
+echo_probe
+assert_probe_ok
 
 # At minimum the node install (10-install-node) must show up
-assert_contains "$out" "node"
+assert_contains "$RUN_ALL" "node"

--- a/e2e/tests/42-run.sh
+++ b/e2e/tests/42-run.sh
@@ -16,8 +16,10 @@ check_run() {
   local tool="$1" expect="$2"
   shift 2
   if proto bin "$tool" >/dev/null 2>&1; then
-    out=$(proto run "$tool" -- "$@" 2>&1)
-    assert_contains "$out" "$expect"
+    run_probe proto run "$tool" -- "$@"
+    echo_probe
+    assert_probe_ok
+    assert_contains "$RUN_ALL" "$expect"
   fi
 }
 

--- a/e2e/tests/43-shim-on-path.sh
+++ b/e2e/tests/43-shim-on-path.sh
@@ -12,8 +12,12 @@ trap 'rm -rf "$work"' EXIT
 echo 'node = "24"' > "$work/.prototools"
 cd "$work"
 
-ver=$(node --version 2>&1)
-assert_contains "$ver" "v24"
+run_probe node --version
+echo_probe
+assert_probe_ok
+assert_contains "$RUN_ALL" "v24"
 
-bin=$(which node 2>&1)
-assert_contains "$bin" "$_PROTO_HOME_POSIX/shims"
+run_probe which node
+echo_probe path
+assert_probe_ok
+assert_contains "$RUN_OUT" "$_PROTO_HOME_POSIX/shims"

--- a/e2e/tests/44-prototools-basic.sh
+++ b/e2e/tests/44-prototools-basic.sh
@@ -10,5 +10,7 @@ trap 'rm -rf "$work"' EXIT
 cp "$E2E_DIR/fixtures/basic.prototools" "$work/.prototools"
 cd "$work"
 
-ver=$(proto run node -- --version 2>&1)
-assert_contains "$ver" "v24"
+run_probe proto run node -- --version
+echo_probe
+assert_probe_ok
+assert_contains "$RUN_ALL" "v24"

--- a/e2e/tests/46-exec-quoting.sh
+++ b/e2e/tests/46-exec-quoting.sh
@@ -12,5 +12,7 @@ trap 'rm -rf "$work"' EXIT
 echo 'node = "24"' > "$work/.prototools"
 cd "$work"
 
-out=$(proto run node -- -e "console.log('hello world with literal \$dollar')" 2>&1)
-assert_contains "$out" 'hello world with literal $dollar'
+run_probe proto run node -- -e "console.log('hello world with literal \$dollar')"
+echo_probe
+assert_probe_ok
+assert_contains "$RUN_ALL" 'hello world with literal $dollar'

--- a/e2e/tests/50-activate.sh
+++ b/e2e/tests/50-activate.sh
@@ -7,7 +7,11 @@ source "$(dirname "$0")/../lib/assert.sh"
 # proto activate <shell> emits shell code that proto users `eval`/source from
 # their shell rc. Verify the output is non-empty, mentions proto, and is
 # actually evaluable without errors.
-hook=$(proto activate bash 2>&1)
+run_probe proto activate bash
+echo_probe hook
+assert_probe_ok
+
+hook="$RUN_OUT"
 [[ -n "$hook" ]] || fail "proto activate bash produced no output"
 assert_contains "$hook" "proto"
 

--- a/e2e/tests/51-npm-nested-scripts.sh
+++ b/e2e/tests/51-npm-nested-scripts.sh
@@ -23,9 +23,23 @@ cat > "$work/package.json" <<'EOF'
 EOF
 cd "$work"
 
-direct=$(npm --version 2>&1 | tr -d '\r')
-one_level=$(npm run -s inner 2>&1 | tr -d '\r')
-two_level=$(npm run -s outer 2>&1 | tr -d '\r')
+# Git Bash on Windows leaves CRs in the output
+strip_cr() { printf '%s' "$1" | tr -d '\r'; }
+
+run_probe npm --version
+echo_probe direct
+assert_probe_ok
+direct=$(strip_cr "$RUN_OUT")
+
+run_probe npm run -s inner
+echo_probe one_level
+assert_probe_ok
+one_level=$(strip_cr "$RUN_OUT")
+
+run_probe npm run -s outer
+echo_probe two_level
+assert_probe_ok
+two_level=$(strip_cr "$RUN_OUT")
 
 # Anchor against every invocation resolving the bundled npm
 assert_contains "$direct" "11.13"


### PR DESCRIPTION
Refs #1095, independent of #1096 (either can land first).

The E2E logs for both failures in run 32400669447 end on `Verifying shim version...` — no exit code, no output, no assertion message, 290 KB of trace logging and the actual error nowhere in it. The cause is in `lib/utils.sh`:

```bash
ver=$("$shim" "$version_arg" 2>&1)   # set -e aborts the test here
shim_rc=$?                           # never runs
echo "  exit=$shim_rc"               # never runs
echo "  output=$ver"                 # never runs, the error dies with $ver
```

Under `set -e` a failing command substitution aborts immediately, so every `if [[ $rc -ne 0 ]]` below it was dead code, and the same pattern was in `test_bin`, `install_tool` and `install_backend`.

### Changes

- **`run_probe` / `echo_probe`** (`lib/assert.sh`) — run a command, record `RUN_RC` / `RUN_OUT` / `RUN_ERR` keeping the two streams apart, never abort the caller. `test_bin` and `test_shim` now log the exit code, the output and the stderr before asserting on any of it. Keeping stderr separate also means `proto bin`'s path can't be polluted by whatever it logs.
- **`ERR` trap with a stack trace** (`lib/assert.sh`) — any unhandled failure now prints the command, `file:line` and the call stack. Failures inside a command substitution are skipped (`BASH_SUBSHELL`), as they are either handled by the caller or reported again by the assignment around them, so tests like `41-bin-shim` that deliberately tolerate failures stay quiet.

  ```
  ASSERT FAIL: expected substring '999' in: moon 2.2.6
  COMMAND FAILED (exit=1) at e2e/lib/assert.sh:49: return 1
    called from assert_contains (e2e/lib/utils.sh:112)
    called from test_shim (e2e/lib/utils.sh:150)
    called from install_tool (e2e/tests/18-install-moon.sh:6)
  ```

- **Post-mortem on failure** (`run.sh`) — writes `.logs/<name>.postmortem.txt` with the shared `.prototools`, the shim registry, the shims dir and `proto status`, captured while the state still exists. None of that is visible in a test's own log, and it is where cross-test failures actually live. The failure report also leads with the `ASSERT FAIL` / `COMMAND FAILED` lines instead of burying them under the tail.
- **GitHub Actions annotations + step summary** (`run.sh`) — a red E2E job showed nothing beyond `Process completed with exit code 1`, not even which test failed. Failures now emit `::error` annotations carrying the assertion message, and the step summary lists every failed and skipped test with its cause. Both are guarded on `GITHUB_ACTIONS` / `GITHUB_STEP_SUMMARY`, so a local run is unchanged.
- **`E2E_SERIAL=1`** (`run.sh`) — never run a group in parallel. The first thing to reach for when a failure smells like tests interfering with their peers.
- **`E2E_TAIL`, `E2E_KEEP_SCRATCH`** (`run.sh`) — inline tail size, and keeping the shared work dir so it can be poked at afterwards.
- **`PROTO_HOME` defaults to `e2e/.proto-home`** (`lib/env.sh`) — it pointed at `$HOME/.proto`, so `just test-e2e` installed 20+ tools into the developer's own store, then `90-uninstall` removed their `uv` and `99-clean` pruned it. `e2e/.gitignore` already lists `.proto-home/` and the README already documented that location, so this is the drift being closed rather than a new choice. `E2E_USE_REAL_HOME=1` opts back in.
- **README** — `PROTO_BIN_DIR` doesn't exist in any script, the group names were stale (`install-base` / `install-deps` vs `tools` / `tools-secondary` / `backends`), and the store is not "wiped at the start of each run". Documents the knobs and how to debug a failure.

### Also found while testing this

Running the suite from inside an AI agent (Claude Code, Codex, Cursor) failed on `assert_executable`, because proto detects the agent and switches its output to NDJSON — so `proto bin node` returned a JSON envelope instead of a path. `lib/env.sh` now blanks the same env vars `crates/core/src/test_utils.rs` does and pins `PROTO_REPORTER=text`, so the suite behaves the same whoever runs it.

### Deliberately not changing

The shared scratch cwd. Nine parallel installs pinning into one `.prototools` is what caught a real lost-update bug in proto; isolating each test would have hidden it.
