### PR TITLE
new: Add community plugin registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     name: Codegen
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: moonrepo/setup-rust@v1
         with:
           cache: false
@@ -36,7 +36,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: moonrepo/setup-rust@v1
         with:
           bins: just
@@ -51,7 +51,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: moonrepo/setup-rust@v1
         with:
           bins: just
@@ -67,7 +67,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: jlumbroso/free-disk-space@main
         if: ${{ runner.os == 'Linux' }}
       - uses: moonrepo/setup-toolchain@v0
@@ -95,7 +95,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: moonrepo/setup-rust@v1
         with:
           bins: cargo-wasi, just

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: moonrepo/setup-rust@v1
         with:
           cache: false
+      - run: python3 -B -m unittest registry/tests/test_generate_community_registry.py
       - run: cargo run -p proto_codegen
   format:
     name: Format

--- a/.github/workflows/community-registry.yml
+++ b/.github/workflows/community-registry.yml
@@ -1,0 +1,53 @@
+name: Update community plugins registry
+
+on:
+  schedule:
+    - cron: "15 1 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: community-plugins-registry
+  cancel-in-progress: true
+
+jobs:
+  update:
+    if: ${{ github.repository == 'moonrepo/proto' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout proto
+        uses: actions/checkout@v6
+
+      - name: Checkout community plugins
+        uses: actions/checkout@v6
+        with:
+          repository: moonrepo/community-plugins
+          path: community-plugins
+
+      - name: Setup Rust
+        uses: moonrepo/setup-rust@v1
+        with:
+          cache: false
+
+      - name: Test registry generator
+        run: python3 -B -m unittest registry/tests/test_generate_community_registry.py
+
+      - name: Generate registry
+        run: python3 registry/generate_community_registry.py community-plugins
+
+      - name: Validate registry
+        run: cargo run -p proto_codegen
+
+      - name: Commit registry changes
+        run: |
+          if git diff --quiet -- registry/data/community.json; then
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add registry/data/community.json
+          git commit -m "chore: Update community plugins registry"
+          git push

--- a/.github/workflows/community-registry.yml
+++ b/.github/workflows/community-registry.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout proto
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Checkout community plugins
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: moonrepo/community-plugins
           path: community-plugins
@@ -40,14 +40,8 @@ jobs:
       - name: Validate registry
         run: cargo run -p proto_codegen
 
-      - name: Commit registry changes
-        run: |
-          if git diff --quiet -- registry/data/community.json; then
-            exit 0
-          fi
-
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add registry/data/community.json
-          git commit -m "chore: Update community plugins registry"
-          git push
+      - name: Commit and push changes
+        uses: EndBug/add-and-commit@v11
+        with:
+          add: registry/data/community.json
+          message: "chore: Update community plugins registry [skip ci]"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,9 +20,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: jlumbroso/free-disk-space@main
         if: ${{ runner.os == 'Linux' }}
       - uses: ./.github/actions/build-binary

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -53,7 +53,7 @@ jobs:
     name: Stable - ${{ matrix.target }}
     runs-on: ${{ matrix.host }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: moonrepo/setup-rust@v1
         with:
           bins: cargo-release

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -40,7 +40,7 @@ jobs:
             runner: macos-15
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: DeterminateSystems/nix-installer-action@v22
       - uses: cachix/cachix-action@v17
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           submodules: recursive
@@ -116,7 +116,7 @@ jobs:
       - name: enable windows longpaths
         run: |
           git config --global core.longpaths true
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           submodules: recursive
@@ -179,7 +179,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           submodules: recursive
@@ -229,7 +229,7 @@ jobs:
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           submodules: recursive
@@ -294,7 +294,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           submodules: recursive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@
 
 #### 🚀 Updates
 
+- Added automatic plugin resolution for tools in the official [community plugins](https://github.com/moonrepo/community-plugins) registry. Community tools can now be used by ID without first configuring a plugin locator.
+  - Set `community-tools = false` in `[settings]`, or `PROTO_COMMUNITY_TOOLS=false`, to disable this behavior.
 - Added `proto activate` support for the following shells: `ash`, `dash`, `sh`, `powershell` (5.1+), `xonsh`
 - Added a new `proto deactivate` command, that turns off a previous activation for the current shell session, by unsetting environment variables, removing shell aliases, and removing the injected `PATH` entries.
   - The activation hook now also defines a `proto_deactivate` function, which runs the command, unregisters the hook, and removes both functions. Re-activate by evaluating `proto activate` again.

--- a/crates/cli/src/commands/plugin/search.rs
+++ b/crates/cli/src/commands/plugin/search.rs
@@ -15,7 +15,7 @@ pub struct PluginSearchArgs {
 
 #[instrument(skip(session))]
 pub async fn search(session: ProtoSession, args: PluginSearchArgs) -> SessionResult {
-    let mut registry = session.create_registry();
+    let registry = session.env.load_registry();
     let plugins = registry.load_external_plugins().await?;
 
     let query = &args.query;

--- a/crates/cli/src/session.rs
+++ b/crates/cli/src/session.rs
@@ -9,7 +9,6 @@ use proto_core::flow::resolve::Resolver;
 use proto_core::{
     ConfigMode, ProtoConfig, ProtoEnvironment, SCHEMA_PLUGIN_KEY, ToolContext, ToolSpec, Version,
     load_schema_plugin_with_proto, load_tool,
-    registry::ProtoRegistry,
     reporter::{ProtoConsole, ProtoReporter, ReporterFormat},
 };
 use proto_core::{ProtoConfigError, ProtoLoaderError, UnresolvedVersionSpec};
@@ -82,10 +81,6 @@ impl ProtoSession {
             console,
             env: Arc::new(env),
         }
-    }
-
-    pub fn create_registry(&self) -> ProtoRegistry {
-        ProtoRegistry::new(Arc::clone(&self.env))
     }
 
     pub fn load_config(&self) -> Result<&ProtoConfig, ProtoConfigError> {

--- a/crates/codegen/src/main.rs
+++ b/crates/codegen/src/main.rs
@@ -105,6 +105,7 @@ fn load_save_json(path: &str) {
 
 fn validate_registries() {
     load_save_json("registry/data/built-in.json");
+    load_save_json("registry/data/community.json");
     load_save_json("registry/data/third-party.json");
 }
 

--- a/crates/core/src/env.rs
+++ b/crates/core/src/env.rs
@@ -5,6 +5,7 @@ use crate::file_manager::{ProtoConfigFile, ProtoDirEntry, ProtoFileManager};
 use crate::helpers::is_offline;
 use crate::layout::Store;
 use crate::lockfile::ProtoLock;
+use crate::registry::ProtoRegistry;
 use crate::telemetry::MetricTimer;
 use crate::tool_context::ToolContext;
 use once_cell::sync::OnceCell;
@@ -35,6 +36,7 @@ pub struct ProtoEnvironment {
 
     file_manager: Arc<OnceCell<ProtoFileManager>>,
     plugin_loader: Arc<OnceCell<PluginLoader>>,
+    registry: Arc<OnceCell<ProtoRegistry>>,
 }
 
 impl ProtoEnvironment {
@@ -76,6 +78,7 @@ impl ProtoEnvironment {
             otel_enabled: false,
             file_manager: Arc::new(OnceCell::new()),
             plugin_loader: Arc::new(OnceCell::new()),
+            registry: Arc::new(OnceCell::new()),
             test_only: env::var("PROTO_TEST").is_ok(),
             store: Store::new(root),
             os: SystemOS::default(),
@@ -116,6 +119,11 @@ impl ProtoEnvironment {
 
             Ok(loader)
         })
+    }
+
+    pub fn load_registry(&self) -> &ProtoRegistry {
+        self.registry
+            .get_or_init(|| ProtoRegistry::new(self.store.clone()))
     }
 
     pub fn get_virtual_paths(&self) -> Vec<(PathBuf, PathBuf)> {
@@ -257,6 +265,7 @@ impl ProtoEnvironment {
             arch: self.arch,
             file_manager: Arc::new(OnceCell::new()),
             plugin_loader: Arc::new(OnceCell::new()),
+            registry: Arc::new(OnceCell::new()),
         }
     }
 }

--- a/crates/core/src/loader.rs
+++ b/crates/core/src/loader.rs
@@ -94,14 +94,23 @@ pub async fn locate_plugin(
     if locator.is_none() && ty == PluginType::Tool && config.settings.community_tools {
         let registry = proto.load_registry();
 
-        if let Some(plugin) = registry.load_community_plugin(id).await? {
-            debug!(
-                context = context.as_str(),
-                plugin = plugin.locator.to_string(),
-                "Using a community plugin"
-            );
+        match registry.load_community_plugin(id).await {
+            Ok(Some(plugin)) => {
+                debug!(
+                    context = context.as_str(),
+                    plugin = plugin.locator.to_string(),
+                    "Using a community plugin"
+                );
 
-            locator = Some(plugin.locator.to_owned());
+                locator = Some(plugin.locator.to_owned());
+            }
+            Ok(None) => {}
+            Err(error) => {
+                warn!(
+                    error = ?error,
+                    "Failed to load the community plugins registry; continuing without it"
+                );
+            }
         }
     }
 

--- a/crates/core/src/loader.rs
+++ b/crates/core/src/loader.rs
@@ -54,7 +54,7 @@ pub fn inject_proto_manifest_config(
 }
 
 #[instrument]
-pub fn locate_plugin(
+pub async fn locate_plugin(
     context: &ToolContext,
     proto: &ProtoEnvironment,
     ty: PluginType,
@@ -77,7 +77,7 @@ pub fn locate_plugin(
 
     let id = context.backend.as_ref().unwrap_or(&context.id);
 
-    // And finally the built-in plugins (must include global config)
+    // Then check the built-in plugins (must include global config)
     if locator.is_none()
         && let Some(maybe_locator) = config.builtin_plugins().get(id, ty)
     {
@@ -88,6 +88,21 @@ pub fn locate_plugin(
         );
 
         locator = Some(maybe_locator.to_owned());
+    }
+
+    // Then check the remote community plugins registry
+    if locator.is_none() && ty == PluginType::Tool {
+        let registry = proto.load_registry();
+
+        if let Some(plugin) = registry.load_community_plugin(id).await? {
+            debug!(
+                context = context.as_str(),
+                plugin = plugin.locator.to_string(),
+                "Using a community plugin"
+            );
+
+            locator = Some(plugin.locator.to_owned());
+        }
     }
 
     // Search in registries
@@ -291,7 +306,8 @@ pub async fn load_tool(
         } else {
             PluginType::Tool
         },
-    )?;
+    )
+    .await?;
 
     let tool = load_tool_from_locator(&context, proto, locator).await?;
 

--- a/crates/core/src/loader.rs
+++ b/crates/core/src/loader.rs
@@ -91,7 +91,7 @@ pub async fn locate_plugin(
     }
 
     // Then check the remote community plugins registry
-    if locator.is_none() && ty == PluginType::Tool {
+    if locator.is_none() && ty == PluginType::Tool && config.settings.community_tools {
         let registry = proto.load_registry();
 
         if let Some(plugin) = registry.load_community_plugin(id).await? {

--- a/crates/core/src/loader_error.rs
+++ b/crates/core/src/loader_error.rs
@@ -1,6 +1,7 @@
 use crate::config::PROTO_CONFIG_NAME;
 use crate::config_error::ProtoConfigError;
 use crate::flow::resolve::ProtoResolveError;
+use crate::registry::ProtoRegistryError;
 use crate::tool_context::ToolContext;
 use crate::tool_error::ProtoToolError;
 use starbase_styles::{Style, Stylize};
@@ -32,6 +33,10 @@ pub enum ProtoLoaderError {
     #[diagnostic(transparent)]
     #[error(transparent)]
     Plugin(#[from] Box<WarpgatePluginError>),
+
+    #[diagnostic(transparent)]
+    #[error(transparent)]
+    Registry(#[from] Box<ProtoRegistryError>),
 
     #[diagnostic(transparent)]
     #[error(transparent)]
@@ -95,6 +100,12 @@ impl From<WarpgateLoaderError> for ProtoLoaderError {
 impl From<WarpgatePluginError> for ProtoLoaderError {
     fn from(e: WarpgatePluginError) -> ProtoLoaderError {
         ProtoLoaderError::Plugin(Box::new(e))
+    }
+}
+
+impl From<ProtoRegistryError> for ProtoLoaderError {
+    fn from(e: ProtoRegistryError) -> ProtoLoaderError {
+        ProtoLoaderError::Registry(Box::new(e))
     }
 }
 

--- a/crates/core/src/registry/registry.rs
+++ b/crates/core/src/registry/registry.rs
@@ -128,17 +128,25 @@ impl ProtoRegistry {
         // Otherwise fetch from the upstream URL
         debug!(url = &data_url, "Loading plugins data from remote URL");
 
-        let data: PluginRegistryDocument = reqwest::get(&data_url)
+        let response = reqwest::get(&data_url)
             .await
+            .map_err(|error| ProtoRegistryError::FailedRequest {
+                url: data_url.clone(),
+                error: Box::new(error),
+            })?
+            .error_for_status()
             .map_err(|error| ProtoRegistryError::FailedRequest {
                 url: data_url,
                 error: Box::new(error),
-            })?
-            .json()
-            .await
-            .map_err(|error| ProtoRegistryError::FailedParse {
-                error: Box::new(error),
             })?;
+
+        let data: PluginRegistryDocument =
+            response
+                .json()
+                .await
+                .map_err(|error| ProtoRegistryError::FailedParse {
+                    error: Box::new(error),
+                })?;
 
         // Cache the result for future requests
         json::write_file(temp_file, &data.plugins, false)?;

--- a/crates/core/src/registry/registry.rs
+++ b/crates/core/src/registry/registry.rs
@@ -1,76 +1,112 @@
-use crate::env::ProtoEnvironment;
+use crate::id::Id;
+use crate::layout::Store;
 use crate::registry::data::{PluginEntry, PluginRegistryDocument};
 use crate::registry::registry_error::ProtoRegistryError;
 use starbase_utils::{fs, json};
 use std::path::PathBuf;
-use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::OnceCell;
 use tracing::{debug, instrument};
 
 pub struct ProtoRegistry {
-    env: Arc<ProtoEnvironment>,
-    internal: Vec<PluginEntry>,
-    external: Vec<PluginEntry>,
+    store: Store,
+    community: OnceCell<Vec<PluginEntry>>,
+    internal: OnceCell<Vec<PluginEntry>>,
+    external: OnceCell<Vec<PluginEntry>>,
 }
 
 impl ProtoRegistry {
-    pub fn new(env: Arc<ProtoEnvironment>) -> Self {
+    pub(crate) fn new(store: Store) -> Self {
         debug!("Creating plugin registry");
 
         Self {
-            env,
-            internal: vec![],
-            external: vec![],
+            store,
+            community: OnceCell::new(),
+            internal: OnceCell::new(),
+            external: OnceCell::new(),
         }
     }
 
-    pub async fn load_plugins(&mut self) -> Result<Vec<&PluginEntry>, ProtoRegistryError> {
-        self.load_internal_plugins().await?;
-        self.load_external_plugins().await?;
+    #[instrument(skip(self))]
+    pub async fn load_community_plugin(
+        &self,
+        id: &Id,
+    ) -> Result<Option<&PluginEntry>, ProtoRegistryError> {
+        Ok(self
+            .load_community_plugins()
+            .await?
+            .into_iter()
+            .find(|plugin| &plugin.id == id))
+    }
 
-        let mut plugins = vec![];
-        plugins.extend(&self.internal);
-        plugins.extend(&self.external);
+    #[instrument(skip(self))]
+    pub async fn load_community_plugins(&self) -> Result<Vec<&PluginEntry>, ProtoRegistryError> {
+        let plugins = self
+            .community
+            .get_or_try_init(|| async {
+                debug!("Loading community plugins registry data");
+
+                self.load_plugins_from_registry(
+                    self.store
+                        .cache_dir
+                        .join("registry/community-plugins.json"),
+                    "https://raw.githubusercontent.com/moonrepo/proto/master/registry/data/community.json"
+                        .into(),
+                )
+                .await
+            })
+            .await?;
+
+        Ok(plugins.iter().collect())
+    }
+
+    pub async fn load_plugins(&self) -> Result<Vec<&PluginEntry>, ProtoRegistryError> {
+        let mut plugins = self.load_internal_plugins().await?;
+        plugins.extend(self.load_external_plugins().await?);
 
         Ok(plugins)
     }
 
     #[instrument(skip(self))]
-    pub async fn load_internal_plugins(&mut self) -> Result<Vec<&PluginEntry>, ProtoRegistryError> {
-        if self.internal.is_empty() {
-            debug!("Loading built-in plugins registry data");
+    pub async fn load_internal_plugins(&self) -> Result<Vec<&PluginEntry>, ProtoRegistryError> {
+        let plugins = self
+            .internal
+            .get_or_try_init(|| async {
+                debug!("Loading built-in plugins registry data");
 
-            let plugins = self.load_plugins_from_registry(
-                self.env
-                    .store
-                    .cache_dir
-                    .join("registry/internal-plugins.json"),
-                "https://raw.githubusercontent.com/moonrepo/proto/master/registry/data/built-in.json".into(),
-            ).await?;
+                self.load_plugins_from_registry(
+                    self.store
+                        .cache_dir
+                        .join("registry/internal-plugins.json"),
+                    "https://raw.githubusercontent.com/moonrepo/proto/master/registry/data/built-in.json"
+                        .into(),
+                )
+                .await
+            })
+            .await?;
 
-            self.internal.extend(plugins);
-        }
-
-        Ok(self.internal.iter().collect())
+        Ok(plugins.iter().collect())
     }
 
     #[instrument(skip(self))]
-    pub async fn load_external_plugins(&mut self) -> Result<Vec<&PluginEntry>, ProtoRegistryError> {
-        if self.external.is_empty() {
-            debug!("Loading third-party plugins registry data");
+    pub async fn load_external_plugins(&self) -> Result<Vec<&PluginEntry>, ProtoRegistryError> {
+        let plugins = self
+            .external
+            .get_or_try_init(|| async {
+                debug!("Loading third-party plugins registry data");
 
-            let plugins = self.load_plugins_from_registry(
-                self.env
-                    .store
-                    .cache_dir
-                    .join("registry/external-plugins.json"),
-                "https://raw.githubusercontent.com/moonrepo/proto/master/registry/data/third-party.json".into(),
-            ).await?;
+                self.load_plugins_from_registry(
+                    self.store
+                        .cache_dir
+                        .join("registry/external-plugins.json"),
+                    "https://raw.githubusercontent.com/moonrepo/proto/master/registry/data/third-party.json"
+                        .into(),
+                )
+                .await
+            })
+            .await?;
 
-            self.external.extend(plugins);
-        }
-
-        Ok(self.external.iter().collect())
+        Ok(plugins.iter().collect())
     }
 
     async fn load_plugins_from_registry(

--- a/crates/core/src/settings/settings.rs
+++ b/crates/core/src/settings/settings.rs
@@ -92,6 +92,13 @@ pub struct ProtoSettingsConfig {
     #[setting(env = "PROTO_CACHE_DURATION")]
     pub cache_duration: Option<u64>,
 
+    #[setting(
+        default = true,
+        env = "PROTO_COMMUNITY_TOOLS",
+        parse_env = env::parse_bool,
+    )]
+    pub community_tools: bool,
+
     #[setting(env = "PROTO_DETECT_STRATEGY")]
     pub detect_strategy: DetectStrategy,
 

--- a/crates/core/tests/config_test.rs
+++ b/crates/core/tests/config_test.rs
@@ -57,6 +57,7 @@ proto = "file://./file.toml"
 [settings]
 auto-clean = true
 auto-install = true
+community-tools = false
 pin-latest = "global"
 "#,
         );
@@ -68,6 +69,7 @@ pin-latest = "global"
             PartialProtoSettingsConfig {
                 auto_clean: Some(true),
                 auto_install: Some(true),
+                community_tools: Some(false),
                 pin_latest: Some(PinLocation::Global),
                 ..Default::default()
             }
@@ -82,6 +84,7 @@ pin-latest = "global"
         unsafe {
             env::set_var("PROTO_AUTO_CLEAN", "1");
             env::set_var("PROTO_AUTO_INSTALL", "true");
+            env::set_var("PROTO_COMMUNITY_TOOLS", "false");
             env::set_var("PROTO_DETECT_STRATEGY", "prefer-prototools");
             env::set_var("PROTO_PIN_LATEST", "local");
         };
@@ -92,6 +95,7 @@ pin-latest = "global"
 
         assert!(config.settings.auto_clean);
         assert!(config.settings.auto_install);
+        assert!(!config.settings.community_tools);
         assert_eq!(
             config.settings.detect_strategy,
             DetectStrategy::PreferPrototools
@@ -101,6 +105,7 @@ pin-latest = "global"
         unsafe {
             env::remove_var("PROTO_AUTO_CLEAN");
             env::remove_var("PROTO_AUTO_INSTALL");
+            env::remove_var("PROTO_COMMUNITY_TOOLS");
             env::remove_var("PROTO_DETECT_STRATEGY");
             env::remove_var("PROTO_PIN_LATEST");
         };

--- a/crates/core/tests/tool_loader_test.rs
+++ b/crates/core/tests/tool_loader_test.rs
@@ -301,6 +301,31 @@ community-tools = false
     }
 
     #[tokio::test]
+    async fn community_registry_failure_falls_back_to_default_registry() {
+        let (_sandbox, proto) = setup(
+            r#"
+[[settings.registries]]
+registry = "ghcr.io"
+namespace = "fallback"
+default = true
+"#,
+        );
+        write_community_cache(&proto, "not valid JSON");
+
+        let result = locate_plugin(&ctx("foo"), &proto, PluginType::Tool)
+            .await
+            .unwrap();
+
+        let PluginLocator::Registry(registry) = result else {
+            panic!("expected Registry locator, got {result:?}");
+        };
+
+        assert_eq!(registry.registry, Some("ghcr.io".into()));
+        assert_eq!(registry.namespace, Some("fallback".into()));
+        assert_eq!(registry.image, "foo");
+    }
+
+    #[tokio::test]
     async fn user_locator_takes_priority_over_community_plugin() {
         let (_sandbox, proto) = setup(
             r#"

--- a/crates/core/tests/tool_loader_test.rs
+++ b/crates/core/tests/tool_loader_test.rs
@@ -155,7 +155,36 @@ mod locate_plugin {
         let mut proto = ProtoEnvironment::new_testing(sandbox.path()).unwrap();
         proto.working_dir = sandbox.path().to_path_buf();
 
+        write_community_cache(&proto, "[]");
+
         (sandbox, proto)
+    }
+
+    fn write_community_cache(proto: &ProtoEnvironment, contents: &str) {
+        let path = proto
+            .store
+            .cache_dir
+            .join("registry/community-plugins.json");
+
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, contents).unwrap();
+    }
+
+    fn write_act_community_cache(proto: &ProtoEnvironment) {
+        write_community_cache(
+            proto,
+            r#"[
+  {
+    "id": "act",
+    "locator": "https://raw.githubusercontent.com/moonrepo/community-plugins/master/tools/act.toml",
+    "format": "toml",
+    "name": "act",
+    "description": "Run your GitHub Actions locally.",
+    "author": "moonrepo",
+    "bins": ["act"]
+  }
+]"#,
+        );
     }
 
     fn ctx(value: &str) -> ToolContext {
@@ -164,8 +193,8 @@ mod locate_plugin {
 
     // User-defined plugins in `[plugins.tools]` must beat the new
     // registry-fallback branch even when a default registry is configured.
-    #[test]
-    fn user_locator_takes_priority_over_registry() {
+    #[tokio::test]
+    async fn user_locator_takes_priority_over_registry() {
         let (_sandbox, proto) = setup(
             r#"
 [plugins.tools]
@@ -178,7 +207,9 @@ default = true
 "#,
         );
 
-        let result = locate_plugin(&ctx("foo"), &proto, PluginType::Tool).unwrap();
+        let result = locate_plugin(&ctx("foo"), &proto, PluginType::Tool)
+            .await
+            .unwrap();
 
         let PluginLocator::GitHub(github) = result else {
             panic!("expected GitHub locator, got {result:?}");
@@ -190,11 +221,13 @@ default = true
     // Built-in plugins resolve through `builtin_plugins()` before reaching
     // the registry fallback. With no debug WASM available, the synthesized
     // locator is a Registry pointing at the moonrepo namespace.
-    #[test]
-    fn builtin_plugin_resolves_via_builtins() {
+    #[tokio::test]
+    async fn builtin_plugin_resolves_via_builtins() {
         let (_sandbox, proto) = setup("");
 
-        let result = locate_plugin(&ctx("node"), &proto, PluginType::Tool).unwrap();
+        let result = locate_plugin(&ctx("node"), &proto, PluginType::Tool)
+            .await
+            .unwrap();
 
         match result {
             // Local debug builds may resolve to a File locator pointing at a
@@ -208,11 +241,80 @@ default = true
         }
     }
 
+    #[tokio::test]
+    async fn community_plugin_resolves_via_remote_registry() {
+        let (_sandbox, proto) = setup(
+            r#"
+[[settings.registries]]
+registry = "ghcr.io"
+namespace = "fallback"
+default = true
+"#,
+        );
+
+        write_act_community_cache(&proto);
+
+        let result = locate_plugin(&ctx("act"), &proto, PluginType::Tool)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            result.to_string(),
+            "https://raw.githubusercontent.com/moonrepo/community-plugins/master/tools/act.toml"
+        );
+    }
+
+    #[tokio::test]
+    async fn community_registry_instance_is_reused_across_environment_clones() {
+        let (_sandbox, proto) = setup("");
+        let cloned_proto = proto.clone();
+        write_act_community_cache(&proto);
+
+        let first = locate_plugin(&ctx("act"), &proto, PluginType::Tool)
+            .await
+            .unwrap();
+
+        write_community_cache(&proto, "[]");
+
+        let second = locate_plugin(&ctx("act"), &cloned_proto, PluginType::Tool)
+            .await
+            .unwrap();
+
+        assert_eq!(first, second);
+    }
+
+    #[tokio::test]
+    async fn user_locator_takes_priority_over_community_plugin() {
+        let (_sandbox, proto) = setup(
+            r#"
+[plugins.tools]
+act = "github://example/act-plugin"
+"#,
+        );
+
+        let result = locate_plugin(&ctx("act"), &proto, PluginType::Tool)
+            .await
+            .unwrap();
+
+        assert_eq!(result.to_string(), "github://example/act-plugin");
+    }
+
+    #[tokio::test]
+    async fn community_registry_does_not_resolve_backends() {
+        let (_sandbox, proto) = setup("");
+
+        let error = locate_plugin(&ctx("act:example"), &proto, PluginType::Backend)
+            .await
+            .expect_err("community plugins should only resolve tools");
+
+        assert!(matches!(error, ProtoLoaderError::UnknownTool { .. }));
+    }
+
     // The central new-behavior test: with a `default = true` registry,
     // an unknown id resolves to a Registry locator built from
     // `registry.get_reference(id)` (so the namespace is preserved).
-    #[test]
-    fn unknown_id_with_default_registry_returns_registry_locator() {
+    #[tokio::test]
+    async fn unknown_id_with_default_registry_returns_registry_locator() {
         let (_sandbox, proto) = setup(
             r#"
 [[settings.registries]]
@@ -222,7 +324,9 @@ default = true
 "#,
         );
 
-        let result = locate_plugin(&ctx("foo"), &proto, PluginType::Tool).unwrap();
+        let result = locate_plugin(&ctx("foo"), &proto, PluginType::Tool)
+            .await
+            .unwrap();
 
         let PluginLocator::Registry(registry) = result else {
             panic!("expected Registry locator, got {result:?}");
@@ -237,11 +341,12 @@ default = true
     // Regression guard for the GHCR migration: the auto-default registry
     // ships with `default: false`, so an unknown id must error rather than
     // silently resolve to ghcr.io.
-    #[test]
-    fn unknown_id_without_default_registry_returns_unknown_tool_error() {
+    #[tokio::test]
+    async fn unknown_id_without_default_registry_returns_unknown_tool_error() {
         let (_sandbox, proto) = setup("");
 
         let err = locate_plugin(&ctx("totally_unknown_xyz"), &proto, PluginType::Tool)
+            .await
             .expect_err("expected UnknownTool error");
 
         match err {
@@ -254,8 +359,8 @@ default = true
 
     // Multiple registries: only the one marked `default = true` is selected,
     // regardless of order in the list.
-    #[test]
-    fn multiple_registries_only_default_is_selected() {
+    #[tokio::test]
+    async fn multiple_registries_only_default_is_selected() {
         let (_sandbox, proto) = setup(
             r#"
 [[settings.registries]]
@@ -275,7 +380,9 @@ default = false
 "#,
         );
 
-        let result = locate_plugin(&ctx("foo"), &proto, PluginType::Tool).unwrap();
+        let result = locate_plugin(&ctx("foo"), &proto, PluginType::Tool)
+            .await
+            .unwrap();
 
         let PluginLocator::Registry(registry) = result else {
             panic!("expected Registry locator, got {result:?}");
@@ -288,8 +395,8 @@ default = false
 
     // PluginType::Backend resolves the context's backend id against
     // `[plugins.backends]`, not `[plugins.tools]`.
-    #[test]
-    fn backend_type_uses_backends_table() {
+    #[tokio::test]
+    async fn backend_type_uses_backends_table() {
         let (_sandbox, proto) = setup(
             r#"
 [plugins.backends]
@@ -300,7 +407,9 @@ asdf = "github://wrong/wrong"
 "#,
         );
 
-        let result = locate_plugin(&ctx("asdf:node"), &proto, PluginType::Backend).unwrap();
+        let result = locate_plugin(&ctx("asdf:node"), &proto, PluginType::Backend)
+            .await
+            .unwrap();
 
         let PluginLocator::GitHub(github) = result else {
             panic!("expected GitHub locator, got {result:?}");
@@ -311,8 +420,8 @@ asdf = "github://wrong/wrong"
 
     // A default registry with no namespace produces a locator with
     // `namespace == None` and `image == id`.
-    #[test]
-    fn unknown_id_default_registry_no_namespace() {
+    #[tokio::test]
+    async fn unknown_id_default_registry_no_namespace() {
         let (_sandbox, proto) = setup(
             r#"
 [[settings.registries]]
@@ -321,7 +430,9 @@ default = true
 "#,
         );
 
-        let result = locate_plugin(&ctx("foo"), &proto, PluginType::Tool).unwrap();
+        let result = locate_plugin(&ctx("foo"), &proto, PluginType::Tool)
+            .await
+            .unwrap();
 
         let PluginLocator::Registry(registry) = result else {
             panic!("expected Registry locator, got {result:?}");

--- a/crates/core/tests/tool_loader_test.rs
+++ b/crates/core/tests/tool_loader_test.rs
@@ -284,6 +284,23 @@ default = true
     }
 
     #[tokio::test]
+    async fn community_registry_can_be_disabled() {
+        let (_sandbox, proto) = setup(
+            r#"
+[settings]
+community-tools = false
+"#,
+        );
+        write_act_community_cache(&proto);
+
+        let error = locate_plugin(&ctx("act"), &proto, PluginType::Tool)
+            .await
+            .expect_err("disabled community tools should not resolve");
+
+        assert!(matches!(error, ProtoLoaderError::UnknownTool { .. }));
+    }
+
+    #[tokio::test]
     async fn user_locator_takes_priority_over_community_plugin() {
         let (_sandbox, proto) = setup(
             r#"

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -43,7 +43,7 @@ Tests run alphabetically. The numeric prefix encodes phase, not strict ordering 
 | ------- | ------------------------------------------------------------------------------------ |
 | `00–09` | Smoke (help, version listing)                                                        |
 | `10–19` | Standalone tool installs                                                             |
-| `20–29` | Secondary tool installs (npm/pnpm/yarn → node, poetry → python, jdk/jre, zig/zls)    |
+| `20–29` | Secondary and community tool installs                                               |
 | `30–39` | Backends (asdf, Unix-only)                                                           |
 | `40–49` | Cross-cutting checks (status, bin, run, shim, prototools, exec, outdated, pin/alias) |
 | `50-59` | Activation checks (activate, deactivate, etc)                                        |

--- a/e2e/tests/27-install-community-shfmt.sh
+++ b/e2e/tests/27-install-community-shfmt.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# group: tools-secondary
+set -euo pipefail
+source "$(dirname "$0")/../lib/utils.sh"
+
+# shfmt is provided by the remote community registry, not the built-in plugin
+# list. Installing it without a configured locator verifies community lookup.
+install_tool shfmt 3.14.0

--- a/registry/README.md
+++ b/registry/README.md
@@ -2,6 +2,10 @@
 
 proto's registry is currently powered by static JSON files located in the [registry/data](./data) directory.
 
+The `community.json` dataset is generated nightly from the TOML plugins in
+[`moonrepo/community-plugins`](https://github.com/moonrepo/community-plugins). Changes to those
+entries should be made in the community plugins repository instead of editing the generated file.
+
 In the future, we plan to build and host an actual server based registry, in which all plugin artifacts are stored. Until then, this works quite well.
 
 ## Publishing a plugin

--- a/registry/data/community.json
+++ b/registry/data/community.json
@@ -1,0 +1,441 @@
+{
+  "$schema": "../schema.json",
+  "version": 1,
+  "plugins": [
+    {
+      "id": "act",
+      "locator": "https://raw.githubusercontent.com/moonrepo/community-plugins/master/tools/act.toml",
+      "format": "toml",
+      "name": "act",
+      "description": "Run your GitHub Actions locally.",
+      "author": "moonrepo",
+      "repositoryUrl": "https://github.com/nektos/act",
+      "bins": [
+        "act"
+      ]
+    },
+    {
+      "id": "actionlint",
+      "locator": "https://raw.githubusercontent.com/moonrepo/community-plugins/master/tools/actionlint.toml",
+      "format": "toml",
+      "name": "actionlint",
+      "description": "Static checker for GitHub Actions workflow files.",
+      "author": "moonrepo",
+      "repositoryUrl": "https://github.com/rhysd/actionlint",
+      "bins": [
+        "actionlint"
+      ]
+    },
+    {
+      "id": "atmos",
+      "locator": "https://raw.githubusercontent.com/moonrepo/community-plugins/master/tools/atmos.toml",
+      "format": "toml",
+      "name": "atmos",
+      "description": "",
+      "author": "moonrepo",
+      "repositoryUrl": "https://github.com/cloudposse/atmos",
+      "bins": [
+        "atmos"
+      ]
+    },
+    {
+      "id": "bazel",
+      "locator": "https://raw.githubusercontent.com/moonrepo/community-plugins/master/tools/bazel.toml",
+      "format": "toml",
+      "name": "Bazel",
+      "description": "A fast, scalable, multi-language and extensible build system.",
+      "author": "moonrepo",
+      "homepageUrl": "https://bazel.build/",
+      "repositoryUrl": "https://github.com/bazelbuild/bazel",
+      "bins": [
+        "bazel"
+      ],
+      "detectionSources": [
+        {
+          "file": ".bazelversion"
+        }
+      ]
+    },
+    {
+      "id": "biome",
+      "locator": "https://raw.githubusercontent.com/moonrepo/community-plugins/master/tools/biome.toml",
+      "format": "toml",
+      "name": "Biome",
+      "description": "A performant toolchain for web projects, aiming to provide developer tools to maintain the health of said projects.",
+      "author": "moonrepo",
+      "homepageUrl": "https://biomejs.dev/",
+      "repositoryUrl": "https://github.com/biomejs/biome",
+      "bins": [
+        "biome"
+      ]
+    },
+    {
+      "id": "caddy",
+      "locator": "https://raw.githubusercontent.com/moonrepo/community-plugins/master/tools/caddy.toml",
+      "format": "toml",
+      "name": "Caddy",
+      "description": "Fast and extensible multi-platform HTTP/1-2-3 web server with automatic HTTPS.",
+      "author": "moonrepo",
+      "homepageUrl": "https://caddyserver.com/",
+      "repositoryUrl": "https://github.com/caddyserver/caddy",
+      "bins": [
+        "caddy"
+      ]
+    },
+    {
+      "id": "cmake",
+      "locator": "https://raw.githubusercontent.com/moonrepo/community-plugins/master/tools/cmake.toml",
+      "format": "toml",
+      "name": "CMake",
+      "description": "CMake is a cross-platform, open-source build system generator.",
+      "author": "moonrepo",
+      "homepageUrl": "https://cmake.org/",
+      "repositoryUrl": "https://github.com/Kitware/CMake",
+      "bins": [
+        "cmake",
+        "ccmake",
+        "cpack",
+        "ctest"
+      ]
+    },
+    {
+      "id": "cosign",
+      "locator": "https://raw.githubusercontent.com/moonrepo/community-plugins/master/tools/cosign.toml",
+      "format": "toml",
+      "name": "Cosign",
+      "description": "Code signing and transparency for containers and binaries.",
+      "author": "moonrepo",
+      "repositoryUrl": "https://github.com/sigstore/cosign",
+      "bins": [
+        "cosign"
+      ]
+    },
+    {
+      "id": "dagger",
+      "locator": "https://raw.githubusercontent.com/moonrepo/community-plugins/master/tools/dagger.toml",
+      "format": "toml",
+      "name": "Dagger",
+      "description": "Powerful, programmable open source CI/CD engine that runs your pipelines in containers.",
+      "author": "moonrepo",
+      "homepageUrl": "https://dagger.io/",
+      "repositoryUrl": "https://github.com/dagger/dagger",
+      "bins": [
+        "dagger"
+      ]
+    },
+    {
+      "id": "dprint",
+      "locator": "https://raw.githubusercontent.com/moonrepo/community-plugins/master/tools/dprint.toml",
+      "format": "toml",
+      "name": "dprint",
+      "description": "A pluggable and configurable code formatting platform written in Rust.",
+      "author": "moonrepo",
+      "homepageUrl": "https://dprint.dev/",
+      "repositoryUrl": "https://github.com/dprint/dprint",
+      "bins": [
+        "dprint"
+      ]
+    },
+    {
+      "id": "flyctl",
+      "locator": "https://raw.githubusercontent.com/moonrepo/community-plugins/master/tools/flyctl.toml",
+      "format": "toml",
+      "name": "flyctl",
+      "description": "A command-line interface for fly.io.",
+      "author": "moonrepo",
+      "repositoryUrl": "https://github.com/superfly/flyctl",
+      "bins": [
+        "flyctl",
+        "fly"
+      ]
+    },
+    {
+      "id": "gitleaks",
+      "locator": "https://raw.githubusercontent.com/moonrepo/community-plugins/master/tools/gitleaks.toml",
+      "format": "toml",
+      "name": "Gitleaks",
+      "description": "A fast, light-weight, portable, and open-source secret scanner for Git repositories, files, and directories.",
+      "author": "moonrepo",
+      "homepageUrl": "https://gitleaks.io/",
+      "repositoryUrl": "https://github.com/gitleaks/gitleaks",
+      "bins": [
+        "gitleaks"
+      ]
+    },
+    {
+      "id": "grain",
+      "locator": "https://raw.githubusercontent.com/moonrepo/community-plugins/master/tools/grain.toml",
+      "format": "toml",
+      "name": "Grain",
+      "description": "",
+      "author": "moonrepo",
+      "repositoryUrl": "https://github.com/grain-lang/grain",
+      "bins": [
+        "grain"
+      ]
+    },
+    {
+      "id": "gum",
+      "locator": "https://raw.githubusercontent.com/moonrepo/community-plugins/master/tools/gum.toml",
+      "format": "toml",
+      "name": "Gum",
+      "description": "A tool for glamorous shell scripts.",
+      "author": "moonrepo",
+      "repositoryUrl": "https://github.com/charmbracelet/gum",
+      "bins": [
+        "gum"
+      ]
+    },
+    {
+      "id": "hurl",
+      "locator": "https://raw.githubusercontent.com/moonrepo/community-plugins/master/tools/hurl.toml",
+      "format": "toml",
+      "name": "Hurl",
+      "description": "A command line tool that runs HTTP requests defined in a simple plain text format.",
+      "author": "moonrepo",
+      "homepageUrl": "https://hurl.dev/",
+      "repositoryUrl": "https://github.com/Orange-OpenSource/hurl",
+      "bins": [
+        "hurl",
+        "hurlfmt"
+      ]
+    },
+    {
+      "id": "hyperfine",
+      "locator": "https://raw.githubusercontent.com/moonrepo/community-plugins/master/tools/hyperfine.toml",
+      "format": "toml",
+      "name": "hyperfine",
+      "description": "A command-line benchmarking tool.",
+      "author": "moonrepo",
+      "repositoryUrl": "https://github.com/sharkdp/hyperfine",
+      "bins": [
+        "hyperfine"
+      ]
+    },
+    {
+      "id": "infisical",
+      "locator": "https://raw.githubusercontent.com/moonrepo/community-plugins/master/tools/infisical.toml",
+      "format": "toml",
+      "name": "Infisical",
+      "description": "The command-line interface for the open source secret management platform Infisical.",
+      "author": "moonrepo",
+      "homepageUrl": "https://infisical.com/",
+      "repositoryUrl": "https://github.com/Infisical/infisical",
+      "bins": [
+        "infisical"
+      ]
+    },
+    {
+      "id": "jira",
+      "locator": "https://raw.githubusercontent.com/moonrepo/community-plugins/master/tools/jira.toml",
+      "format": "toml",
+      "name": "JiraCLI",
+      "description": "An interactive command line tool for Atlassian Jira.",
+      "author": "moonrepo",
+      "repositoryUrl": "https://github.com/ankitpokhrel/jira-cli",
+      "bins": [
+        "jira"
+      ]
+    },
+    {
+      "id": "just",
+      "locator": "https://raw.githubusercontent.com/moonrepo/community-plugins/master/tools/just.toml",
+      "format": "toml",
+      "name": "just",
+      "description": "A handy way to save and run project-specific commands.",
+      "author": "moonrepo",
+      "repositoryUrl": "https://github.com/casey/just",
+      "bins": [
+        "just"
+      ]
+    },
+    {
+      "id": "mage",
+      "locator": "https://raw.githubusercontent.com/moonrepo/community-plugins/master/tools/mage.toml",
+      "format": "toml",
+      "name": "Mage",
+      "description": "A make/rake-like build tool using Go.",
+      "author": "moonrepo",
+      "homepageUrl": "https://magefile.org/",
+      "repositoryUrl": "https://github.com/magefile/mage",
+      "bins": [
+        "mage"
+      ]
+    },
+    {
+      "id": "mkcert",
+      "locator": "https://raw.githubusercontent.com/moonrepo/community-plugins/master/tools/mkcert.toml",
+      "format": "toml",
+      "name": "mkcert",
+      "description": "A simple zero-config tool to make locally trusted development certificates with any names you'd like.",
+      "author": "moonrepo",
+      "repositoryUrl": "https://github.com/FiloSottile/mkcert",
+      "bins": [
+        "mkcert"
+      ]
+    },
+    {
+      "id": "ninja",
+      "locator": "https://raw.githubusercontent.com/moonrepo/community-plugins/master/tools/ninja.toml",
+      "format": "toml",
+      "name": "Ninja",
+      "description": "A small build system with a focus on speed.",
+      "author": "moonrepo",
+      "homepageUrl": "https://ninja-build.org/",
+      "repositoryUrl": "https://github.com/ninja-build/ninja",
+      "bins": [
+        "ninja"
+      ]
+    },
+    {
+      "id": "octopus",
+      "locator": "https://raw.githubusercontent.com/moonrepo/community-plugins/master/tools/octopus.toml",
+      "format": "toml",
+      "name": "Octopus CLI",
+      "description": "Command line interface for Octopus Deploy.",
+      "author": "moonrepo",
+      "homepageUrl": "https://octopus.com/",
+      "repositoryUrl": "https://github.com/OctopusDeploy/cli",
+      "bins": [
+        "octopus"
+      ]
+    },
+    {
+      "id": "oxlint",
+      "locator": "https://raw.githubusercontent.com/moonrepo/community-plugins/master/tools/oxlint.toml",
+      "format": "toml",
+      "name": "oxlint",
+      "description": "Oxlint is a JavaScript linter designed to catch erroneous or useless code without requiring any configurations by default.",
+      "author": "moonrepo",
+      "homepageUrl": "https://oxc-project.github.io/",
+      "repositoryUrl": "https://github.com/oxc-project/oxc",
+      "bins": [
+        "oxlint"
+      ]
+    },
+    {
+      "id": "pixi",
+      "locator": "https://raw.githubusercontent.com/moonrepo/community-plugins/master/tools/pixi.toml",
+      "format": "toml",
+      "name": "pixi",
+      "description": "",
+      "author": "moonrepo",
+      "repositoryUrl": "https://github.com/prefix-dev/pixi",
+      "bins": [
+        "pixi"
+      ]
+    },
+    {
+      "id": "rattler-build",
+      "locator": "https://raw.githubusercontent.com/moonrepo/community-plugins/master/tools/rattler-build.toml",
+      "format": "toml",
+      "name": "rattler-build",
+      "description": "A fast Conda package builder.",
+      "author": "moonrepo",
+      "homepageUrl": "https://prefix-dev.github.io/rattler-build/",
+      "repositoryUrl": "https://github.com/prefix-dev/rattler-build",
+      "bins": [
+        "rattler-build"
+      ]
+    },
+    {
+      "id": "ruff",
+      "locator": "https://raw.githubusercontent.com/moonrepo/community-plugins/master/tools/ruff.toml",
+      "format": "toml",
+      "name": "Ruff",
+      "description": "An extremely fast Python linter and code formatter.",
+      "author": "moonrepo",
+      "homepageUrl": "https://docs.astral.sh/ruff/",
+      "repositoryUrl": "https://github.com/astral-sh/ruff",
+      "bins": [
+        "ruff"
+      ]
+    },
+    {
+      "id": "shellcheck",
+      "locator": "https://raw.githubusercontent.com/moonrepo/community-plugins/master/tools/shellcheck.toml",
+      "format": "toml",
+      "name": "ShellCheck",
+      "description": "A static analysis tool for shell scripts.",
+      "author": "moonrepo",
+      "repositoryUrl": "https://github.com/koalaman/shellcheck",
+      "bins": [
+        "shellcheck"
+      ]
+    },
+    {
+      "id": "shfmt",
+      "locator": "https://raw.githubusercontent.com/moonrepo/community-plugins/master/tools/shfmt.toml",
+      "format": "toml",
+      "name": "shfmt",
+      "description": "A shell formatter for POSIX Shell, Bash and mksh.",
+      "author": "moonrepo",
+      "repositoryUrl": "https://github.com/mvdan/sh",
+      "bins": [
+        "shfmt"
+      ]
+    },
+    {
+      "id": "task",
+      "locator": "https://raw.githubusercontent.com/moonrepo/community-plugins/master/tools/task.toml",
+      "format": "toml",
+      "name": "Task",
+      "description": "Task is a task runner / build tool that aims to be simpler and easier to use than, for example, GNU Make.",
+      "author": "moonrepo",
+      "homepageUrl": "https://taskfile.dev/",
+      "repositoryUrl": "https://github.com/go-task/task",
+      "bins": [
+        "task"
+      ]
+    },
+    {
+      "id": "traefik",
+      "locator": "https://raw.githubusercontent.com/moonrepo/community-plugins/master/tools/traefik.toml",
+      "format": "toml",
+      "name": "Traefik",
+      "description": "A modern HTTP reverse proxy and load balancer that makes deploying microservices easy.",
+      "author": "moonrepo",
+      "homepageUrl": "https://traefik.io/",
+      "repositoryUrl": "https://github.com/traefik/traefik",
+      "bins": [
+        "traefik"
+      ]
+    },
+    {
+      "id": "trufflehog",
+      "locator": "https://raw.githubusercontent.com/moonrepo/community-plugins/master/tools/trufflehog.toml",
+      "format": "toml",
+      "name": "TruffleHog",
+      "description": "Find and verify credentials.",
+      "author": "moonrepo",
+      "repositoryUrl": "https://github.com/trufflesecurity/trufflehog",
+      "bins": [
+        "trufflehog"
+      ]
+    },
+    {
+      "id": "watchexec",
+      "locator": "https://raw.githubusercontent.com/moonrepo/community-plugins/master/tools/watchexec.toml",
+      "format": "toml",
+      "name": "watchexec",
+      "description": "",
+      "author": "moonrepo",
+      "repositoryUrl": "https://github.com/watchexec/watchexec",
+      "bins": [
+        "watchexec"
+      ]
+    },
+    {
+      "id": "wizer",
+      "locator": "https://raw.githubusercontent.com/moonrepo/community-plugins/master/tools/wizer.toml",
+      "format": "toml",
+      "name": "Wizer",
+      "description": "The WebAssembly Pre-Initializer.",
+      "author": "moonrepo",
+      "repositoryUrl": "https://github.com/bytecodealliance/wizer",
+      "bins": [
+        "wizer"
+      ]
+    }
+  ]
+}

--- a/registry/generate_community_registry.py
+++ b/registry/generate_community_registry.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Generate the proto registry dataset for moonrepo/community-plugins."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import tomllib
+from typing import Any
+
+
+COMMUNITY_REPOSITORY = "https://github.com/moonrepo/community-plugins"
+COMMUNITY_RAW_ROOT = (
+    "https://raw.githubusercontent.com/moonrepo/community-plugins/master/tools"
+)
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    try:
+        with path.open("rb") as file:
+            manifest = tomllib.load(file)
+    except tomllib.TOMLDecodeError as error:
+        raise ValueError(f"failed to parse {path}: {error}") from error
+
+    if not isinstance(manifest, dict):
+        raise ValueError(f"expected {path} to contain a TOML table")
+
+    return manifest
+
+
+def require_table(parent: dict[str, Any], key: str, path: Path) -> dict[str, Any]:
+    value = parent.get(key, {})
+
+    if not isinstance(value, dict):
+        raise ValueError(f"expected [{key}] in {path} to be a table")
+
+    return value
+
+
+def require_string(parent: dict[str, Any], key: str, path: Path) -> str:
+    value = parent.get(key)
+
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"expected {key!r} in {path} to be a non-empty string")
+
+    return value
+
+
+def string_list(parent: dict[str, Any], key: str, path: Path) -> list[str]:
+    value = parent.get(key, [])
+
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ValueError(f"expected {key!r} in {path} to be an array of strings")
+
+    return value
+
+
+def parse_bins(plugin_id: str, install: dict[str, Any], path: Path) -> list[str]:
+    exes = install.get("exes", {})
+
+    if not isinstance(exes, dict):
+        raise ValueError(f"expected [install.exes] in {path} to be a table")
+
+    primary_bins: list[str] = []
+    secondary_bins: list[str] = []
+
+    for bin_name, config in exes.items():
+        if not isinstance(config, dict):
+            raise ValueError(
+                f"expected [install.exes.{bin_name}] in {path} to be a table"
+            )
+
+        if config.get("primary") is True:
+            primary_bins.append(bin_name)
+        else:
+            secondary_bins.append(bin_name)
+
+    # The TOML plugin implicitly registers the plugin ID as the primary executable
+    # when none of the explicitly configured executables are marked as primary.
+    if not primary_bins:
+        primary_bins.append(plugin_id)
+
+    return list(dict.fromkeys([*primary_bins, *secondary_bins]))
+
+
+def build_plugin_entry(path: Path) -> dict[str, Any]:
+    manifest = load_manifest(path)
+    plugin_id = path.stem
+    metadata = require_table(manifest, "plugin", path)
+    install = require_table(manifest, "install", path)
+    detect = require_table(manifest, "detect", path)
+    packages = require_table(manifest, "packages", path)
+
+    entry: dict[str, Any] = {
+        "id": plugin_id,
+        "locator": f"{COMMUNITY_RAW_ROOT}/{path.name}",
+        "format": "toml",
+        "name": require_string(manifest, "name", path),
+        "description": metadata.get("description", ""),
+        "author": "moonrepo",
+    }
+
+    if not isinstance(entry["description"], str):
+        raise ValueError(f"expected 'plugin.description' in {path} to be a string")
+
+    for source_key, output_key in (
+        ("homepage-url", "homepageUrl"),
+        ("repository-url", "repositoryUrl"),
+    ):
+        value = metadata.get(source_key)
+
+        if value is not None:
+            if not isinstance(value, str):
+                raise ValueError(f"expected 'plugin.{source_key}' in {path} to be a string")
+
+            entry[output_key] = value
+
+    entry.setdefault("repositoryUrl", COMMUNITY_REPOSITORY)
+    entry["bins"] = parse_bins(plugin_id, install, path)
+
+    version_files = string_list(detect, "version-files", path)
+    if version_files:
+        entry["detectionSources"] = [{"file": file} for file in version_files]
+
+    globals_dirs = string_list(packages, "globals-lookup-dirs", path)
+    if globals_dirs:
+        entry["globalsDirs"] = globals_dirs
+
+    return entry
+
+
+def generate_registry(source_root: Path) -> dict[str, Any]:
+    tools_dir = source_root / "tools"
+
+    if not tools_dir.is_dir():
+        raise ValueError(f"community plugins tools directory does not exist: {tools_dir}")
+
+    manifests = sorted(tools_dir.glob("*.toml"), key=lambda path: path.name)
+    if not manifests:
+        raise ValueError(f"no community plugin manifests found in {tools_dir}")
+
+    return {
+        "$schema": "../schema.json",
+        "version": 1,
+        "plugins": [build_plugin_entry(path) for path in manifests],
+    }
+
+
+def write_registry(source_root: Path, output_path: Path) -> None:
+    registry = generate_registry(source_root)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(registry, indent=2), encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "source_root",
+        type=Path,
+        help="path to a checkout of moonrepo/community-plugins",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("registry/data/community.json"),
+        help="registry JSON file to write",
+    )
+    args = parser.parse_args()
+
+    write_registry(args.source_root, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/registry/tests/test_generate_community_registry.py
+++ b/registry/tests/test_generate_community_registry.py
@@ -1,0 +1,96 @@
+import importlib.util
+from pathlib import Path
+import tempfile
+import textwrap
+import unittest
+
+
+SCRIPT_PATH = Path(__file__).parents[1] / "generate_community_registry.py"
+SPEC = importlib.util.spec_from_file_location("generate_community_registry", SCRIPT_PATH)
+assert SPEC and SPEC.loader
+GENERATOR = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(GENERATOR)
+
+
+class GenerateCommunityRegistryTest(unittest.TestCase):
+    def write_manifest(self, root: Path, name: str, contents: str) -> None:
+        tools_dir = root / "tools"
+        tools_dir.mkdir(exist_ok=True)
+        (tools_dir / f"{name}.toml").write_text(textwrap.dedent(contents))
+
+    def test_maps_metadata_and_plugin_configuration(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self.write_manifest(
+                root,
+                "example",
+                """
+                name = "Example"
+
+                [plugin]
+                description = "An example tool."
+                homepage-url = "https://example.com/"
+                repository-url = "https://github.com/example/example"
+
+                [detect]
+                version-files = [".example-version", "example.json"]
+
+                [install]
+                download-url = "https://example.com/{version}"
+
+                [install.exes.helper]
+                exe-path = "bin/helper"
+
+                [packages]
+                globals-lookup-dirs = ["$EXAMPLE_HOME/bin", "~/.example/bin"]
+                """,
+            )
+
+            [plugin] = GENERATOR.generate_registry(root)["plugins"]
+
+            self.assertEqual(plugin["id"], "example")
+            self.assertEqual(plugin["name"], "Example")
+            self.assertEqual(plugin["description"], "An example tool.")
+            self.assertEqual(plugin["homepageUrl"], "https://example.com/")
+            self.assertEqual(
+                plugin["repositoryUrl"], "https://github.com/example/example"
+            )
+            self.assertEqual(plugin["bins"], ["example", "helper"])
+            self.assertEqual(
+                plugin["detectionSources"],
+                [{"file": ".example-version"}, {"file": "example.json"}],
+            )
+            self.assertEqual(
+                plugin["globalsDirs"], ["$EXAMPLE_HOME/bin", "~/.example/bin"]
+            )
+
+    def test_uses_explicit_primary_bin_and_sorts_plugins(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self.write_manifest(root, "zulu", 'name = "Zulu"\n')
+            self.write_manifest(
+                root,
+                "alpha",
+                """
+                name = "Alpha"
+
+                [install.exes.alpha-cli]
+                primary = true
+
+                [install.exes.alpha-helper]
+                """,
+            )
+
+            plugins = GENERATOR.generate_registry(root)["plugins"]
+
+            self.assertEqual([plugin["id"] for plugin in plugins], ["alpha", "zulu"])
+            self.assertEqual(plugins[0]["bins"], ["alpha-cli", "alpha-helper"])
+            self.assertEqual(plugins[1]["bins"], ["zulu"])
+            self.assertEqual(plugins[1]["description"], "")
+            self.assertEqual(
+                plugins[1]["repositoryUrl"], GENERATOR.COMMUNITY_REPOSITORY
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- generate `registry/data/community.json` nightly from `moonrepo/community-plugins`
- resolve community tools automatically after configured and built-in plugins, using the shared HTTP-backed registry cache
- add `settings.community-tools` and `PROTO_COMMUNITY_TOOLS` opt-outs
- reuse registry instances through `ProtoEnvironment::load_registry`

## Testing

- `python3 -B -m unittest registry/tests/test_generate_community_registry.py`
- `cargo test -p proto_core --test config_test can_set_settings`
- `cargo test -p proto_core --test tool_loader_test locate_plugin`
- `cargo check -p proto_cli`
- `cargo clippy -p proto_cli`
- `cargo fmt --all --check`