### PR TITLE
feat: make user-agent configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@
 - [Zig](https://github.com/moonrepo/plugins/blob/master/tools/zig/CHANGELOG.md)
 - [ZLS](https://github.com/moonrepo/plugins/blob/master/tools/zig-ls/CHANGELOG.md)
 
+## Unreleased
+
+#### 🚀 Updates
+
+- Added a `user-agent` setting to `[settings.http]`, which overrides the user agent that proto sends with each HTTP(S) request.
+
 ## 0.62.0
 
 #### 💥 Breaking

--- a/crates/core/tests/config_test.rs
+++ b/crates/core/tests/config_test.rs
@@ -328,6 +328,28 @@ root-cert = "../cert.pem"
     }
 
     #[test]
+    fn parses_http_user_agent() {
+        let sandbox = create_empty_sandbox();
+        sandbox.create_file(
+            ".prototools",
+            r#"
+[settings.http]
+user-agent = "acme-corp/1.2.3"
+"#,
+        );
+
+        let config = ProtoConfig::load_from(sandbox.path(), false).unwrap();
+
+        assert_eq!(
+            config.settings.unwrap().http.unwrap(),
+            HttpOptions {
+                user_agent: Some("acme-corp/1.2.3".into()),
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
     fn parses_plugins_table() {
         let sandbox = create_empty_sandbox();
         sandbox.create_file(

--- a/crates/warpgate/src/clients/http.rs
+++ b/crates/warpgate/src/clients/http.rs
@@ -3,6 +3,7 @@ use async_trait::async_trait;
 use core::ops::Deref;
 use netrc::Netrc;
 use regex::Regex;
+use reqwest::header::HeaderValue;
 use reqwest::{Client, Response, Url};
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware, RequestBuilder, RequestInitialiser};
 use reqwest_retry::{RetryTransientMiddleware, policies::ExponentialBackoff};
@@ -152,6 +153,19 @@ pub struct HttpOptions {
 
     /// Absolute path to the root certificate. Supports `.pem` and `.der` files.
     pub root_cert: Option<PathBuf>,
+
+    /// Override the user agent that is sent with every request.
+    pub user_agent: Option<String>,
+}
+
+/// Parse a user agent into a header value.
+fn parse_user_agent(user_agent: &str) -> Result<HeaderValue, WarpgateHttpClientError> {
+    HeaderValue::from_str(user_agent)
+        .ok()
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| WarpgateHttpClientError::InvalidUserAgent {
+            value: user_agent.to_owned(),
+        })
 }
 
 /// Build a [`reqwest::ClientBuilder`] with the provided options.
@@ -162,6 +176,12 @@ pub fn build_http_client(
     let mut client_builder = reqwest::Client::builder()
         .user_agent(format!("warpgate@{}", env!("CARGO_PKG_VERSION")))
         .use_rustls_tls();
+
+    if let Some(user_agent) = &options.user_agent {
+        trace!(user_agent, "Using a user provided user agent");
+
+        client_builder = client_builder.user_agent(parse_user_agent(user_agent)?);
+    }
 
     if !envx::bool_var("WARPGATE_HTTP_NO_TIMEOUTS") {
         client_builder = client_builder

--- a/crates/warpgate/src/clients/http_error.rs
+++ b/crates/warpgate/src/clients/http_error.rs
@@ -64,6 +64,16 @@ pub enum WarpgateHttpClientError {
         #[source]
         error: Box<reqwest::Error>,
     },
+
+    #[cfg_attr(
+        feature = "miette",
+        diagnostic(code(plugin::http_client::invalid_user_agent))
+    )]
+    #[error(
+        "Invalid user agent {}. Must not be empty, and must not contain control characters.",
+        .value.style(Style::Symbol)
+    )]
+    InvalidUserAgent { value: String },
 }
 
 impl From<FsError> for WarpgateHttpClientError {

--- a/crates/warpgate/tests/http_client_test.rs
+++ b/crates/warpgate/tests/http_client_test.rs
@@ -1,12 +1,58 @@
 use rustc_hash::FxHashMap;
 use starbase_utils::net::Downloader;
 use std::env;
-use warpgate::create_http_client;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::thread;
+use warpgate::{HttpOptions, create_http_client, create_http_client_with_options};
 
 // Env var names are unique per test since tests run in parallel threads
 // within the same process.
 fn set_env(key: &str, value: &str) {
     unsafe { env::set_var(key, value) };
+}
+
+// Accept a single connection, capture the raw request head, and reply
+// with an empty 200 so the client resolves without retrying.
+fn spawn_server(listener: TcpListener) -> thread::JoinHandle<String> {
+    thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut request = Vec::new();
+        let mut buffer = [0u8; 1024];
+
+        loop {
+            let bytes = stream.read(&mut buffer).unwrap();
+            request.extend_from_slice(&buffer[..bytes]);
+
+            if bytes == 0 || request.windows(4).any(|window| window == b"\r\n\r\n") {
+                break;
+            }
+        }
+
+        stream
+            .write_all(b"HTTP/1.1 200 OK\r\ncontent-length: 0\r\nconnection: close\r\n\r\n")
+            .unwrap();
+
+        String::from_utf8_lossy(&request).into_owned()
+    })
+}
+
+// Download a file with the provided options, and return the raw request head.
+async fn capture_request(options: HttpOptions) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = spawn_server(listener);
+
+    let downloader = create_http_client_with_options(&options)
+        .unwrap()
+        .create_downloader();
+
+    downloader
+        .download(format!("http://{addr}/file.txt").parse().unwrap())
+        .await
+        .unwrap();
+
+    server.join().unwrap()
 }
 
 mod expand_env_vars {
@@ -107,34 +153,6 @@ mod expand_env_vars {
 
 mod downloader_headers {
     use super::*;
-    use std::io::{Read, Write};
-    use std::net::TcpListener;
-    use std::thread;
-
-    // Accept a single connection, capture the raw request head, and reply
-    // with an empty 200 so the client resolves without retrying.
-    fn spawn_server(listener: TcpListener) -> thread::JoinHandle<String> {
-        thread::spawn(move || {
-            let (mut stream, _) = listener.accept().unwrap();
-            let mut request = Vec::new();
-            let mut buffer = [0u8; 1024];
-
-            loop {
-                let bytes = stream.read(&mut buffer).unwrap();
-                request.extend_from_slice(&buffer[..bytes]);
-
-                if bytes == 0 || request.windows(4).any(|window| window == b"\r\n\r\n") {
-                    break;
-                }
-            }
-
-            stream
-                .write_all(b"HTTP/1.1 200 OK\r\ncontent-length: 0\r\nconnection: close\r\n\r\n")
-                .unwrap();
-
-            String::from_utf8_lossy(&request).into_owned()
-        })
-    }
 
     #[tokio::test]
     async fn expands_env_vars_in_request_headers() {
@@ -166,5 +184,59 @@ mod downloader_headers {
                 .to_lowercase()
                 .contains("authorization: bearer wg-secret-value")
         );
+    }
+}
+
+mod user_agent {
+    use super::*;
+
+    #[tokio::test]
+    async fn keeps_client_default_when_not_configured() {
+        let request = capture_request(HttpOptions::default()).await;
+
+        assert!(request.contains(&format!(
+            "user-agent: warpgate@{}\r\n",
+            env!("CARGO_PKG_VERSION")
+        )));
+    }
+
+    #[tokio::test]
+    async fn sends_configured_value() {
+        let request = capture_request(HttpOptions {
+            user_agent: Some("acme-corp/1.2.3 (+https://acme.corp)".into()),
+            ..Default::default()
+        })
+        .await;
+
+        assert!(request.contains("user-agent: acme-corp/1.2.3 (+https://acme.corp)\r\n"));
+        assert!(!request.contains("warpgate@"));
+    }
+
+    #[test]
+    fn errors_when_empty() {
+        let error = create_http_client_with_options(&HttpOptions {
+            user_agent: Some("".into()),
+            ..Default::default()
+        })
+        .unwrap_err();
+
+        assert!(error.to_string().starts_with("Invalid user agent"));
+    }
+
+    #[test]
+    fn errors_when_not_a_valid_header_value() {
+        for value in [
+            "proto\nX-Injected: yes",
+            "proto\rX-Injected: yes",
+            "proto\u{0}",
+        ] {
+            let error = create_http_client_with_options(&HttpOptions {
+                user_agent: Some(value.into()),
+                ..Default::default()
+            })
+            .unwrap_err();
+
+            assert!(error.to_string().starts_with("Invalid user agent"));
+        }
     }
 }


### PR DESCRIPTION
This PR makes it possible for users to specify the User-Agent used by Proto when making http(s) requests.

My ulterior intention is to start using a more specific UA for Proto, instead of the one from `warpgate`, but I think having this option can be good for a transitional period, in case the proposal is accepted.