### PR TITLE
fix: Route reporter output correctly for outdated --update and tool execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@
 - Fixed `proto outdated --update` reporting a successful update when no versions were actually written. We now warn and list the tools that were skipped.
 - Fixed `proto run`, `proto exec`, and `proto shell` writing proto's own output to stdout, which corrupts the output of the tool being ran. Errors (including the NDJSON error record in AI agent environments), auto-install messages, and install progress are now written to stderr, leaving stdout to the tool.
 
+#### ⚙️ Internal
+
+- Updated dependencies.
+
 ## 0.61.2
 
 #### 🐞 Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Fixed `proto outdated --update` not writing any versions when the reporter format is JSON or NDJSON, which is enabled with `--json`/`--reporter`, and detected automatically within AI agent environments.
 - Fixed `proto outdated --update` not writing any versions when not running in a terminal, as the confirmation prompt could never be answered. The `--update` flag is now the confirmation in this situation.
 - Fixed `proto outdated --update` reporting a successful update when no versions were actually written. We now warn and list the tools that were skipped.
+- Fixed `proto run`, `proto exec`, and `proto shell` writing proto's own output to stdout, which corrupts the output of the tool being ran. Errors (including the NDJSON error record in AI agent environments), auto-install messages, and install progress are now written to stderr, leaving stdout to the tool.
 
 ## 0.61.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@
 - [Swift](https://github.com/moonrepo/plugins/blob/master/tools/swift/CHANGELOG.md)
 - [Schema (TOML, JSON, YAML)](https://github.com/moonrepo/plugins/blob/master/tools/internal-schema/CHANGELOG.md)
 
+## Unreleased
+
+#### 🐞 Fixes
+
+- Fixed `proto outdated --update` not writing any versions when the reporter format is JSON or NDJSON, which is enabled with `--json`/`--reporter`, and detected automatically within AI agent environments.
+- Fixed `proto outdated --update` not writing any versions when not running in a terminal, as the confirmation prompt could never be answered. The `--update` flag is now the confirmation in this situation.
+- Fixed `proto outdated --update` reporting a successful update when no versions were actually written. We now warn and list the tools that were skipped.
+
 ## 0.61.2
 
 #### 🐞 Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,7 +228,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -245,9 +245,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.18.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+checksum = "b281d307588d634de920874890732659e2e7672f72b5e10e81badc1a8a83621e"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -256,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.44.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+checksum = "9bff6c3b54fad79a2e60b8102caf565819711497c1f5f092f49508e2f5c31b27"
 dependencies = [
  "cc",
  "cmake",
@@ -276,7 +276,7 @@ dependencies = [
  "addr2line 0.25.1",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
  "object 0.37.3",
  "rustc-demangle",
  "windows-link",
@@ -559,7 +559,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ec6a5b75f54547c579a6b117c6fdd5f04f4ab7598de747b9f440a53592b3a4a"
 dependencies = [
  "ambient-authority",
- "rand 0.8.7",
+ "rand 0.8.8",
 ]
 
 [[package]]
@@ -668,12 +668,12 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "rand_core 0.10.1",
 ]
 
@@ -760,7 +760,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -806,9 +806,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
 dependencies = [
  "bytes",
  "memchr",
@@ -940,9 +940,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -1175,7 +1175,7 @@ dependencies = [
  "parking_lot",
  "rustix 1.1.4",
  "serde",
- "signal-hook",
+ "signal-hook 0.3.18",
  "signal-hook-mio",
  "winapi",
 ]
@@ -1342,7 +1342,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1375,7 +1375,7 @@ checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
 dependencies = [
  "darling_core 0.24.1",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1573,7 +1573,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1916,12 +1916,12 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.9.1",
  "zlib-rs",
 ]
 
@@ -2049,7 +2049,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2267,9 +2267,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2466,9 +2466,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2731,9 +2731,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -3061,9 +3061,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.20"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
+checksum = "8d8f1ea3f21fd3405dcaf6c9b5c1630af9afc422d9073ea39c5f6d6c772e08ed"
 dependencies = [
  "libc",
 ]
@@ -3196,9 +3196,9 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memfd"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
+checksum = "57804b2c9b69967f1536a56f86297e367a33b19e98852ed624b84551cdbc0d90"
 dependencies = [
  "rustix 1.1.4",
 ]
@@ -3290,14 +3290,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
+dependencies = [
+ "adler2",
  "simd-adler32",
 ]
 
 [[package]]
 name = "mio"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
  "log",
@@ -3376,7 +3385,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.7",
+ "rand 0.8.8",
  "serde",
  "smallvec",
  "zeroize",
@@ -3732,9 +3741,9 @@ dependencies = [
 
 [[package]]
 name = "owo-colors"
-version = "4.3.0"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+checksum = "13c45bb4a6ae1280ec0803b1ef9d3455eb50f01efbbe1447ab020f1d54fba9d8"
 
 [[package]]
 name = "p256"
@@ -3933,7 +3942,7 @@ dependencies = [
  "p256",
  "p384",
  "p521",
- "rand 0.8.7",
+ "rand 0.8.8",
  "replace_with",
  "ripemd",
  "rsa",
@@ -4263,7 +4272,7 @@ dependencies = [
  "proto_core",
  "proto_pdk_api",
  "proto_shim",
- "rand 0.8.7",
+ "rand 0.8.8",
  "regex",
  "reqwest",
  "rustc-hash",
@@ -4447,9 +4456,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -4616,7 +4625,7 @@ checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4808,9 +4817,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "3.1.4"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a15bc53261a9dc37e105df006e4656c598379a8f9581f8950debb130f27a7cf"
+checksum = "42b6914fac0be956fe704a38239c3f44a9f841d1b06a5713d2f638065593f5b5"
 dependencies = [
  "base64 0.23.1",
  "chrono",
@@ -4831,15 +4840,15 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "3.1.4"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a85d45508e9b4ba024fe996c2638799635d75b6dd0ba8f32ccf08f8026f0c780"
+checksum = "cdf1c49bd4d52014b94db0877410db273c2008f01628b0252a2e9460ad9b7fda"
 dependencies = [
  "darling 0.24.1",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5060,9 +5069,9 @@ dependencies = [
 
 [[package]]
 name = "scc"
-version = "3.8.6"
+version = "3.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8af0b99483d1c3e59471d4f0cb58b244169436a8979c889a91a3f697075ea01"
+checksum = "5d5f8ca67c4f6208caf824037a6a9df0211b4e0937fccc4f543441f294d04511"
 dependencies = [
  "saa",
  "sdd",
@@ -5100,7 +5109,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5125,7 +5134,7 @@ dependencies = [
  "serde_path_to_error",
  "starbase_styles",
  "thiserror 2.0.20",
- "toml 1.1.4+spec-1.1.0",
+ "toml 1.1.5+spec-1.1.0",
  "tracing",
 ]
 
@@ -5139,7 +5148,7 @@ dependencies = [
  "darling 0.24.1",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5151,7 +5160,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "schematic_core",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5164,7 +5173,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "toml 1.1.4+spec-1.1.0",
+ "toml 1.1.5+spec-1.1.0",
  "url",
 ]
 
@@ -5176,9 +5185,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sdd"
-version = "4.8.9"
+version = "4.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c0f6aa664d1a2a4d4a9d894bac41e27d518cb2ea90a00d68e9c77d02519116"
+checksum = "f95d4cc3459db1e608946153c95cf20158af0b86131ae4ae451f90f54549e7d1"
 dependencies = [
  "saa",
 ]
@@ -5267,7 +5276,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5278,7 +5287,7 @@ checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5424,7 +5433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "digest 0.11.3",
 ]
 
@@ -5489,13 +5498,13 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "sigchld"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47106eded3c154e70176fc83df9737335c94ce22f821c32d17ed1db1f83badb1"
+checksum = "24f2b37f04360cd465089b87a9c3869c08220a2f3458463f0adf8badf5e77f2c"
 dependencies = [
  "libc",
  "os_pipe",
- "signal-hook",
+ "signal-hook 0.4.4",
 ]
 
 [[package]]
@@ -5509,6 +5518,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
 name = "signal-hook-mio"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5516,7 +5535,7 @@ checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
  "mio",
- "signal-hook",
+ "signal-hook 0.3.18",
 ]
 
 [[package]]
@@ -5594,9 +5613,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 dependencies = [
  "serde",
 ]
@@ -5798,9 +5817,9 @@ dependencies = [
 
 [[package]]
 name = "starbase_utils"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4fa3bb440faaea7ef237edd14e81e40875c872fbee854eae6a6765b29cce4a"
+checksum = "4e191c692d1ab7608def8afc816fc493f8a7823780dc5e6a4f7f030d0a1f0d3e"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -5818,7 +5837,7 @@ dependencies = [
  "starbase_styles",
  "thiserror 2.0.20",
  "tokio",
- "toml 1.1.4+spec-1.1.0",
+ "toml 1.1.5+spec-1.1.0",
  "tracing",
  "url",
  "wax",
@@ -5895,9 +5914,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6076,7 +6095,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -6169,7 +6188,7 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -6234,9 +6253,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.4+spec-1.1.0"
+version = "1.1.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -6681,9 +6700,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.25.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -6943,12 +6962,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.257.1"
+version = "0.258.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d8ad9f0a39050867bda22e6486c316e2e52d20a42154d5bc433934bf738d085"
+checksum = "e974fe6821a8cf64575d51ea2194e2c8f77e7b66e9afe7419ce8a97f9ee0d251"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.257.1",
+ "wasmparser 0.258.0",
 ]
 
 [[package]]
@@ -6979,9 +6998,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.257.1"
+version = "0.258.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92fc335fb6d48f46bda1d8b26b69e28320c15ac3272208333833d6e217e2b4a"
+checksum = "d9a61719f93a87b16d325921e251800c4833f8fab50fa21c7de73aed50086313"
 dependencies = [
  "bitflags",
  "indexmap",
@@ -7281,24 +7300,24 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "257.0.1"
+version = "258.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c416ee8044cf88c5280e3d87c322b009525eb25142cf7428f0a90ea88febc3b"
+checksum = "97f7defc7ecca8b19ac7f824598eadd0c53985ee00c74060d65051e9da5b58a1"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.2",
- "wasm-encoder 0.257.1",
+ "wasm-encoder 0.258.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.257.1"
+version = "1.258.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "672e5495f00c5fc6c6b502205bae4708aa4dd13d969754438743afe0a8af0f1d"
+checksum = "7555c008cca87f2ac58d9f83ccda7e7b44611093ce28eb28f052e7c78024b9bf"
 dependencies = [
- "wast 257.0.1",
+ "wast 258.0.0",
 ]
 
 [[package]]
@@ -7955,7 +7974,7 @@ checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ futures = "0.3.34"
 hex = { version = "0.4.3", features = ["alloc"] }
 http-cache-reqwest = "1.0.0-alpha.7"
 human-sort = "0.2.2"
-indexmap = "2.14.0"
+indexmap = "2.14.1"
 iocraft = "0.8.4"
 # iocraft = { git = "https://github.com/ccbrown/iocraft.git", branch = "main" }
 miette = "7.6.0"
@@ -42,12 +42,12 @@ reqwest-middleware = { version = "0.5.2", default-features = false, features = [
     "charset",
     "http2",
 ] }
-rmcp = { version = "3.1.4", default-features = false, features = [
+rmcp = { version = "3.2.0", default-features = false, features = [
     "base64",
     "macros",
 ] }
 rustc-hash = "2.1.3"
-scc = "3.8.5"
+scc = "3.8.8"
 schemars = "1.2.2"
 schematic = { version = "0.20.2", default-features = false }
 serde = { version = "1.0.229", features = ["derive"] }
@@ -73,7 +73,7 @@ starbase_id = { version = "0.4.0", features = ["miette", "schematic"] }
 starbase_sandbox = { version = "0.12.0" }
 starbase_shell = { version = "0.12.8", features = ["miette"] }
 starbase_styles = { version = "0.6.9" }
-starbase_utils = { version = "0.14.3", default-features = false, features = [
+starbase_utils = { version = "0.14.4", default-features = false, features = [
     "fs-lock",
     "json",
     "miette",
@@ -86,4 +86,4 @@ toml_edit = "0.25"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", default-features = false }
 url = "2.5.8"
-uuid = { version = "1.25.0", features = ["v4"] }
+uuid = { version = "1.26.0", features = ["v4"] }

--- a/crates/cli/src/app.rs
+++ b/crates/cli/src/app.rs
@@ -209,6 +209,7 @@ pub enum StdoutOwner {
     ShellCode,
     CompletionCode,
     McpStdio,
+    ToolProcess,
 }
 
 impl App {
@@ -233,6 +234,9 @@ impl App {
                     StdoutOwner::McpStdio
                 }
             }
+            // Stdout belongs to the tool we're executing, so everything we
+            // write, errors included, must go to stderr instead
+            Commands::Exec(_) | Commands::Run(_) | Commands::Shell(_) => StdoutOwner::ToolProcess,
             _ => StdoutOwner::Reporter,
         }
     }

--- a/crates/cli/src/commands/activate.rs
+++ b/crates/cli/src/commands/activate.rs
@@ -58,7 +58,7 @@ pub async fn activate(session: ProtoSession, args: ActivateArgs) -> SessionResul
         StdoutOwner::Reporter => ActivateOutputMode::Structured,
         StdoutOwner::ShellCode if args.export => ActivateOutputMode::Export,
         StdoutOwner::ShellCode => ActivateOutputMode::Hook,
-        StdoutOwner::CompletionCode | StdoutOwner::McpStdio => {
+        StdoutOwner::CompletionCode | StdoutOwner::McpStdio | StdoutOwner::ToolProcess => {
             unreachable!("activate resolved to an unrelated stdout owner")
         }
     };

--- a/crates/cli/src/commands/outdated.rs
+++ b/crates/cli/src/commands/outdated.rs
@@ -7,7 +7,7 @@ use proto_core::flow::lock::Locker;
 use proto_core::flow::resolve::{ProtoResolveError, Resolver};
 use proto_core::{
     PROTO_CONFIG_NAME, ProtoConfig, Requirement, ToolContext, ToolSpec, UnresolvedVersionSpec,
-    VersionSpec, cfg,
+    VersionSpec, cfg, reporter::NoticeOutput,
 };
 use serde::Serialize;
 use starbase_console::ui::*;
@@ -51,6 +51,73 @@ fn get_in_major_range(spec: &UnresolvedVersionSpec) -> UnresolvedVersionSpec {
         ),
         _ => spec.clone(),
     }
+}
+
+fn render_table(
+    session: &ProtoSession,
+    items: &BTreeMap<ToolContext, OutdatedItem>,
+) -> miette::Result<()> {
+    let ctx_width = items.keys().fold(0, |acc, ctx| acc.max(ctx.as_str().len()));
+
+    // Only show the locked column if a tool is using a lockfile
+    let show_locked = items.values().any(|item| item.locked_version.is_some());
+
+    let mut headers = vec![
+        TableHeader::new("Tool", Size::Length((ctx_width + 3).max(10) as u32)),
+        TableHeader::new("Current", Size::Length(10)),
+    ];
+
+    if show_locked {
+        headers.push(TableHeader::new("Locked", Size::Length(10)));
+    }
+
+    headers.extend([
+        TableHeader::new("Newest", Size::Length(10)),
+        TableHeader::new("Latest", Size::Length(10)),
+        TableHeader::new("Config", Size::Auto),
+    ]);
+
+    session.console.table(
+        headers,
+        items
+            .iter()
+            .map(|(ctx, item)| {
+                let mut row = vec![format!("<id>{ctx}</id>"), item.current_version.to_string()];
+
+                if show_locked {
+                    row.push(if let Some(version) = &item.locked_version {
+                        format!("<hash>{version}</hash>")
+                    } else {
+                        "<mutedlight>N/A</mutedlight>".into()
+                    });
+                }
+
+                row.extend([
+                    if item.newest_version == item.current_version {
+                        format!("<mutedlight>{}</mutedlight>", item.newest_version)
+                    } else {
+                        format!("<success>{}</success>", item.newest_version)
+                    },
+                    if item.latest_version == item.current_version {
+                        format!("<mutedlight>{}</mutedlight>", item.latest_version)
+                    } else if item.latest_version == item.newest_version {
+                        format!("<success>{}</success>", item.latest_version)
+                    } else {
+                        format!("<failure>{}</failure>", item.latest_version)
+                    },
+                    if let Some(src) = &item.config_source {
+                        format!("<path>{}</path>", src.to_string_lossy())
+                    } else {
+                        "<mutedlight>N/A</mutedlight>".into()
+                    },
+                ]);
+
+                row
+            })
+            .collect(),
+    )?;
+
+    Ok(())
 }
 
 #[instrument(skip(session))]
@@ -152,80 +219,25 @@ pub async fn outdated(session: ProtoSession, args: OutdatedArgs) -> SessionResul
     );
 
     if session.is_json_format() {
-        session.console.write_json_for_format(items)?;
-
-        return Ok(None);
+        session.console.write_json_for_format(&items)?;
+    } else {
+        render_table(&session, &items)?;
     }
-
-    let ctx_width = items.keys().fold(0, |acc, ctx| acc.max(ctx.as_str().len()));
-
-    // Only show the locked column if a tool is using a lockfile
-    let show_locked = items.values().any(|item| item.locked_version.is_some());
-
-    let mut headers = vec![
-        TableHeader::new("Tool", Size::Length((ctx_width + 3).max(10) as u32)),
-        TableHeader::new("Current", Size::Length(10)),
-    ];
-
-    if show_locked {
-        headers.push(TableHeader::new("Locked", Size::Length(10)));
-    }
-
-    headers.extend([
-        TableHeader::new("Newest", Size::Length(10)),
-        TableHeader::new("Latest", Size::Length(10)),
-        TableHeader::new("Config", Size::Auto),
-    ]);
-
-    session.console.table(
-        headers,
-        items
-            .iter()
-            .map(|(ctx, item)| {
-                let mut row = vec![format!("<id>{ctx}</id>"), item.current_version.to_string()];
-
-                if show_locked {
-                    row.push(if let Some(version) = &item.locked_version {
-                        format!("<hash>{version}</hash>")
-                    } else {
-                        "<mutedlight>N/A</mutedlight>".into()
-                    });
-                }
-
-                row.extend([
-                    if item.newest_version == item.current_version {
-                        format!("<mutedlight>{}</mutedlight>", item.newest_version)
-                    } else {
-                        format!("<success>{}</success>", item.newest_version)
-                    },
-                    if item.latest_version == item.current_version {
-                        format!("<mutedlight>{}</mutedlight>", item.latest_version)
-                    } else if item.latest_version == item.newest_version {
-                        format!("<success>{}</success>", item.latest_version)
-                    } else {
-                        format!("<failure>{}</failure>", item.latest_version)
-                    },
-                    if let Some(src) = &item.config_source {
-                        format!("<path>{}</path>", src.to_string_lossy())
-                    } else {
-                        "<mutedlight>N/A</mutedlight>".into()
-                    },
-                ]);
-
-                row
-            })
-            .collect(),
-    )?;
 
     // If updating versions, batch the changes based on config paths
     if !args.update {
         return Ok(None);
     }
 
-    let skip_prompts = session.should_skip_prompts();
-    let mut confirmed = false;
+    // A prompt can only be answered when attached to a terminal that isn't
+    // rendering machine readable output, otherwise the explicit `--update`
+    // flag is the confirmation, as there's no one to ask
+    let can_prompt =
+        !session.should_skip_prompts() && !session.is_json_format() && session.is_tty();
 
-    if !skip_prompts {
+    if can_prompt {
+        let mut confirmed = false;
+
         session
             .console
             .render_interactive(element! {
@@ -239,100 +251,147 @@ pub async fn outdated(session: ProtoSession, args: OutdatedArgs) -> SessionResul
                 )
             })
             .await?;
+
+        if !confirmed {
+            session.console.notice(
+                Variant::Info,
+                "Update aborted, no configuration files were changed.",
+            )?;
+
+            return Ok(None);
+        }
     }
 
-    if skip_prompts || confirmed {
-        let mut updates: BTreeMap<PathBuf, BTreeMap<ToolContext, UnresolvedVersionSpec>> =
-            BTreeMap::new();
+    let mut updates: BTreeMap<PathBuf, BTreeMap<ToolContext, UnresolvedVersionSpec>> =
+        BTreeMap::new();
+    let mut skipped = vec![];
 
-        for (context, item) in &items {
-            let Some(src) = &item.config_source else {
-                continue;
-            };
+    for (context, item) in &items {
+        let Some(src) = &item.config_source else {
+            skipped.push(format!(
+                "<id>{context}</id> - version was not detected from a configuration file"
+            ));
 
-            // Only proto configs can be updated, including environment scoped
-            // configs, as versions may also be detected from ecosystem files
-            if !ProtoConfig::is_config_file(src) {
-                warn!(
-                    config = ?src,
-                    "Unable to update the version for {}, as its config source is not a {} file",
-                    color::id(context),
-                    color::file(PROTO_CONFIG_NAME),
-                );
+            continue;
+        };
 
-                continue;
-            }
-
-            // Don't update aliases, only semantic or calendar versions
-            if matches!(
-                item.config_version.req,
-                UnresolvedVersionSpec::Canary | UnresolvedVersionSpec::Alias(_)
-            ) {
-                continue;
-            }
-
-            updates.entry(src.to_owned()).or_default().insert(
-                context.to_owned(),
-                if args.latest {
-                    item.latest_version.to_unresolved_spec()
-                } else {
-                    item.newest_version.to_unresolved_spec()
-                },
-            );
-        }
-
-        for (config_path, updated_versions) in &updates {
-            debug!(
-                config = ?config_path,
-                versions = ?updated_versions
-                    .iter()
-                    .map(|(k, v)| (k.to_string(), v.to_string()))
-                    .collect::<BTreeMap<_, _>>(),
-                "Updating config with versions",
+        // Only proto configs can be updated, including environment scoped
+        // configs, as versions may also be detected from ecosystem files
+        if !ProtoConfig::is_config_file(src) {
+            warn!(
+                config = ?src,
+                "Unable to update the version for {}, as its config source is not a {} file",
+                color::id(context),
+                color::file(PROTO_CONFIG_NAME),
             );
 
-            ProtoConfig::update_document(config_path, |doc| {
-                for (context, updated_version) in updated_versions {
-                    doc[context.as_str()] =
-                        cfg::value(ToolSpec::new(updated_version.to_owned()).to_string());
-                }
-            })?;
+            skipped.push(format!(
+                "<id>{context}</id> - <path>{}</path> is not a <file>{PROTO_CONFIG_NAME}</file> file",
+                src.to_string_lossy()
+            ));
+
+            continue;
         }
 
-        // Update records in the lockfiles owned by the updated configs,
-        // otherwise the stale records will be used indefinitely
-        for tool in &tools {
-            let Some(item) = items.get(&tool.context) else {
-                continue;
-            };
+        // Don't update aliases, only semantic or calendar versions
+        if matches!(
+            item.config_version.req,
+            UnresolvedVersionSpec::Canary | UnresolvedVersionSpec::Alias(_)
+        ) {
+            skipped.push(format!(
+                "<id>{context}</id> - <version>{}</version> is an alias, not a version",
+                item.config_version.req
+            ));
 
-            let Some(src) = &item.config_source else {
-                continue;
-            };
-
-            let Some(new_spec) = updates
-                .get(src)
-                .and_then(|versions| versions.get(&tool.context))
-            else {
-                continue;
-            };
-
-            Locker::for_config(tool, src).update_spec_in_lockfile(
-                &item.config_version.req,
-                new_spec,
-                if args.latest {
-                    &item.latest_version
-                } else {
-                    &item.newest_version
-                },
-            )?;
+            continue;
         }
 
-        session.console.notice(
-            Variant::Success,
-            "Update complete! Run <shell>proto install</shell> to install these new versions.",
+        updates.entry(src.to_owned()).or_default().insert(
+            context.to_owned(),
+            if args.latest {
+                item.latest_version.to_unresolved_spec()
+            } else {
+                item.newest_version.to_unresolved_spec()
+            },
+        );
+    }
+
+    // Don't silently do nothing, as callers have no other signal that we
+    // declined to write anything to their configs
+    if updates.is_empty() {
+        let mut messages = vec!["No versions were updated!".into()];
+        messages.extend(skipped);
+
+        session.console.notice_with(NoticeOutput {
+            variant: Variant::Caution,
+            messages,
+            ..Default::default()
+        })?;
+
+        return Ok(None);
+    }
+
+    for (config_path, updated_versions) in &updates {
+        debug!(
+            config = ?config_path,
+            versions = ?updated_versions
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect::<BTreeMap<_, _>>(),
+            "Updating config with versions",
+        );
+
+        ProtoConfig::update_document(config_path, |doc| {
+            for (context, updated_version) in updated_versions {
+                doc[context.as_str()] =
+                    cfg::value(ToolSpec::new(updated_version.to_owned()).to_string());
+            }
+        })?;
+    }
+
+    // Update records in the lockfiles owned by the updated configs,
+    // otherwise the stale records will be used indefinitely
+    for tool in &tools {
+        let Some(item) = items.get(&tool.context) else {
+            continue;
+        };
+
+        let Some(src) = &item.config_source else {
+            continue;
+        };
+
+        let Some(new_spec) = updates
+            .get(src)
+            .and_then(|versions| versions.get(&tool.context))
+        else {
+            continue;
+        };
+
+        Locker::for_config(tool, src).update_spec_in_lockfile(
+            &item.config_version.req,
+            new_spec,
+            if args.latest {
+                &item.latest_version
+            } else {
+                &item.newest_version
+            },
         )?;
     }
+
+    let mut messages = vec![
+        "Update complete! Run <shell>proto install</shell> to install these new versions.".into(),
+    ];
+
+    if !skipped.is_empty() {
+        messages.push("The following tools were not updated:".into());
+        messages.extend(skipped);
+    }
+
+    session.console.notice_with(NoticeOutput {
+        variant: Variant::Success,
+        messages,
+        ..Default::default()
+    })?;
 
     Ok(None)
 }

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -427,7 +427,8 @@ pub async fn run(session: ProtoSession, mut args: RunArgs) -> SessionResult {
             if hide_output {
                 session.console.set_quiet(true);
             } else {
-                session.console.out.write_line(format!(
+                // Write to stderr, as stdout belongs to the tool being ran
+                session.console.err.write_line(format!(
                     "Auto-install is enabled, attempting to install {} {}",
                     tool.get_name(),
                     resolved_version,
@@ -457,7 +458,7 @@ pub async fn run(session: ProtoSession, mut args: RunArgs) -> SessionResult {
             if hide_output {
                 session.console.set_quiet(false);
             } else {
-                session.console.out.write_line(format!(
+                session.console.err.write_line(format!(
                     "{} {} has been installed, continuing execution...",
                     tool.get_name(),
                     resolved_version,

--- a/crates/cli/src/session.rs
+++ b/crates/cli/src/session.rs
@@ -44,7 +44,12 @@ pub struct ProtoSession {
 }
 
 fn should_check_for_new_version(cli: &CLI) -> bool {
-    if cli.stdout_owner() != StdoutOwner::Reporter {
+    // The remaining owners write a protocol payload to stdout that the notice
+    // would corrupt. The tool process owner renders to stderr, so it's safe
+    if !matches!(
+        cli.stdout_owner(),
+        StdoutOwner::Reporter | StdoutOwner::ToolProcess
+    ) {
         return false;
     }
 
@@ -422,7 +427,8 @@ mod tests {
     use clap::Parser;
 
     #[test]
-    fn version_checks_require_reporter_owned_stdout() {
+    fn version_checks_never_corrupt_protocol_stdout() {
+        // Renders to stderr, so the notice can't corrupt the shell session
         let shell = CLI::try_parse_from(["proto", "shell", "--shell", "bash"]).unwrap();
         assert!(should_check_for_new_version(&shell));
 
@@ -434,5 +440,13 @@ mod tests {
 
         let mcp_info = CLI::try_parse_from(["proto", "mcp", "--info"]).unwrap();
         assert!(should_check_for_new_version(&mcp_info));
+
+        // Excluded by command, as the notice is just noise when passing
+        // through to another tool
+        let run = CLI::try_parse_from(["proto", "run", "node"]).unwrap();
+        assert!(!should_check_for_new_version(&run));
+
+        let exec = CLI::try_parse_from(["proto", "exec", "--", "node"]).unwrap();
+        assert!(!should_check_for_new_version(&exec));
     }
 }

--- a/crates/cli/src/session.rs
+++ b/crates/cli/src/session.rs
@@ -334,13 +334,6 @@ impl ProtoSession {
         ProgressInstance { reporter, handle }
     }
 
-    pub fn is_tool_exec_command(&self) -> bool {
-        matches!(
-            self.cli.command,
-            Commands::Exec(_) | Commands::Run(_) | Commands::Shell(_)
-        )
-    }
-
     pub fn is_json_format(&self) -> bool {
         self.console.is_json_format()
     }
@@ -359,9 +352,9 @@ impl AppSession for ProtoSession {
     type Error = miette::Report;
 
     async fn startup(&mut self) -> AppResult<Self::Error> {
-        // Do not show for run/exec commands, as we don't want to pollute the output
-        if !self.is_tool_exec_command()
-            && self.cli.stdout_owner() == StdoutOwner::Reporter
+        // Only show when we own stdout, otherwise we pollute the output of
+        // the tool process, shell code, and other stdout protocols
+        if self.cli.stdout_owner() == StdoutOwner::Reporter
             && self.cli.reporter_format() == ReporterFormat::Ndjson
             && ai_env::is_ai_agent()
         {

--- a/crates/cli/tests/exec_test.rs
+++ b/crates/cli/tests/exec_test.rs
@@ -43,6 +43,8 @@ mod exec {
         ));
     }
 
+    // Stdout belongs to the tool being executed, so the reporter must render
+    // to stderr, otherwise a failure corrupts the tool's output stream
     #[test]
     fn errors_use_reporter_output_in_agent_environments() {
         let sandbox = create_empty_proto_sandbox();
@@ -53,13 +55,14 @@ mod exec {
                 .env_remove("PROTO_REPORTER");
         });
 
-        let stdout = assert.stdout();
-        let records = stdout
+        let stderr = assert.stderr();
+        let records = stderr
             .lines()
+            .filter(|line| line.starts_with('{'))
             .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
             .collect::<Vec<_>>();
 
-        assert.failure();
+        assert.failure().stdout(predicate::str::is_empty());
         assert!(records.iter().any(|record| {
             record.get("type").and_then(|value| value.as_str()) == Some("error")
                 && record

--- a/crates/cli/tests/outdated_test.rs
+++ b/crates/cli/tests/outdated_test.rs
@@ -167,6 +167,85 @@ mod outdated {
     }
 
     #[test]
+    fn updates_when_using_json_format() {
+        let sandbox = create_empty_proto_sandbox();
+        sandbox.create_file(".prototools", r#"moonbase = "1.0.0""#);
+
+        sandbox
+            .run_bin(|cmd| {
+                cmd.arg("outdated")
+                    .arg("--update")
+                    .arg("--latest")
+                    .arg("--yes")
+                    .arg("--json");
+            })
+            .success();
+
+        assert!(
+            !fs::read_to_string(sandbox.path().join(".prototools"))
+                .unwrap()
+                .contains("1.0.0")
+        );
+    }
+
+    #[test]
+    fn updates_when_using_ndjson_format() {
+        let sandbox = create_empty_proto_sandbox();
+        sandbox.create_file(".prototools", r#"moonbase = "1.0.0""#);
+
+        sandbox
+            .run_bin(|cmd| {
+                cmd.arg("outdated")
+                    .arg("--update")
+                    .arg("--latest")
+                    .arg("--yes")
+                    .arg("--reporter")
+                    .arg("ndjson");
+            })
+            .success();
+
+        assert!(
+            !fs::read_to_string(sandbox.path().join(".prototools"))
+                .unwrap()
+                .contains("1.0.0")
+        );
+    }
+
+    // Prompts can't be answered without a terminal, so the `--update`
+    // flag itself is the confirmation
+    #[test]
+    fn updates_without_yes_when_not_a_tty() {
+        let sandbox = create_empty_proto_sandbox();
+        sandbox.create_file(".prototools", r#"moonbase = "1.0.0""#);
+
+        sandbox
+            .run_bin(|cmd| {
+                cmd.arg("outdated").arg("--update").arg("--latest");
+            })
+            .success();
+
+        assert!(
+            !fs::read_to_string(sandbox.path().join(".prototools"))
+                .unwrap()
+                .contains("1.0.0")
+        );
+    }
+
+    #[test]
+    fn warns_when_nothing_was_updated() {
+        let sandbox = create_empty_proto_sandbox();
+        sandbox.create_file(".prototools", r#"moonbase = "latest""#);
+
+        let assert = sandbox.run_bin(|cmd| {
+            cmd.arg("outdated").arg("--update").arg("--yes");
+        });
+
+        let output = assert.output();
+
+        assert!(predicate::str::contains("No versions were updated!").eval(&output));
+    }
+
+    #[test]
     fn doesnt_overwrite_aliases() {
         let sandbox = create_empty_proto_sandbox();
         sandbox.create_file(".prototools", r#"moonbase = "latest""#);

--- a/crates/cli/tests/run_test.rs
+++ b/crates/cli/tests/run_test.rs
@@ -120,6 +120,50 @@ mod run {
         ));
     }
 
+    // Stdout belongs to the tool being ran, so a failure must never write to
+    // it, even when rendering machine readable output. The banner is also
+    // suppressed for the same reason, so stdout stays completely empty.
+    #[test]
+    fn errors_to_stderr_as_ndjson_and_not_stdout() {
+        let sandbox = create_empty_proto_sandbox();
+
+        let assert = sandbox.run_bin(|cmd| {
+            cmd.arg("run")
+                .arg("node")
+                .arg("19.0.0")
+                .arg("--reporter")
+                .arg("ndjson")
+                .env("CODEX_CI", "1")
+                .env("PROTO_AUTO_INSTALL", "false")
+                .env("PROTO_TELEMETRY", "false")
+                // The testing reporter ignores both the format and the
+                // stream, so opt into the real one
+                .env_remove("PROTO_SANDBOX")
+                .env_remove("PROTO_TEST");
+        });
+        let stderr = assert.stderr();
+
+        assert.failure().stdout(predicate::str::is_empty());
+
+        let records = stderr
+            .lines()
+            .filter(|line| line.starts_with('{'))
+            .map(|line| {
+                serde_json::from_str::<serde_json::Value>(line).unwrap_or_else(|error| {
+                    panic!("stderr line is not valid NDJSON: {line}: {error}")
+                })
+            })
+            .collect::<Vec<_>>();
+
+        assert!(records.iter().any(|record| {
+            record.get("type").and_then(|value| value.as_str()) == Some("error")
+                && record
+                    .get("message")
+                    .and_then(|value| value.as_str())
+                    .is_some_and(|message| message.contains("This project requires Node.js 19.0.0"))
+        }));
+    }
+
     #[test]
     fn errors_if_no_version_detected() {
         let sandbox = create_empty_proto_sandbox();
@@ -317,7 +361,8 @@ mod run {
             })
             .success();
 
-        assert.stdout(predicate::str::contains("installed"));
+        // Proto's own output goes to stderr, as stdout belongs to the tool
+        assert.stderr(predicate::str::contains("installed"));
     }
 
     #[test]
@@ -337,7 +382,8 @@ mod run {
             })
             .success();
 
-        assert.stdout(predicate::str::contains("installed"));
+        // Proto's own output goes to stderr, as stdout belongs to the tool
+        assert.stderr(predicate::str::contains("installed"));
 
         unsafe { env::remove_var("PROTO_AUTO_INSTALL") };
     }
@@ -381,7 +427,7 @@ mod run {
             })
             .success();
 
-        assert.stdout(predicate::str::contains("Node.js 19.0.0 installed"));
+        assert.stderr(predicate::str::contains("Node.js 19.0.0 installed"));
 
         let assert = sandbox
             .run_bin(|cmd| {
@@ -394,7 +440,7 @@ mod run {
             })
             .success();
 
-        assert.stdout(predicate::str::contains("Node.js 19.0.0 installed").not());
+        assert.stderr(predicate::str::contains("Node.js 19.0.0 installed").not());
     }
 
     #[test]


### PR DESCRIPTION
Fixes #1111 and #1110. Both are silent-output bugs reported by the same user, and both trace back to how the reporter's format and stream are chosen rather than to the command logic itself.

## `proto outdated --update` silently writes nothing (#1111)

Two independent no-ops, neither in the config-writing code (which is why the existing tests pass):

1. `if session.is_json_format() { write_json; return }` sat **before** the `--update` block. `default_reporter()` selects `Ndjson` whenever `ai_env::is_ai_agent()`, so any agent shell hit this with no flag at all — which is what the reporter's unattended job was running under. The report now renders as JSON *or* a table (table rendering extracted to `render_table`) and execution continues either way.
2. `render_interactive` returns immediately without a TTY, leaving `confirmed = false`, so `--update` without `--yes` silently declined. We now prompt only when it can actually be answered (`!should_skip_prompts() && !is_json_format() && is_tty()`); otherwise the explicit `--update` flag is the confirmation, which is what its help text promises. Declining at the prompt now says so instead of exiting silently.

Also closes the third gap the reporter named: we no longer report `Update complete!` when nothing was written. Skipped tools are collected with reasons (alias/canary, non-`.prototools` source, no config source) and either listed under the success notice or raised as a `CAUTION` "No versions were updated!".

## Shim errors go to stdout with an empty stderr (#1110)

`App::stdout_owner()` classifies who owns stdout, but `run`/`exec`/`shell` fell through to the `_ => Reporter` arm, so the reporter wrote to stdout. `main_error` emits the NDJSON error record there and swallows the error rather than letting miette render it — hence a failure with a corrupted protocol stream on stdout and **nothing at all** on stderr.

#1105 only added `!is_tool_exec_command()` to the banner condition; the reporter itself stayed pointed at stdout. This adds `StdoutOwner::ToolProcess` and maps `Exec | Run | Shell` to it, so the rest follows from the existing design.

Before: stdout 406 bytes / stderr 0. After: stdout **0** / stderr 406, NDJSON record intact so structured consumers keep their machine-readable form. Non-agent mode is unchanged.

**Note on scope:** routing the reporter to stderr also moves install progress off stdout, which is the fix working — those lines were corrupting the wrapped tool's stdout for the same reason. For consistency the two remaining `console.out` writes in `run.rs` (`Auto-install is enabled…`, `…has been installed, continuing execution…`) moved to stderr too. That part is separable if you'd rather keep auto-install chatter on stdout — the `StdoutOwner` change alone fixes the issue.

`exec_test::errors_use_reporter_output_in_agent_environments` (from #1055) asserted the error on stdout and now asserts NDJSON on stderr plus an empty stdout.

## Tests

Five new tests: four in `outdated_test` (json, ndjson, no-TTY-without-`--yes`, and the warn path) and `run_test::errors_to_stderr_as_ndjson_and_not_stdout` — each verified to fail without its fix.

Run serially: `run_test` 38/38, `exec_test` 9/9, `outdated_test` 12/12, `outdated_lockfile_test` 7/7, `shim_test` 7/7, `activate_test` 20/20, `general_test` 5/5. Clippy clean.

`run_test` has a pre-existing parallel race — `auto_installs_if_missing_with_env_var` sets `PROTO_AUTO_INSTALL` via process-global `env::set_var` and only removes it after its assert, so one failure there cascades into three siblings. Untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
