### PR TITLE
internal: Upgrade rmcp to v3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1296,16 +1296,6 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
-dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
@@ -1344,19 +1334,6 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
-dependencies = [
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "darling_core"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
@@ -1386,17 +1363,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
-dependencies = [
- "darling_core 0.23.0",
  "quote",
  "syn 2.0.119",
 ]
@@ -4833,14 +4799,14 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "2.2.0"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
+checksum = "1a15bc53261a9dc37e105df006e4656c598379a8f9581f8950debb130f27a7cf"
 dependencies = [
- "async-trait",
- "base64 0.22.1",
+ "base64 0.23.1",
  "chrono",
  "futures",
+ "indexmap",
  "pastey",
  "pin-project-lite",
  "rmcp-macros",
@@ -4851,19 +4817,20 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
 name = "rmcp-macros"
-version = "2.2.0"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
+checksum = "a85d45508e9b4ba024fe996c2638799635d75b6dd0ba8f32ccf08f8026f0c780"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.24.1",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ reqwest-middleware = { version = "0.5.2", default-features = false, features = [
     "charset",
     "http2",
 ] }
-rmcp = { version = "2.2.0", default-features = false, features = [
+rmcp = { version = "3.1.4", default-features = false, features = [
     "base64",
     "macros",
 ] }

--- a/crates/cli/src/commands/mcp.rs
+++ b/crates/cli/src/commands/mcp.rs
@@ -3,7 +3,7 @@ use crate::session::{ProtoSession, SessionResult};
 use clap::Args;
 use iocraft::prelude::element;
 use miette::IntoDiagnostic;
-use rmcp::model::InitializeResult;
+use rmcp::model::{InitializeResult, ProtocolVersion};
 use rmcp::{ServerHandler, ServiceExt, transport::stdio};
 use serde::Serialize;
 use starbase_console::ui::*;
@@ -21,6 +21,7 @@ pub struct McpArgs {
 #[derive(Serialize)]
 pub struct McpOutput {
     info: InitializeResult,
+    protocol_versions: Vec<ProtocolVersion>,
     tools: Vec<rmcp::model::Tool>,
     resources: Vec<rmcp::model::Resource>,
 }
@@ -44,6 +45,11 @@ pub async fn mcp(session: ProtoSession, args: McpArgs) -> SessionResult {
 
     let info = server.get_info();
 
+    // The version in `info` is only what we fall back to when a client requests
+    // a version we don't support, so report everything we can negotiate to
+    let mut protocol_versions = server.supported_protocol_versions().into_owned();
+    protocol_versions.sort_by(|a, d| a.as_str().cmp(d.as_str()));
+
     let mut tools = server.tool_router.list_all();
     tools.sort_by(|a, d| a.name.cmp(&d.name));
 
@@ -53,12 +59,25 @@ pub async fn mcp(session: ProtoSession, args: McpArgs) -> SessionResult {
     if session.is_json_format() {
         console.write_json_for_format(McpOutput {
             info,
+            protocol_versions,
             tools,
             resources,
         })?;
 
         return Ok(None);
     }
+
+    let protocol_versions = protocol_versions
+        .iter()
+        .map(|version| {
+            if *version == info.protocol_version {
+                format!("<hash>{version}</hash> <mutedlight>(default)</mutedlight>")
+            } else {
+                format!("<hash>{version}</hash>")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
 
     console.render(element! {
         Container {
@@ -83,11 +102,10 @@ pub async fn mcp(session: ProtoSession, args: McpArgs) -> SessionResult {
                     }.into_any()
                 )
                 Entry(
-                    name: "Protocol version",
+                    name: "Protocol versions",
                     value: element! {
                         StyledText(
-                            content: info.protocol_version.to_string(),
-                            style: Style::Hash
+                            content: protocol_versions,
                         )
                     }.into_any()
                 )

--- a/crates/cli/src/mcp/server.rs
+++ b/crates/cli/src/mcp/server.rs
@@ -41,15 +41,11 @@ pub struct ProtoMcp {
 
 impl ProtoMcp {
     pub fn list_all_resources(&self) -> ListResourcesResult {
-        ListResourcesResult {
-            resources: vec![
-                Resource::new("proto://config", "Configuration"),
-                Resource::new("proto://env", "Environment"),
-                Resource::new("proto://tools", "Installed tools"),
-            ],
-            next_cursor: None,
-            meta: None,
-        }
+        ListResourcesResult::with_all_items(vec![
+            Resource::new("proto://config", "Configuration"),
+            Resource::new("proto://env", "Environment"),
+            Resource::new("proto://tools", "Installed tools"),
+        ])
     }
 
     fn parse_context(&self, value: &str) -> Result<ToolContext, McpError> {
@@ -311,16 +307,28 @@ impl ServerHandler for ProtoMcp {
     async fn list_resources(
         &self,
         _request: Option<PaginatedRequestParams>,
-        _context: RequestContext<RoleServer>,
+        context: RequestContext<RoleServer>,
     ) -> Result<ListResourcesResult, McpError> {
-        Ok(self.list_all_resources())
+        let mut result = self.list_all_resources();
+
+        // The resource list is static, so mirror the cache hints that the tool
+        // router emits, but only for peers that negotiated a protocol version
+        // that supports them (SEP-2549)
+        if context
+            .protocol_version()
+            .is_some_and(|version| version >= ProtocolVersion::V_2026_07_28)
+        {
+            result = result.with_ttl_ms(0).with_cache_scope(CacheScope::Public);
+        }
+
+        Ok(result)
     }
 
     async fn read_resource(
         &self,
         ReadResourceRequestParams { uri, .. }: ReadResourceRequestParams,
         _: RequestContext<RoleServer>,
-    ) -> Result<ReadResourceResult, McpError> {
+    ) -> Result<ReadResourceResponse, McpError> {
         let text = match uri.as_str() {
             "proto://config" => {
                 let resource = self
@@ -361,7 +369,8 @@ impl ServerHandler for ProtoMcp {
                 mime_type: Some("application/json".into()),
                 meta: None,
             },
-        ]))
+        ])
+        .into())
     }
 }
 

--- a/crates/cli/src/mcp/server.rs
+++ b/crates/cli/src/mcp/server.rs
@@ -362,15 +362,15 @@ impl ServerHandler for ProtoMcp {
             }
         };
 
-        Ok(ReadResourceResult::new(vec![
-            ResourceContents::TextResourceContents {
+        Ok(
+            ReadResourceResult::new(vec![ResourceContents::TextResourceContents {
                 uri,
                 text,
                 mime_type: Some("application/json".into()),
                 meta: None,
-            },
-        ])
-        .into())
+            }])
+            .into(),
+        )
     }
 }
 


### PR DESCRIPTION
Upgrades the MCP SDK from `2.2.0` to `3.1.4`, which brings support for the `2026-07-28` protocol version.

## What changed

**`Cargo.toml`** — bumped to `3.1.4`. The feature set (`base64`, `macros`, `server`, `transport-io`) is unchanged and still valid.

**`crates/cli/src/mcp/server.rs`** — three changes, two of them compile-forced by v3's model updates:

1. `ListResourcesResult` gained `result_type`, `ttl_ms`, and `cache_scope` fields (SEP-2322 / SEP-2549), so the struct literal no longer compiles. Switched to the `with_all_items()` constructor, which defaults `result_type` to `COMPLETE`.
2. `ServerHandler::read_resource` now returns `ReadResourceResponse` — an enum added for the MRTR extension (SEP-2322) with `Complete` and `InputRequired` variants. Changed the signature and wrapped the existing result via `.into()`; proto never needs `InputRequired`.
3. Not compile-forced, but needed for parity: rmcp's `#[tool_handler]` macro now emits SEP-2549 cache hints on `tools/list` for peers that negotiated `2026-07-28`. The hand-written `list_resources` had no equivalent, so `resources/list` was silently omitting spec-required fields. It now emits `ttlMs: 0` / `cacheScope: public` under the same version gate, and stays absent for older peers.

**`crates/cli/src/commands/mcp.rs`** — `proto mcp --info` reported `ServerInfo`'s protocol version, which is only the *fallback* used when a client requests a version we don't support. That understated the server: rmcp negotiates any version in `supported_protocol_versions()` (which defaults to all of `KNOWN_VERSIONS`), so a client asking for `2026-07-28` already gets it. The entry now lists every negotiable version and marks the fallback, and the JSON output gains a matching `protocol_versions` field.

```
CLI version: 3.1.4
Protocol versions: 2024-11-05, 2025-03-26, 2025-06-18, 2025-11-25 (default), 2026-07-28
```

## Verification

`cargo check --all-targets`, `cargo clippy --all-targets`, and `cargo fmt --check` are clean, and `mcp_test` passes.

The server was also driven over stdio under both `2025-11-25` and `2026-07-28`, covering `initialize`, `resources/list`, `resources/read` (success and not-found), `tools/list`, and `tools/call` with an invalid argument. All correct on both versions, including one behavior change that comes from the SDK by design: `resource_not_found` is remapped from `-32002` to `-32602` for `2026-07-28` peers (SEP-2164), which the existing `McpError::resource_not_found` call picks up for free.

Negotiation was checked directly against the built binary:

| Client requests | Server answers |
| --- | --- |
| `2024-11-05` | `2024-11-05` |
| `2026-07-28` | `2026-07-28` |
| `2099-01-01` | `2025-11-25` (fallback) |

## Notes for the reviewer

`ProtocolVersion::LATEST` is still `2025-11-25` in 3.1.4 — rmcp deliberately keeps the `2026-07-28` draft out of `LATEST`, so proto advertises `2025-11-25` and negotiates upward on request. No override of `ServerInfo.protocol_version` is needed, and adding one would make proto advertise a draft version as its floor.

One pre-existing issue was left alone: `Implementation::from_build_env()` reads `CARGO_CRATE_NAME` / `CARGO_PKG_VERSION` from *rmcp's* own build env, so the server advertises itself as `rmcp` and `--info` prints `CLI version: 3.1.4`. The code is identical in 2.2.0, so it printed `2.2.0` before — the label just looks more obviously wrong now. The fix would be constructing `Implementation` explicitly with proto's name and version in `get_info`. Happy to fold that in if wanted.

No `CHANGELOG.md` entry was added, since the repo has no `Unreleased` heading convention and `0.61.0` is already tagged. Happy to add one under a new section if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
